### PR TITLE
Add simple caching - Default to off, default cache_time 2 hours, defa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ bin/
 home-assistant/addons/sbam/bin/
 # Test binary, built with `go test -c`
 *.test
+**/gotest*.json
+**/gotest*.json.*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Flags:
   -h, --help                help for estimate
   -u, --url string          Set the forecast URL. For multiple URLs, use a comma (,) to separate them
   -n, --cache_forecast bool Enabling the cache forcast to reduce the number of times we query the forecast URL. Defaults to false
-  -f, --cache_file_prefix   When caching is enabled, the forecast will be saved locally to files with this pefix. Defaults to cached_forecast
+  -f, --cache_file_prefix   When caching is enabled, the forecast will be saved locally to files with this prefix. Defaults to cached_forecast
   -l, --cache_time          The length of time to cache the forecast. Defaults to 7200 seconds
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Flags:
   -H, --fronius_ip string   set FRONIUS_IP
   -h, --help                help for estimate
   -u, --url string          Set the forecast URL. For multiple URLs, use a comma (,) to separate them
+  -n, --cache_forecast bool Enabling the cache forcast to reduce the number of times we query the forecast URL. Defaults to false
+  -f, --cache_file_prefix   When caching is enabled, the forecast will be saved locally to files with this pefix. Defaults to cached_forecast
+  -l, --cache_time          The length of time to cache the forecast. Defaults to 7200 seconds
 ```
 
 ## Schedule
@@ -114,6 +117,9 @@ Flags:
   -c, --pw_consumption float           PW_CONSUMPTION
   -s, --start_hr string                START_HR (default "00:00")
   -u, --url string                     Set the Forecast URL. For multiple URLs, use a comma (,) to separate them
+  -n, --cache_forecast bool            Enabling the cache forcast to reduce the number of times we query the forecast URL. Defaults to false
+  -f, --cache_file_prefix              When caching is enabled, the forecast will be saved locally to files with this prefix. Defaults to cached_forecast
+  -l, --cache_time                     The length of time to cache the forecast. Defaults to 7200 seconds
 ```
 
 ## Debug Logs

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -48,29 +48,30 @@ Once added, it can be installed:
 Do not start yet but configure it:
 
 1. Click on the configuration tab
-2. **url:** Solcast forecast site address (replace <YOUR-SITE> with your identifier). Multiple addresses are supported (max. 2); separate them with a comma (,); Solcast has a limit of 10 API calls per **UTC** day. If there are **two URLs**, the API calls are split evenly, with a maximum of 5 calls per array per **UTC** day.
-3. **apikey:** Solcast API key.
-4. **fronius_ip:** Fronius inverter LAN IP.
-5. **start_hr:** Start time of the advantageous network operator rate (default 00:00).
-6. **end_hr:** End time of the advantageous network operator rate (default 06:00).
-7. **crontab:** Crontab to run sbam (default: 00 00-05 \* \* \* so At minute 0 past every hour from 0 through 5.); with **two** URLs: **CET**: 10 00,03,05,06 \* \* \* (At minute 10 past hour 0, 3, 5, and 6), **UTC**: Add 1 additional hour per API call (e.g., 10 00,03,05,06,07 \* \* \*). Frequent calls are scheduled near the end time to improve forecast accuracy and allow time for charging.
-8. **pw_consumption:** Daily electrical consumption in Wh (Default: 11000, means 11kWh).
-9. **max_charge:** Maximum amount of power required from the electricity network to charge the battery in W (Default: 3500).
-10. **pw_lwt:** The hysteresis logic lower threshold **offset** in Wh to stop charging (Default: 0).
-11. **pw_upt:** The hysteresis logic upper threshold **offset** in Wh to start charging (Default: 0).
-12. **pw_batt_reserve:** Minimum battery capacity to maintain in Wh (Default: 4000, means 4kWh).
-13. **batt_reserve_start_hr:** The start time to activate battery reserve charging (if empty default **start_hr**).
-14. **batt_reserve_end_hr:** The end time to activate battery reserve charging (if empty default **end_hr**).
-15. **defaults:** At the end of the crontab cycle, reconfigure the Fronius inverter to default (automatic management).
-16. **reset:** At the add-on boot, reconfigure the Fronius inverter to its default settings.
-17. **debug:** Increase the log level to debug, for example, printing Modbus read/write operations.
-18. **cache_forecast:** Enabling the cache forcast to reduce the number of times we query the forecast URL (Default: false).
-19. **cache_file_prefix:** When caching is enabled, the forecast will be saved locally to files with this prefix. (Default: cached_forecast).
-20. **cache_time:**  The length of time to cache the forecast (Default: 7200, means 7200 seconds).
+2. Modify Options:  
+- **url:** Solcast forecast site address (replace <YOUR-SITE> with your identifier). Multiple addresses are supported (max. 2); separate them with a comma (,); Solcast has a limit of 10 API calls per **UTC** day. If there are **two URLs**, the API calls are split evenly, with a maximum of 5 calls per array per **UTC** day.
+- **apikey:** Solcast API key.
+- **fronius_ip:** Fronius inverter LAN IP.
+- **start_hr:** Start time of the advantageous network operator rate (default 00:00).
+-**end_hr:** End time of the advantageous network operator rate (default 06:00).
+- **crontab:** Crontab to run sbam (default: 00 00-05 \* \* \* so At minute 0 past every hour from 0 through 5.); with **two** URLs: **CET**: 10 00,03,05,06 \* \* \* (At minute 10 past hour 0, 3, 5, and 6), **UTC**: Add 1 additional hour per API call (e.g., 10 00,03,05,06,07 \* \* \*). Frequent calls are scheduled near the end time to improve forecast accuracy and allow time for charging.
+- **pw_consumption:** Daily electrical consumption in Wh (Default: 11000, means 11kWh).
+- **max_charge:** Maximum amount of power required from the electricity network to charge the battery in W (Default: 3500).
+- **pw_lwt:** The hysteresis logic lower threshold **offset** in Wh to stop charging (Default: 0).
+- **pw_upt:** The hysteresis logic upper threshold **offset** in Wh to start charging (Default: 0).
+- **pw_batt_reserve:** Minimum battery capacity to maintain in Wh (Default: 4000, means 4kWh).
+- **batt_reserve_start_hr:** The start time to activate battery reserve charging (if empty default **start_hr**).
+- **batt_reserve_end_hr:** The end time to activate battery reserve charging (if empty default **end_hr**).
+- **defaults:** At the end of the crontab cycle, reconfigure the Fronius inverter to default (automatic management).
+- **reset:** At the add-on boot, reconfigure the Fronius inverter to its default settings.
+- **debug:** Increase the log level to debug, for example, printing Modbus read/write operations.
+- **cache_forecast:** Enabling the cache forcast to reduce the number of times we query the forecast URL (Default: false).
+- **cache_file_prefix:** When caching is enabled, the forecast will be saved locally to files with this prefix. (Default: cached_forecast).
+- **cache_time:**  The length of time to cache the forecast (Default: 7200, means 7200 seconds).
+3. Click on **save** to apply the configuration
 
-- Click on **save** to apply the configuration
+![sbam-conf](https://github.com/user-attachments/assets/d0eab452-7b77-4d2c-9b24-7ac44fd50b7a)
 
-![sbam-conf](https://github.com/user-attachments/assets/51df5a4a-d355-4d37-ba62-f86451c6fb08)
 
 
 Finally Start **sbam**!

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -48,23 +48,27 @@ Once added, it can be installed:
 Do not start yet but configure it:
 
 1. Click on the configuration tab
-2. **url:** Solcast forecast site address (replace <YOUR-SITE> with your identifier). Multiple addresses are supported (max. 2); separate them with a comma (,); Solcast has a limit of 10 API calls per **UTC** day. If there are **two URLs**, the API calls are split evenly, with a maximum of 5 calls per array per **UTC** day
-3. **apikey:** Solcast API key
-4. **fronius_ip:** Fronius inverter LAN IP
-5. **start_hr:** Start time of the advantageous network operator rate (default 00:00)
-6. **end_hr:** End time of the advantageous network operator rate (default 06:00)
-7. **crontab:** Crontab to run sbam (default: 00 00-05 \* \* \* so At minute 0 past every hour from 0 through 5.); with **two** URLs: **CET**: 10 00,03,05,06 \* \* \* (At minute 10 past hour 0, 3, 5, and 6), **UTC**: Add 1 additional hour per API call (e.g., 10 00,03,05,06,07 \* \* \*). Frequent calls are scheduled near the end time to improve forecast accuracy and allow time for charging
-8. **pw_consumption:** Daily electrical consumption in Wh (Default: 11000, means 11kWh)
-9. **max_charge:** Maximum amount of power required from the electricity network to charge the battery in W (Default: 3500)
-10. **pw_lwt:** The hysteresis logic lower threshold **offset** in Wh to stop charging (Default: 0)
-11. **pw_upt:** The hysteresis logic upper threshold **offset** in Wh to start charging (Default: 0)
-12. **pw_batt_reserve:** Minimum battery capacity to maintain in Wh (Default: 4000, means 4kWh)
-13. **batt_reserve_start_hr:** The start time to activate battery reserve charging (if empty default **start_hr**)
-14. **batt_reserve_end_hr:** The end time to activate battery reserve charging (if empty default **end_hr**)
+2. **url:** Solcast forecast site address (replace <YOUR-SITE> with your identifier). Multiple addresses are supported (max. 2); separate them with a comma (,); Solcast has a limit of 10 API calls per **UTC** day. If there are **two URLs**, the API calls are split evenly, with a maximum of 5 calls per array per **UTC** day.
+3. **apikey:** Solcast API key.
+4. **fronius_ip:** Fronius inverter LAN IP.
+5. **start_hr:** Start time of the advantageous network operator rate (default 00:00).
+6. **end_hr:** End time of the advantageous network operator rate (default 06:00).
+7. **crontab:** Crontab to run sbam (default: 00 00-05 \* \* \* so At minute 0 past every hour from 0 through 5.); with **two** URLs: **CET**: 10 00,03,05,06 \* \* \* (At minute 10 past hour 0, 3, 5, and 6), **UTC**: Add 1 additional hour per API call (e.g., 10 00,03,05,06,07 \* \* \*). Frequent calls are scheduled near the end time to improve forecast accuracy and allow time for charging.
+8. **pw_consumption:** Daily electrical consumption in Wh (Default: 11000, means 11kWh).
+9. **max_charge:** Maximum amount of power required from the electricity network to charge the battery in W (Default: 3500).
+10. **pw_lwt:** The hysteresis logic lower threshold **offset** in Wh to stop charging (Default: 0).
+11. **pw_upt:** The hysteresis logic upper threshold **offset** in Wh to start charging (Default: 0).
+12. **pw_batt_reserve:** Minimum battery capacity to maintain in Wh (Default: 4000, means 4kWh).
+13. **batt_reserve_start_hr:** The start time to activate battery reserve charging (if empty default **start_hr**).
+14. **batt_reserve_end_hr:** The end time to activate battery reserve charging (if empty default **end_hr**).
 15. **defaults:** At the end of the crontab cycle, reconfigure the Fronius inverter to default (automatic management).
 16. **reset:** At the add-on boot, reconfigure the Fronius inverter to its default settings.
 17. **debug:** Increase the log level to debug, for example, printing Modbus read/write operations.
-18. finally click on **save**
+18. **cache_forecast:** Enabling the cache forcast to reduce the number of times we query the forecast URL (Default: false).
+19. **cache_file_prefix:** When caching is enabled, the forecast will be saved locally to files with this prefix. (Default: cached_forecast).
+20. **cache_time:**  The length of time to cache the forecast (Default: 7200, means 7200 seconds).
+
+- Click on **save** to apply the configuration
 
 ![sbam-conf](https://github.com/user-attachments/assets/51df5a4a-d355-4d37-ba62-f86451c6fb08)
 

--- a/home-assistant/addons/sbam/config.json
+++ b/home-assistant/addons/sbam/config.json
@@ -1,6 +1,6 @@
 {
   "name": "sbam",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "slug": "sbam",
   "init": "false",
   "description": "Smart Battery Advanced Manager",

--- a/home-assistant/addons/sbam/config.json
+++ b/home-assistant/addons/sbam/config.json
@@ -23,7 +23,10 @@
     "batt_reserve_end_hr": "",
     "defaults": true,
     "reset": false,
-    "debug": false
+    "debug": false,
+    "cache_forecast": false,
+    "cache_time": 7200,
+    "cache_file_prefix": "cached_forecast"
   },
   "schema": {
     "url": "str",
@@ -41,6 +44,9 @@
     "batt_reserve_end_hr": "match(^$|^([01]?[0-9]|2[0-3]):[0-5][0-9]$)",
     "defaults": "bool",
     "reset": "bool",
-    "debug": "bool"
+    "debug": "bool",
+    "cache_forecast": "bool",
+    "cache_time": "int",
+    "cache_file_prefix": "string"
   }
 }

--- a/home-assistant/addons/sbam/run.sh
+++ b/home-assistant/addons/sbam/run.sh
@@ -16,6 +16,9 @@ export BATT_RESERVE_END_HR=$(bashio::config 'batt_reserve_end_hr')
 export DEFAULTS=$(bashio::config 'defaults')
 export RESET=$(bashio::config 'reset')
 export DEBUG=$(bashio::config 'debug')
+export CACHE_FORECAST=$(bashio::config 'cache_forecast')
+export CACHE_FILE_PREFIX=$(bashio::config 'cache_file_prefix')
+export CACHE_TIME=$(bashio::config 'cache_time')
 
 [ "$RESET" = "true" ] && sbam configure -d
 

--- a/pkg/power/estimate.go
+++ b/pkg/power/estimate.go
@@ -3,7 +3,9 @@ package power
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"os"
 	u "sbam/src/utils"
 	"time"
 )
@@ -32,6 +34,100 @@ func GetForecast(apiKey string, url string) (Forecasts, error) {
 		return Forecasts{}, err
 	}
 	return forecasts, nil
+}
+
+func GetForecastChache(apiKey string, url string, cache_file_name string, cache_time int32) (Forecasts, error) {
+	// Very simple cachefile - not generic in any way, we simply use a localfile to hold the json we got last time
+	// Try getting the forecast from the local cachefile fist. If the cachefile is less than X hous old, then use it.
+	// Else fall through to the oiginal code and download from the website.
+	// Content downloaded from the website should then be saved to the local cachefile
+	var cachedForecasts Forecasts
+	var cacheHit bool
+
+	u.Log.Debugf("cache_forecast is enabled")
+	u.Log.Debugf("cache_forecast file %s cache_time %d", cache_file_name, cache_time)
+
+	fileInfo, err := os.Stat(cache_file_name)
+	if err != nil {
+		u.Log.Errorf("Error getting file info: %v", err)
+		if os.IsNotExist(err) {
+			u.Log.Infof("Info: Cache File '%s' does not exist - fallthough to download", cache_file_name)
+		}
+	} else {
+		modTime := fileInfo.ModTime()
+		currentTime := time.Now()
+
+		age := currentTime.Sub(modTime)
+
+		u.Log.Debugf("File '%s' was last modified at: %s", cache_file_name, modTime.Format(time.RFC3339))
+		u.Log.Debugf("Age of file '%s': %s", cache_file_name, age)
+
+		cachedForecasts, cacheHit, _ = ReadForecastCache(cache_file_name)
+		if cacheHit {
+			// Check if the file is older than a certain duration
+			threshold := time.Duration(cache_time) * time.Second
+			if age > threshold {
+				u.Log.Debugf("File '%s' is older than %s - fall though to download", cache_file_name, threshold)
+			} else {
+				u.Log.Debugf("File '%s' is not older than %s - use cached forecast", cache_file_name, threshold)
+				return cachedForecasts, nil
+			}
+		}
+	}
+	u.Log.Debugf("Falling through to URL read for forecast")
+
+	// Read the forecast from the URL
+	forecasts, err := GetForecast(apiKey, url)
+	if err != nil {
+		if cacheHit {
+			u.Log.Errorln("Error getting forecast for", url, ":", err)
+			u.Log.Debugf("Using cached forecast")
+			return cachedForecasts, nil
+		} else {
+			u.Log.Errorln("Error getting forecast for", url, " and there isn't a valid cache available:", err)
+			return Forecasts{}, err
+		}
+	}
+
+	// Write the json to the cachefile
+	jsonData, err := json.MarshalIndent(forecasts, "", "  ") // Use "  " for 2-space indentation
+	if err != nil {
+		u.Log.Errorf("Error: Unable to marshall forecast")
+	} else {
+		err = os.WriteFile(cache_file_name, jsonData, 0644)
+		if err != nil {
+			u.Log.Errorf("Error: Unable to write cachefile %s", cache_file_name)
+		} else {
+			u.Log.Infof("Cachefile %s written successfully", cache_file_name)
+		}
+	}
+
+	return forecasts, nil
+}
+
+func ReadForecastCache(cache_file_name string) (Forecasts, bool, error) {
+	var cachedForecasts Forecasts
+
+	// Read the cachefile
+	cacheFile, err := os.Open(cache_file_name)
+	if err != nil {
+		u.Log.Errorf("Error opening file:", err)
+		return Forecasts{}, false, err
+	}
+	defer cacheFile.Close() // Ensure the file is closed after function execution
+	byteValue, err := io.ReadAll(cacheFile)
+	if err != nil {
+		u.Log.Errorf("Error reading file:", err)
+		return Forecasts{}, false, err
+	}
+
+	err = json.Unmarshal(byteValue, &cachedForecasts)
+	if err != nil {
+		u.Log.Errorf("Error unmarshaling JSON:", err)
+		return Forecasts{}, false, err
+	}
+	u.Log.Debugf("Cache File Read Successfully - returning cached forecast")
+	return cachedForecasts, true, nil
 }
 
 func GetTotalDayPowerEstimate(forecasts Forecasts, day time.Time) (float64, error) {

--- a/pkg/power/power_test.go
+++ b/pkg/power/power_test.go
@@ -1,15 +1,38 @@
 package power_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sbam/pkg/power"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// Dummy Forecasts struct for testing
+// Replace with the actual struct if different
+
+type Forecast struct {
+	PeriodEnd  string  `json:"period_end"`
+	PVEstimate float64 `json:"pv_estimate"`
+}
+
+type Forecasts struct {
+	Forecasts []Forecast `json:"forecasts"`
+}
+
+func createTestCacheFile(t *testing.T, forecasts Forecasts, filename string, modTime time.Time) {
+	data, err := json.MarshalIndent(forecasts, "", "  ")
+	assert.NoError(t, err)
+	err = os.WriteFile(filename, data, 0644)
+	assert.NoError(t, err)
+	// Set mod time
+	os.Chtimes(filename, modTime, modTime)
+}
 
 func TestGetForecast(t *testing.T) {
 	// Create a mock HTTP server
@@ -154,7 +177,50 @@ func TestHandler(t *testing.T) {
 	power := power.New()
 
 	// Call the Handler function with the mock HTTP server's URL
-	production, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL)
+	production, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL, false, "cached_forecast", 7200)
+	assert.NoError(t, err)
+	assert.Equal(t, 250000.0, production)
+}
+
+func TestHandlerCache(t *testing.T) {
+	now := time.Now()
+	tomorrow := now.AddDate(0, 0, 1)
+	pe := now.Format(time.RFC3339)
+	pe30 := now.Add(time.Minute * 30).Format(time.RFC3339)
+	pet := tomorrow.Format(time.RFC3339)
+	pet30 := tomorrow.Add(time.Minute * 30).Format(time.RFC3339)
+
+	// Create a mock HTTP server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"forecasts": [
+				{
+					"period_end": "`+pe+`",
+					"pv_estimate": 100
+				},
+				{
+					"period_end": "`+pe30+`",
+					"pv_estimate": 150
+				},
+				{
+					"period_end": "`+pet+`",
+					"pv_estimate": 100
+				},
+				{
+					"period_end": "`+pet30+`",
+					"pv_estimate": 150
+				}
+			]
+		}`)
+	}))
+	defer ts.Close()
+
+	// Create a new Power object
+	power := power.New()
+
+	// Call the Handler function with the mock HTTP server's URL
+	production, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL, true, "gotest_cached_forecast.json", 7200)
 	assert.NoError(t, err)
 	assert.Equal(t, 250000.0, production)
 }
@@ -182,7 +248,7 @@ func TestHandlerError(t *testing.T) {
 	power := power.New()
 
 	// Call the Handler function with the mock HTTP server's URL
-	_, test_forecast_retrieved, err := power.Handler("apiKey", ts.URL)
+	_, test_forecast_retrieved, err := power.Handler("apiKey", ts.URL+", "+ts.URL, false, "cached_forecast", 7200)
 	assert.NoError(t, err)
 	assert.Equal(t, test_forecast_retrieved, false)
 }
@@ -225,7 +291,7 @@ func TestHandlerError2(t *testing.T) {
 	power := power.New()
 
 	// Call the Handler function with the mock HTTP server's URL
-	_, _, err := power.Handler("apiKey", ts.URL)
+	_, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL, false, "cached_forecast", 7200)
 	assert.Error(t, err)
 
 }
@@ -268,7 +334,7 @@ func TestHandlerError3(t *testing.T) {
 	power := power.New()
 
 	// Call the Handler function with the mock HTTP server's URL
-	_, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL+", ")
+	_, _, err := power.Handler("apiKey", ts.URL+", "+ts.URL+", ", false, "cached_forecast", 7200)
 	assert.Error(t, err)
 }
 
@@ -296,4 +362,91 @@ func TestCheckSun(t *testing.T) {
 			assert.Equal(t, test.expectedTime, actualTime)
 		})
 	}
+}
+
+func TestReadForecastCache_ValidFile(t *testing.T) {
+	filename := "gotest_cache_valid.json"
+	defer os.Remove(filename)
+	f := Forecasts{Forecasts: []Forecast{{PeriodEnd: time.Now().Format(time.RFC3339), PVEstimate: 1.23}}}
+	createTestCacheFile(t, f, filename, time.Now())
+	result, hit, err := power.ReadForecastCache(filename)
+	assert.True(t, hit)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Forecasts[0].PVEstimate, result.Forecasts[0].PVEstimate)
+}
+
+func TestReadForecastCache_FileNotExist(t *testing.T) {
+	filename := "gotest_cache_not_exist.json"
+	os.Remove(filename)
+	_, hit, err := power.ReadForecastCache(filename)
+	assert.False(t, hit)
+	assert.Error(t, err)
+}
+
+func TestReadForecastCache_InvalidJSON(t *testing.T) {
+	filename := "gotest_cache_invalid.json"
+	defer os.Remove(filename)
+	_ = os.WriteFile(filename, []byte("not json"), 0644)
+	_, hit, err := power.ReadForecastCache(filename)
+	assert.False(t, hit)
+	assert.Error(t, err)
+}
+
+func TestGetForecastChache_UsesCache(t *testing.T) {
+	filename := "gotest_cache_recent.json"
+	defer os.Remove(filename)
+	f := Forecasts{Forecasts: []Forecast{{PeriodEnd: time.Now().Format(time.RFC3339), PVEstimate: 2.34}}}
+	createTestCacheFile(t, f, filename, time.Now())
+	// cache_time = 3600 seconds (1 hour)
+	result, err := power.GetForecastChache("", "", filename, 3600)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Forecasts[0].PVEstimate, result.Forecasts[0].PVEstimate)
+}
+
+func TestGetForecastChache_ExpiredCache1(t *testing.T) {
+	filename := "gotest_cache_expired.json"
+	defer os.Remove(filename)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	f := Forecasts{Forecasts: []Forecast{{PeriodEnd: oldTime.Format(time.RFC3339), PVEstimate: 3.45}}}
+	createTestCacheFile(t, f, filename, oldTime)
+	// cache_time = 3600 seconds (1 hour), so cache is expired
+	// GetForecast will fail, so should fallback to cache
+	result, err := power.GetForecastChache("", "", filename, 3600)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Forecasts[0].PVEstimate, result.Forecasts[0].PVEstimate)
+}
+
+func TestGetForecastChache_ExpiredCache2(t *testing.T) {
+	filename := "gotest_cache_expired.json"
+	defer os.Remove(filename)
+	oldTime := time.Now().Add(-2 * time.Hour)
+	f := Forecasts{Forecasts: []Forecast{{PeriodEnd: oldTime.Format(time.RFC3339), PVEstimate: 3.45}}}
+	createTestCacheFile(t, f, filename, oldTime)
+	// Create a mock HTTP server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"forecasts": [
+				{
+					"period_end": "`+oldTime.Format(time.RFC3339)+`",
+					"pv_estimate": 3.45
+				}
+			]
+		}`)
+	}))
+	defer ts.Close()
+	// cache_time = 3600 seconds (1 hour), so cache is expired
+	// fallback to cache url method, GetForecast will not fail and update the cache file with the new value.
+	result, err := power.GetForecastChache("apikey", ts.URL, filename, 3600)
+	assert.NoError(t, err)
+	assert.Equal(t, f.Forecasts[0].PVEstimate, result.Forecasts[0].PVEstimate)
+}
+
+func TestGetForecastChache_NoCacheFile(t *testing.T) {
+	filename := "gotest_cache_missing.json"
+	os.Remove(filename)
+	// Cache file is missing
+	// GetForecast will fail, so should return error
+	_, err := power.GetForecastChache("", "", filename, 3600)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
…ult cache file in $PWD (#67)

* Add simple caching - currently a fixed 2 hour lifetime for downloaded forecasts

* Make the forecast cache parameters configurable and default the caching to off

* Add the new parameters for forecast caching to the README

* Fix declaration of cache_time type in HA config.json

* Add the env var exports for the foecast caching to the HA run.sh scipt

* Fix name of the cache_file_name parameter in config.json where it was missing the _name on the end

* Move the caching logic to the handler in pkg/power/handler
 - This allows all URL's to be cached if more than 1 URL is specified
 - Alter the cache_file_name to cache_file_prefix. The URL index is added to the prefix to produce the actual cache_file_name. The default is cached_forecast, resulting in a cache file of cached_fiecast.0 for the first cache file.

* refacto(power): refactoring caching code under estimate

* Check cache_time is between 0 and 86400 seconds

* feat(cache): do not read cache file if file stats are unavailable

* feat(tests): adding cache unit tests

* feat(tests): adding power handler cache unit tests

---------