### PR TITLE
fronius: classifier error handling and tests

### DIFF
--- a/pkg/fronius/classify.go
+++ b/pkg/fronius/classify.go
@@ -9,6 +9,7 @@ const (
 	DecisionForecastCharge Decision = "forecast_charge"
 	DecisionReserveCharge  Decision = "reserve_charge"
 	DecisionIdle           Decision = "idle"
+	DecisionSkip           Decision = "skip"
 )
 
 func (d Decision) String() string {
@@ -26,7 +27,7 @@ func ClassifyDecision(
 	pwBatt2charge, pwForecast, pwConsumption, pwBattMax,
 	pwBattReserve, pwLwt float64,
 	forecastChargeEnabled, battReserveChargeEnabled bool,
-) (Decision, string, PowerState) {
+) (Decision, string, PowerState, error) {
 	pw := PowerState{
 		PvNet: pwForecast - pwConsumption,
 		Batt:  pwBattMax - pwBatt2charge,
@@ -36,12 +37,15 @@ func ClassifyDecision(
 
 	switch {
 	case pwBatt2charge == 0:
-		return DecisionBatteryFull, "Battery is full charged", pw
+		return DecisionBatteryFull, "Battery is full charged", pw, nil
 	case pw.Net < -1*pwLwt && forecastChargeEnabled:
-		return DecisionForecastCharge, fmt.Sprintf("Net Power (actual battery power + Net solar power) is not enough: %f Wh", pw.Net), pw
+		return DecisionForecastCharge, fmt.Sprintf("Net Power (actual battery power + Net solar power) is not enough: %f Wh", pw.Net), pw, nil
 	case pw.BattReserveNet < -1*pwLwt && battReserveChargeEnabled:
-		return DecisionReserveCharge, fmt.Sprintf("battery %f Wh < reserve %f Wh", pw.Batt, pwBattReserve), pw
+		return DecisionReserveCharge, fmt.Sprintf("battery %f Wh < reserve %f Wh", pw.Batt, pwBattReserve), pw, nil
+	case pw.Net >= -1*pwLwt:
+		return DecisionIdle, fmt.Sprintf("Net Power (actual battery power + Net solar power) is enough: %f Wh", pw.Net), pw, nil
 	default:
-		return DecisionIdle, fmt.Sprintf("Net Power (actual battery power + Net solar power) is enough: %f Wh", pw.Net), pw
+		reason := fmt.Sprintf("unexpected power state: %+v", pw)
+		return DecisionSkip, reason, pw, fmt.Errorf("%s", reason)
 	}
 }

--- a/pkg/fronius/classify_test.go
+++ b/pkg/fronius/classify_test.go
@@ -79,22 +79,25 @@ func TestClassifyDecision(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotDecision, gotReason, _ := fronius.ClassifyDecision(
+			gotDecision, gotReason, _, err := fronius.ClassifyDecision(
 				tc.pwBatt2charge, tc.pwForecast, tc.pwConsumption, tc.pwBattMax,
 				tc.pwBattReserve, tc.pwLwt,
 				tc.forecastChargeEnabled, tc.battReserveChargeEnabled,
 			)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedDecision, gotDecision)
 			assert.Equal(t, tc.expectedReason, gotReason)
 		})
 	}
 
 	t.Run("returns power state snapshot", func(t *testing.T) {
-		_, _, gotPowerState := fronius.ClassifyDecision(
+		// updated signature adds an error return; ensure it's nil
+		_, _, gotPowerState, err := fronius.ClassifyDecision(
 			500, 5000, 100, 5000,
 			1000, 100,
 			true, true,
 		)
+		assert.NoError(t, err)
 
 		assert.Equal(t, fronius.PowerState{
 			PvNet:          4900,

--- a/pkg/fronius/classify_test.go
+++ b/pkg/fronius/classify_test.go
@@ -90,6 +90,18 @@ func TestClassifyDecision(t *testing.T) {
 		})
 	}
 
+	t.Run("returns skip and error for unexpected power state", func(t *testing.T) {
+		decision, reason, _, err := fronius.ClassifyDecision(
+			2000, 100, 5000, 5000,
+			1000, 100,
+			false, false,
+		)
+
+		assert.Error(t, err)
+		assert.Equal(t, fronius.DecisionSkip, decision)
+		assert.Contains(t, reason, "unexpected power state")
+	})
+
 	t.Run("returns power state snapshot", func(t *testing.T) {
 		// updated signature adds an error return; ensure it's nil
 		_, _, gotPowerState, err := fronius.ClassifyDecision(

--- a/pkg/fronius/fronius_test.go
+++ b/pkg/fronius/fronius_test.go
@@ -297,3 +297,54 @@ func TestBatteryChargeError(t *testing.T) {
 
 	teardown()
 }
+
+func TestBatteryChargeModeClassifierErrorResetsDefaults(t *testing.T) {
+	assert := assert.New(t)
+	setup()
+
+	result, err := fronius.SetFroniusChargeBatteryMode(
+		100,
+		2000,
+		5000,
+		5000,
+		3500,
+		1000,
+		"00:00",
+		"23:59",
+		modbus_ip,
+		false,
+		100,
+		0,
+		false,
+		modbus_port,
+	)
+
+	assert.Equal(int16(0), result, "SetFroniusChargeBatteryMode returned wrong value")
+	assert.NoError(err)
+
+	teardown()
+}
+
+func TestBatteryChargeModeClassifierErrorResetFails(t *testing.T) {
+	assert := assert.New(t)
+
+	result, err := fronius.SetFroniusChargeBatteryMode(
+		100,
+		2000,
+		5000,
+		5000,
+		3500,
+		1000,
+		"00:00",
+		"23:59",
+		modbus_ip,
+		false,
+		100,
+		0,
+		false,
+		modbus_port,
+	)
+
+	assert.Equal(int16(0), result, "SetFroniusChargeBatteryMode returned wrong value")
+	assert.Error(err)
+}

--- a/pkg/fronius/schedule.go
+++ b/pkg/fronius/schedule.go
@@ -9,12 +9,22 @@ func SetFroniusChargeBatteryMode(pw_forecast float64, pw_batt2charge float64, pw
 	}
 	var ch_pc int16 = 0
 
-	decision, reason, pw := ClassifyDecision(
+	decision, reason, pw, cerr := ClassifyDecision(
 		pw_batt2charge, pw_forecast, pw_consumption, pw_batt_max,
 		pw_batt_reserve, pw_lwt,
 		forecast_charge_enabled, batt_reserve_charge_enabled,
 	)
 	u.Log.Infof("Decision: %s - %s", decision.String(), reason)
+
+	if cerr != nil {
+		u.Log.Errorf("Classifier error: %s - resetting Fronius to defaults (stop forced charge)", cerr)
+		err = ForceCharge(fronius_ip, 0, p)
+		if err != nil {
+			u.Log.Errorf("Error setting defaults after classifier error: %s", err)
+			return 0, err
+		}
+		return 0, nil
+	}
 
 	switch decision {
 	case DecisionForecastCharge:


### PR DESCRIPTION
Base branch: release/v2.0.0
improve issue: #90 

Summary:
- Change ClassifyDecision signature to return error.
- Handle classifier error in SetFroniusChargeBatteryMode by resetting Fronius to defaults (stop forced charge).
- Add unit tests covering skip and error branches to reach 100% coverage for pkg/fronius.

Please review the changes and test results.