### PR TITLE
Wire MQTT schedule: subscribe commands & latest-state republish (issue #88)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,7 @@ pkg/
     schedule.go               - `schedule` command: main intelligent charging workflow
     schedule_runner.go        - Single-goroutine runner that serializes schedule ticks and command intents
     schedule_runner_test.go   - Unit tests for runner command handling and queue behavior
+    schedule_mqtt_wiring_test.go - Unit tests for MQTT command subscription wiring and latest-state re-publish behavior
     schedule_lifecycle_test.go - Unit tests for runner lifecycle behavior in no-cron MQTT/no-MQTT modes
     precedence_test.go        - Unit tests for flag > env > yaml viper precedence
   fronius/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,10 @@ jobs:
           fi
 
       - name: go testing
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+        run: |
+          go mod tidy
+          go vet ./...
+          go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v6

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,16 @@ endif
 
 DATE=$(shell date)
 
-.PHONY: build test test-build
+.PHONY: build test test-build fmt tidy vet
 
-make fmt:
+fmt:
 	go fmt ./...
+
+tidy:
+	go mod tidy
+
+vet:
+	go vet ./...
 
 test:
 	go test -cover -race ./...
@@ -36,4 +42,4 @@ build:
 
 test-build: test build
 
-all: fmt test-build
+all: fmt tidy vet test build

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
@@ -9,7 +9,7 @@
 
 ## 1. Task Analysis
 
-Goal: finish the remaining #88 `schedule` MQTT wiring by subscribing to command topics, routing messages into the #87 runner, preserving runner-owned execution acknowledgements, re-publishing the latest state when Home Assistant comes online, and expanding precedence tests for every MQTT key.
+Goal: finish the remaining #88 `schedule` MQTT wiring by subscribing to command topics, routing messages into the #87 runner, preserving runner-owned execution acknowledgements, and expanding precedence tests for every MQTT key.
 
 Non-goals:
 
@@ -57,7 +57,6 @@ flowchart LR
 	Cron[cron callbacks] -->|IntentTick / IntentSetDefaults| Inbox
 	Inbox --> Runner[single-goroutine Runner]
 	Runner -->|Modbus writes| Fronius[Fronius writer]
-	Runner -->|state| StateCache[latest state cache]
 	Runner -->|state / ack / error| Broker
 	HA[homeassistant/status=online] --> HAHandler[HA status handler]
 	HAHandler -->|discovery| Broker
@@ -134,57 +133,26 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 	 - Return `normalizePrefix(prefix) + "/cmd/+"`.
 	 - Rationale: avoid duplicating topic prefix normalization in `pkg/cmd`.
 
-3. Add latest-state cache support in [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go).
-	 - Add an unexported cache type using `sync.RWMutex` or `atomic.Value`.
-	 - Store a deep copy of `mqtt.StatePayload` because it contains pointer fields (`*float64`, `*int16`, `*bool`, `*time.Time`).
-	 - Add an optional field to `RunnerConfig`:
+3. Wire MQTT command subscription in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+	- Call `mqtt.InitWithCleanup` after configuration is prepared.
+	- After `runner := NewRunner(...)`, subscribe when `mqttCfg.Enabled && mqttClient != nil && mqttClient.IsConnected()`:
 
-		 ```go
-		 LatestState *latestStateCache
-		 ```
+		```go
+		func subscribeScheduleCommands(ctx context.Context, client mqtt.Client, cfg mqtt.Config, runner *Runner) error
+		```
 
-	 - In `NewRunner`, create a cache when `RunnerConfig.LatestState` is nil.
-	 - In `Runner.publishState`, store the cloned payload before calling `publishStateSnapshot`.
-	 - Add a helper such as:
+	- Use `mqtt.CommandTopicFilter(cfg.TopicPrefix)` and QoS 1.
+	- In the callback, copy the payload before dispatch:
 
-		 ```go
-		 func publishLatestState(ctx context.Context, client mqtt.Client, cfg mqtt.Config, latest *latestStateCache) bool
-		 ```
+		```go
+		payloadCopy := append([]byte(nil), payload...)
+		opCtx, cancel := context.WithTimeout(context.Background(), const_mqtt_op_timeout)
+		defer cancel()
+		runner.HandleCommand(opCtx, topic, payloadCopy)
+		```
 
-		 It returns `false` when no snapshot exists and otherwise calls `mqtt.PublishState`.
-	 - Rationale: HA birth handling needs the latest state without reaching into runner internals or racing on mutable pointer fields.
-
-4. Wire MQTT command subscription in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
-	 - Create `latestState := newLatestStateCache()` before calling MQTT init.
-	 - Call `mqtt.InitWithCleanup` with an HA-online handler that publishes the cached state after discovery:
-
-		 ```go
-		 mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(mqttCfg, appVersion, 3, 250*time.Millisecond,
-				 func(ctx context.Context, client mqtt.Client) {
-						 publishLatestState(ctx, client, mqttCfg, latestState)
-				 },
-		 )
-		 ```
-
-	 - Pass `LatestState: latestState` into `RunnerConfig`.
-	 - After `runner := NewRunner(...)`, subscribe when `mqttCfg.Enabled && mqttClient != nil && mqttClient.IsConnected()`:
-
-		 ```go
-		 func subscribeScheduleCommands(ctx context.Context, client mqtt.Client, cfg mqtt.Config, runner *Runner) error
-		 ```
-
-	 - Use `mqtt.CommandTopicFilter(cfg.TopicPrefix)` and QoS 1.
-	 - In the callback, copy the payload before dispatch:
-
-		 ```go
-		 payloadCopy := append([]byte(nil), payload...)
-		 opCtx, cancel := context.WithTimeout(context.Background(), const_mqtt_op_timeout)
-		 defer cancel()
-		 runner.HandleCommand(opCtx, topic, payloadCopy)
-		 ```
-
-	 - Treat subscribe failure as non-fatal but visible: return/log the error with `u.HandleError`, because state publication can still work even if command control does not.
-	 - Do not publish accepted acks in this callback; `Runner.handleIntent` already does that.
+	- Treat subscribe failure as non-fatal but visible: return/log the error with `u.HandleError`, because state publication can still work even if command control does not.
+	- Do not publish accepted acks in this callback; `Runner.handleIntent` already does that.
 
 5. Tighten/adjust comments in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
 	 - Update the `publishStateSnapshot` comment so it no longer claims to store `latestState` unless the cache is actually passed/stored elsewhere.
@@ -236,8 +204,7 @@ For every changed area, include expected, edge, and failure coverage.
 
 - Expected: command subscription uses `<mqtt_topic_prefix>/cmd/+` and routes `trigger_now` to the runner.
 - Expected: `pause`, `resume`, `force_charge`, and `set_defaults` still get accepted/execution acks from runner tests.
-- Edge: no latest state exists when HA comes online; discovery re-publishes and no empty state is sent.
-- Edge: latest state exists; HA online re-publishes a retained state snapshot with the same values.
+ - Edge: no latest state exists when HA comes online; discovery re-publishes and no empty state is sent.
 - Edge: a full runner queue returns `false` from `HandleCommand` and publishes a rejected ack.
 - Failure: invalid command topic/payload publishes rejected ack and does not enqueue an intent.
 - Failure: command subscription error is surfaced/logged and does not crash `schedule`.

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
@@ -4,38 +4,321 @@
 > TASK: [88-issue-wire-mqtt-schedule-TASK.md](88-issue-wire-mqtt-schedule-TASK.md)  
 > Issue: https://github.com/atbore-phx/sbam/issues/88  
 > Parent issue: https://github.com/atbore-phx/sbam/issues/64  
-> Reconciled: 2026-05-10
+> Date: 2026-05-13  
+> Reconciled against current code: 2026-05-13
 
-## 1. Current State
+## 1. Task Analysis
 
-`pkg/cmd/schedule.go` already reads the twelve MQTT keys, builds `mqtt.Config`, calls `mqtt.InitWithCleanup`, and publishes basic schedule state. `src/utils/startup.go` already redacts MQTT secrets. `config.yaml` and the HA add-on already contain non-TLS MQTT options.
+Goal: finish the remaining #88 `schedule` MQTT wiring by subscribing to command topics, routing messages into the #87 runner, preserving runner-owned execution acknowledgements, re-publishing the latest state when Home Assistant comes online, and expanding precedence tests for every MQTT key.
 
-The missing pieces are command subscription, runner integration, ack routing, latest-state re-publication, and broad precedence tests.
+Non-goals:
 
-## 2. Implementation Steps
+- Do not reimplement the MQTT scaffold, discovery builder, command parser, ack publisher, or runner lifecycle already delivered by #84/#85/#86/#87.
+- Do not add `set_reserve` MQTT support in v2.0.0.
+- Do not modify Home Assistant add-on service auto-discovery or README release docs; those remain #89/#91.
+- Do not change Solcast, Fronius Solar API, or Fronius Modbus register semantics.
 
-1. After #87, construct `Runner` in `scdCmd.Run` and start `go runner.Run(ctx)`.
-2. Change cron callbacks to submit runner tick intents.
-3. Subscribe to `<prefix>/cmd/+` after MQTT connect. Keep the callback tiny: copy payload, parse, publish rejected ack if needed, submit accepted intent.
-4. Ensure accepted command acks are published after runner execution, not before.
-5. Track latest state in the runner or a small holder so HA birth messages can re-publish it.
-6. Keep `mqtt.InitWithCleanup` fallback-to-noop behavior on setup/connect failures.
-7. Extend `pkg/cmd/precedence_test.go` with table-driven coverage for the twelve MQTT keys.
-8. Add focused tests with fake MQTT client and fake runner/client adapters.
+Acceptance criteria from the TASK:
 
-## 3. Test Plan
+- `mqtt_enabled=false` remains a no-connect/no-subscribe/no-Modbus-diff path.
+- MQTT-enabled `schedule` subscribes to `<mqtt_topic_prefix>/cmd/+` and publishes state after ticks.
+- `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults` route through the runner.
+- Parser failures publish rejected acks immediately; accepted/error execution acks are published by the runner.
+- `homeassistant/status=online` re-publishes discovery and latest state when known.
+- `mqtt_password` and `mqtt_tls_client_cert_key` stay redacted.
+- All twelve MQTT keys observe flag > env > yaml > default precedence.
+- `make test` and `make build` pass.
 
-- Disabled MQTT: no connect/subscribe path and existing schedule tests remain green.
-- Enabled MQTT: command subscription topic is `<prefix>/cmd/+`.
-- Parse failure: rejected ack is published immediately.
-- Accepted command: runner receives the expected intent.
-- HA status `online`: discovery and latest state are re-published.
-- Precedence: flag > env > yaml > default for all twelve keys.
+## 2. Current State
 
-## 4. Validation
+| Area | File | Current behavior |
+| --- | --- | --- |
+| Schedule flags/config | [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | Registers and reads all twelve MQTT keys, builds `mqtt.Config`, calls `mqtt.InitWithCleanup`, logs startup parameters, constructs `Runner`, starts `Runner.Run`, and uses `crontabSchedule` for cron. |
+| Runner lifecycle | [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | `finalizeRunnerMode` stops the runner immediately when MQTT is disabled, and waits for signals when MQTT is enabled. `crontabSchedule` already submits `mqtt.IntentTick` and `mqtt.IntentSetDefaults` instead of running schedule work directly. |
+| Runner API | [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) | `NewRunner`, `Run`, `Submit`, `HandleCommand`, `Tick`, and `handleIntent` exist. `Submit` is non-blocking with queue size 16. `HandleCommand` parses with `mqtt.ParseIntent`, publishes rejected acks for parser failures or full queue, and submits accepted intents. `handleIntent` publishes accepted/error acks after execution. |
+| State/error publishing | [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go), [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | `Runner.publishState` delegates to `publishStateSnapshot`, which publishes retained `mqtt.StatePayload`. Despite its comment, no latest-state cache currently exists. |
+| MQTT init | [pkg/mqtt/init.go](../../../pkg/mqtt/init.go) | `InitWithCleanup` creates/connects the client, falls back to noop on setup/connect failure, and subscribes to `homeassistant/status` to re-publish discovery only. |
+| MQTT client API | [pkg/mqtt/client.go](../../../pkg/mqtt/client.go) | `Client` supports `Connect`, `Disconnect`, `Publish`, `Subscribe`, and `IsConnected`. Topic helpers are currently unexported. |
+| MQTT parser/ack | [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go) | `ParseIntent` supports `trigger_now`, `force_charge`, `set_defaults`, `pause`, and `resume`; `pause` accepts empty payload or `{}` as indefinite. `PublishAck` publishes `{ts, command, accepted, error}` to `<cmd-topic>/ack`. |
+| Payload types | [pkg/mqtt/types.go](../../../pkg/mqtt/types.go) | `StatePayload`, `ErrorPayload`, `AckPayload`, and `Intent` are already defined. |
+| Startup redaction | [src/utils/startup.go](../../../src/utils/startup.go) | `SecretKeys` already includes `mqtt_password` and `mqtt_tls_client_cert_key`. |
+| Precedence tests | [pkg/cmd/precedence_test.go](../../../pkg/cmd/precedence_test.go) | Existing tests cover Viper precedence generally and only one MQTT key, `mqtt_ha_discovery_prefix`. |
+| Runner tests | [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go) | Tests already cover empty pause payloads, command acks, force charge/defaults execution, queue-full rejection, paused rejection, `set_reserve` rejection, and unknown command rejection. |
+| MQTT init tests | [pkg/mqtt/init_test.go](../../../pkg/mqtt/init_test.go) | Tests cover connect retries, setup/connect fallback, HA status subscription errors, and discovery re-publication on `online`. |
+
+## 3. Target Architecture
+
+```mermaid
+flowchart LR
+	Broker[(MQTT broker)] -->|<prefix>/cmd/+| CmdSub[command subscription]
+	CmdSub -->|copy payload| Handle[Runner.HandleCommand]
+	Handle -->|ParseIntent failure| AckReject[Publish rejected ack]
+	Handle -->|accepted intent| Inbox[(Runner intent queue)]
+	Cron[cron callbacks] -->|IntentTick / IntentSetDefaults| Inbox
+	Inbox --> Runner[single-goroutine Runner]
+	Runner -->|Modbus writes| Fronius[Fronius writer]
+	Runner -->|state| StateCache[latest state cache]
+	Runner -->|state / ack / error| Broker
+	HA[homeassistant/status=online] --> HAHandler[HA status handler]
+	HAHandler -->|discovery| Broker
+	HAHandler -->|latest state if cached| Broker
+```
+
+Implementation shape:
+
+- Keep the runner as the only owner of Fronius write operations.
+- Use `Runner.HandleCommand(ctx, topic, payload)` as the command entry point instead of duplicating parser/ack logic in `schedule.go`.
+- Add command subscription wiring in `schedule.go` after MQTT init and runner construction.
+- Add a small latest-state cache in `pkg/cmd` and store snapshots inside `Runner.publishState` before calling `mqtt.PublishState`.
+- Extend MQTT HA status handling so `homeassistant/status=online` can publish discovery and also call a schedule-owned latest-state republisher.
+- Keep MQTT init fallback behavior: setup/connect failures return a noop client and a non-fatal error to log.
+
+## 4. Dependency Choices
+
+No new Go modules are required.
+
+Continue using existing dependencies:
+
+| Dependency | Purpose | Reference |
+| --- | --- | --- |
+| `github.com/eclipse/paho.mqtt.golang` | Production MQTT client already wrapped by `pkg/mqtt`. | https://pkg.go.dev/github.com/eclipse/paho.mqtt.golang |
+| `github.com/mochi-mqtt/server/v2` | Existing in-process broker tests in `pkg/mqtt`. | https://pkg.go.dev/github.com/mochi-mqtt/server/v2 |
+| `github.com/stretchr/testify` | Assertions in existing test style. | https://pkg.go.dev/github.com/stretchr/testify |
+| `github.com/spf13/viper` / `github.com/spf13/cobra` | Existing config precedence and CLI flag wiring. | https://pkg.go.dev/github.com/spf13/viper |
+
+## 5. Configuration Changes
+
+No new config keys are planned. Verify and test the existing twelve standalone keys:
+
+| Key / flag | Env | Type | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `mqtt_enabled` | `MQTT_ENABLED` | bool | `false` | Master switch; disabled path must not connect or subscribe. |
+| `mqtt_broker` | `MQTT_BROKER` | string | `""` | Broker URL consumed by Paho. |
+| `mqtt_client_id` | `MQTT_CLIENT_ID` | string | `""` | Empty value auto-generates in the MQTT layer. |
+| `mqtt_username` | `MQTT_USERNAME` | string | `""` | Optional username. |
+| `mqtt_password` | `MQTT_PASSWORD` | string | `""` | Secret; redacted by startup dump. |
+| `mqtt_tls_ca_file` | `MQTT_TLS_CA_FILE` | string | `""` | Standalone TLS CA bundle. |
+| `mqtt_tls_client_cert` | `MQTT_TLS_CLIENT_CERT` | string | `""` | Standalone client cert. |
+| `mqtt_tls_client_cert_key` | `MQTT_TLS_CLIENT_CERT_KEY` | string | `""` | Secret; redacted by startup dump. |
+| `mqtt_tls_insecure_skip` | `MQTT_TLS_INSECURE_SKIP` | bool | `false` | Development-only TLS bypass. |
+| `mqtt_topic_prefix` | `MQTT_TOPIC_PREFIX` | string | `sbam` | State, error, availability, command, and ack topic prefix. |
+| `mqtt_ha_discovery` | `MQTT_HA_DISCOVERY` | bool | `true` | Discovery publish switch. |
+| `mqtt_ha_discovery_prefix` | `MQTT_HA_DISCOVERY_PREFIX` | string | `homeassistant` | Discovery config root. |
+
+Precedence remains flag > env > yaml > default through `bindFlags` in [pkg/cmd/root.go](../../../pkg/cmd/root.go).
+
+Home Assistant add-on schema and `run.sh` changes remain #89. This issue should not change add-on option surfaces unless tests reveal a direct regression from #88 wiring.
+
+## 6. Implementation Blueprint
+
+1. Update MQTT HA status init hook in [pkg/mqtt/init.go](../../../pkg/mqtt/init.go).
+	 - Add a small extension point while preserving current callers, for example:
+
+		 ```go
+		 type HAOnlineHandler func(context.Context, Client)
+
+		 func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration, handlers ...HAOnlineHandler) (Client, func(), error)
+		 ```
+
+	 - In the existing `homeassistant/status` callback, copy `payload` with `append([]byte(nil), payload...)`, ignore non-`online`, publish discovery as today, then invoke each non-nil handler with the same short-lived context and connected client.
+	 - Keep existing behavior when no handler is passed.
+	 - Rationale: schedule needs a latest-state republish hook, but `pkg/mqtt` should still own the HA status topic helper and discovery publish behavior it already has.
+
+2. Add command topic filter helper in [pkg/mqtt/client.go](../../../pkg/mqtt/client.go).
+	 - Add:
+
+		 ```go
+		 func CommandTopicFilter(prefix string) string
+		 ```
+
+	 - Return `normalizePrefix(prefix) + "/cmd/+"`.
+	 - Rationale: avoid duplicating topic prefix normalization in `pkg/cmd`.
+
+3. Add latest-state cache support in [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go).
+	 - Add an unexported cache type using `sync.RWMutex` or `atomic.Value`.
+	 - Store a deep copy of `mqtt.StatePayload` because it contains pointer fields (`*float64`, `*int16`, `*bool`, `*time.Time`).
+	 - Add an optional field to `RunnerConfig`:
+
+		 ```go
+		 LatestState *latestStateCache
+		 ```
+
+	 - In `NewRunner`, create a cache when `RunnerConfig.LatestState` is nil.
+	 - In `Runner.publishState`, store the cloned payload before calling `publishStateSnapshot`.
+	 - Add a helper such as:
+
+		 ```go
+		 func publishLatestState(ctx context.Context, client mqtt.Client, cfg mqtt.Config, latest *latestStateCache) bool
+		 ```
+
+		 It returns `false` when no snapshot exists and otherwise calls `mqtt.PublishState`.
+	 - Rationale: HA birth handling needs the latest state without reaching into runner internals or racing on mutable pointer fields.
+
+4. Wire MQTT command subscription in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+	 - Create `latestState := newLatestStateCache()` before calling MQTT init.
+	 - Call `mqtt.InitWithCleanup` with an HA-online handler that publishes the cached state after discovery:
+
+		 ```go
+		 mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(mqttCfg, appVersion, 3, 250*time.Millisecond,
+				 func(ctx context.Context, client mqtt.Client) {
+						 publishLatestState(ctx, client, mqttCfg, latestState)
+				 },
+		 )
+		 ```
+
+	 - Pass `LatestState: latestState` into `RunnerConfig`.
+	 - After `runner := NewRunner(...)`, subscribe when `mqttCfg.Enabled && mqttClient != nil && mqttClient.IsConnected()`:
+
+		 ```go
+		 func subscribeScheduleCommands(ctx context.Context, client mqtt.Client, cfg mqtt.Config, runner *Runner) error
+		 ```
+
+	 - Use `mqtt.CommandTopicFilter(cfg.TopicPrefix)` and QoS 1.
+	 - In the callback, copy the payload before dispatch:
+
+		 ```go
+		 payloadCopy := append([]byte(nil), payload...)
+		 opCtx, cancel := context.WithTimeout(context.Background(), const_mqtt_op_timeout)
+		 defer cancel()
+		 runner.HandleCommand(opCtx, topic, payloadCopy)
+		 ```
+
+	 - Treat subscribe failure as non-fatal but visible: return/log the error with `u.HandleError`, because state publication can still work even if command control does not.
+	 - Do not publish accepted acks in this callback; `Runner.handleIntent` already does that.
+
+5. Tighten/adjust comments in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+	 - Update the `publishStateSnapshot` comment so it no longer claims to store `latestState` unless the cache is actually passed/stored elsewhere.
+	 - Keep comments succinct and tied to concurrency/state behavior.
+
+6. Extend MQTT init tests in [pkg/mqtt/init_test.go](../../../pkg/mqtt/init_test.go).
+	 - Expected: existing discovery-on-`online` behavior still publishes discovery.
+	 - Expected: a passed `HAOnlineHandler` is called exactly once for `online` and not for `offline`.
+	 - Edge: nil handler is ignored.
+	 - Failure: subscription failure is still returned as an accumulated error.
+	 - Verify payload copying if practical by mutating the original byte slice after callback entry in a focused unit test.
+
+7. Extend command wiring tests in `pkg/cmd`.
+	 - Extend the existing fake MQTT client in [pkg/cmd/schedule_test.go](../../../pkg/cmd/schedule_test.go) or create a local recording fake in a new test file under `pkg/cmd`.
+	 - Test `subscribeScheduleCommands`:
+		 - expected: subscribes to `sbam/cmd/+` for the default prefix.
+		 - expected: custom prefix `house/sbam` subscribes to `house/sbam/cmd/+`.
+		 - expected: invoking the stored handler with `sbam/cmd/trigger_now` enqueues `mqtt.IntentTriggerNow` through `Runner.HandleCommand`.
+		 - failure: invalid payload publishes a rejected ack and leaves the runner queue empty.
+		 - failure: subscribe error is returned/loggable and does not panic.
+	 - Test latest-state cache:
+		 - before any state, HA online handler does not publish `state`.
+		 - after `Runner.publishState`, HA online handler publishes the cached state.
+		 - mutate original payload pointer values after storing and verify cached state does not change.
+
+8. Extend precedence tests in [pkg/cmd/precedence_test.go](../../../pkg/cmd/precedence_test.go).
+	 - Replace the one-off MQTT discovery-prefix test with a table covering all twelve keys.
+	 - For each key, cover flag > env > yaml > default. Prefer subtests that reset Viper and reset the shared `scdCmd` flag `Changed` state after each case.
+	 - Include bool keys (`mqtt_enabled`, `mqtt_tls_insecure_skip`, `mqtt_ha_discovery`) and string keys.
+	 - Keep tests non-parallel because they mutate global Viper and shared Cobra flags.
+
+9. Keep startup redaction as a regression check.
+	 - [src/utils/startup.go](../../../src/utils/startup.go) already has both MQTT secrets in `SecretKeys`.
+	 - Do not edit it unless tests show a regression; rely on existing [src/utils/startup_test.go](../../../src/utils/startup_test.go) and add only a focused assertion if missing.
+
+## 7. Test Plan
+
+For every changed area, include expected, edge, and failure coverage.
+
+`pkg/mqtt`:
+
+- Expected: `InitWithCleanup` still connects and publishes discovery on `homeassistant/status=online`.
+- Expected: optional HA online handler runs after discovery publish.
+- Edge: offline/blank/non-`online` HA payloads do not call the handler.
+- Failure: setup/connect/subscribe failures continue to fall back or return errors as current tests expect.
+- Expected: `CommandTopicFilter("") == "sbam/cmd/+"` and custom prefixes are trimmed/normalized.
+
+`pkg/cmd` runner/schedule wiring:
+
+- Expected: command subscription uses `<mqtt_topic_prefix>/cmd/+` and routes `trigger_now` to the runner.
+- Expected: `pause`, `resume`, `force_charge`, and `set_defaults` still get accepted/execution acks from runner tests.
+- Edge: no latest state exists when HA comes online; discovery re-publishes and no empty state is sent.
+- Edge: latest state exists; HA online re-publishes a retained state snapshot with the same values.
+- Edge: a full runner queue returns `false` from `HandleCommand` and publishes a rejected ack.
+- Failure: invalid command topic/payload publishes rejected ack and does not enqueue an intent.
+- Failure: command subscription error is surfaced/logged and does not crash `schedule`.
+
+`pkg/cmd` precedence:
+
+- Expected: each MQTT flag value beats env and yaml.
+- Expected: each MQTT env var beats yaml.
+- Expected: each MQTT yaml value beats the flag default.
+- Edge: bool defaults resolve correctly for `mqtt_enabled=false`, `mqtt_tls_insecure_skip=false`, and `mqtt_ha_discovery=true`.
+
+Regression checks:
+
+- Disabled MQTT lifecycle tests in [pkg/cmd/schedule_lifecycle_test.go](../../../pkg/cmd/schedule_lifecycle_test.go) stay green.
+- Existing parser/ack tests in [pkg/mqtt/commands_test.go](../../../pkg/mqtt/commands_test.go) stay green.
+- Existing runner command tests in [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go) stay green.
+
+## 8. Validation Gates
+
+Run and pass:
 
 ```bash
-go test ./pkg/cmd -run 'Test.*MQTT|Test.*Precedence|Test.*Schedule'
+go test ./pkg/mqtt -run 'TestInitWithCleanup|TestCommandTopic|TestParseIntent|TestPublishAck' -v
+go test ./pkg/cmd -run 'Test.*MQTT|Test.*Runner|Test.*Precedence|Test.*Schedule|TestFinalizeRunnerMode|TestCrontabSchedule' -v
 make test
 make build
 ```
+
+If command subscription or latest-state cache introduces goroutine/channel-sensitive tests, also run:
+
+```bash
+go test -race ./pkg/cmd
+```
+
+No Docker build is required for this issue unless implementation unexpectedly changes Docker or Home Assistant add-on files.
+
+## 9. Rollout / Backward Compatibility
+
+- `mqtt_enabled=false` remains the default and must not attempt any MQTT connection or command subscription.
+- Existing schedule cron behavior is already routed through the runner; #88 must preserve that behavior.
+- Existing MQTT command topics and ack payload shapes from #86 remain stable.
+- Existing `homeassistant/status=online` discovery re-publication remains; #88 adds latest-state re-publication only when a snapshot exists.
+- No migration is required for users who do not enable MQTT.
+- No Home Assistant add-on schema migration is part of this issue.
+
+## 10. Security Considerations
+
+- MQTT topic payloads are untrusted input. Only `mqtt.ParseIntent` should interpret them, and rejected commands must not reach Fronius write helpers.
+- Keep command callbacks non-blocking enough for Paho receive goroutines. Use short contexts and rely on `Runner.Submit` queue-full handling.
+- Copy MQTT payload bytes before parsing/dispatch to avoid retaining or racing with broker/client buffers.
+- Do not log raw secret config values. `mqtt_password` and `mqtt_tls_client_cert_key` must remain in `utils.SecretKeys`.
+- Latest-state cache must deep-copy pointer fields to avoid data races or later mutation changing retained snapshots.
+- No command path should execute shell commands, evaluate templates, or call reflection based on MQTT payload content.
+
+## 11. Gotchas
+
+- `InitWithCleanup` currently owns the HA status subscription. Add the latest-state hook there rather than creating two subscriptions to `homeassistant/status` from the same client.
+- `Runner.HandleCommand` already publishes parser-failure acks and queue-full rejected acks; duplicating that logic in `schedule.go` would create double acks.
+- `Runner.handleIntent` already publishes accepted/error execution acks for command intents; the MQTT callback should stop after `HandleCommand` returns.
+- `publishStateSnapshot` currently has a stale comment about latest-state storage. Fix the comment while adding the actual cache.
+- Topic helper functions in `pkg/mqtt/client.go` are unexported today, so command subscription should use a small exported helper rather than hand-normalizing prefixes in `pkg/cmd`.
+- Shared Cobra command flags and Viper globals make precedence tests order-sensitive. Reset flag values and `Changed` state in `t.Cleanup`.
+- `mqtt.New` returns a noop client when disabled; guard subscriptions with both `cfg.Enabled` and `client.IsConnected()` to keep disabled behavior quiet.
+- `set_reserve` exists as an intent placeholder but must stay unsupported for v2.0.0.
+
+## 12. Open Questions / Risks
+
+- RESOLVED: runner command API exists as `Runner.HandleCommand(ctx, topic, payload)` and should be used by #88.
+- RESOLVED: pause `{}` already parses as indefinite pause in `pkg/mqtt/commands.go`.
+- RESOLVED: runner stays alive in no-cron MQTT mode through `finalizeRunnerMode`.
+- RISK: adding an HA online hook to `InitWithCleanup` touches `pkg/mqtt` tests; keep the variadic API backward-compatible.
+- RISK: latest-state cache cloning can miss a pointer field if `mqtt.StatePayload` grows; keep clone tests strict.
+- RISK: command subscription is non-fatal by design; document/log clearly so operators can diagnose missing remote control while state publishing still works.
+
+## 13. Confidence Score
+
+9/10.
+
+The runner, parser, ack publisher, MQTT init, and most lifecycle behavior already exist and have focused tests. The remaining work is narrow. Confidence would rise further after implementation validates the exact latest-state cache shape under `go test -race ./pkg/cmd`.
+
+## 14. Revision History
+
+- 2026-05-10: Initial reconciled PLAN captured command subscription, runner integration, latest state, and precedence tests at a high level.
+- 2026-05-13: Rewrote PLAN after reading #64, #88, current `schedule.go`, current `schedule_runner.go`, MQTT init/parser/publisher APIs, and cmd/mqtt tests. Updated blueprint to use existing `Runner.HandleCommand` and current no-cron runner lifecycle.

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
@@ -100,17 +100,11 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 ## 6. Implementation Blueprint
 
 1. Update MQTT HA status init hook in [pkg/mqtt/init.go](../../../pkg/mqtt/init.go).
-	 - Add a small extension point while preserving current callers, for example:
+ 	 - Ensure `InitWithCleanup` subscribes to `homeassistant/status` and publishes discovery when `cfg.HADiscovery` is true. The function no longer accepts caller-provided handlers; discovery re-publication is the sole built-in HA-online behavior.
 
-		 ```go
-		 type HAOnlineHandler func(context.Context, Client)
-
-		 func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration, handlers ...HAOnlineHandler) (Client, func(), error)
-		 ```
-
-	 - In the existing `homeassistant/status` callback, copy `payload` with `append([]byte(nil), payload...)`, ignore non-`online`, publish discovery as today, then invoke each non-nil handler with the same short-lived context and connected client.
-	- Keep existing behavior when no handler is passed.
-	- Rationale: schedule needs a way to re-publish discovery when HA signals online; `pkg/mqtt` should own the HA status subscription and discovery publish behavior.
+	 - In the existing `homeassistant/status` callback, copy `payload` with `append([]byte(nil), payload...)`, ignore non-`online`, and call `PublishDiscovery(ctx, client, cfg, version)`.
+	 - Keep existing behavior when `HADiscovery` is false (no subscription).
+	 - Rationale: `pkg/mqtt` should own discovery publish; higher-level code should publish any additional application state explicitly (for example, via the runner) rather than registering inline callbacks.
 
 2. Add command topic filter helper in [pkg/mqtt/client.go](../../../pkg/mqtt/client.go).
 	 - Add:
@@ -148,11 +142,10 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 	 - Keep comments succinct and tied to concurrency/state behavior.
 
 6. Extend MQTT init tests in [pkg/mqtt/init_test.go](../../../pkg/mqtt/init_test.go).
-	 - Expected: existing discovery-on-`online` behavior still publishes discovery.
-	 - Expected: a passed `HAOnlineHandler` is called exactly once for `online` and not for `offline`.
-	 - Edge: nil handler is ignored.
-	 - Failure: subscription failure is still returned as an accumulated error.
-	 - Verify payload copying if practical by mutating the original byte slice after callback entry in a focused unit test.
+ 	 - Expected: existing discovery-on-`online` behavior still publishes discovery.
+ 	 - Expected: handler-based registration support has been removed; tests should exercise discovery publish and subscription behavior via `HADiscovery=true` instead of passing inline handlers.
+ 	 - Failure: subscription failure is still returned as an accumulated error.
+ 	 - Verify payload copying if practical by mutating the original byte slice after callback entry in a focused unit test.
 
 7. Extend command wiring tests in `pkg/cmd`.
 	 - Extend the existing fake MQTT client in [pkg/cmd/schedule_test.go](../../../pkg/cmd/schedule_test.go) or create a local recording fake in a new test file under `pkg/cmd`.

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-PLAN.md
@@ -18,16 +18,7 @@ Non-goals:
 - Do not modify Home Assistant add-on service auto-discovery or README release docs; those remain #89/#91.
 - Do not change Solcast, Fronius Solar API, or Fronius Modbus register semantics.
 
-Acceptance criteria from the TASK:
-
-- `mqtt_enabled=false` remains a no-connect/no-subscribe/no-Modbus-diff path.
-- MQTT-enabled `schedule` subscribes to `<mqtt_topic_prefix>/cmd/+` and publishes state after ticks.
-- `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults` route through the runner.
-- Parser failures publish rejected acks immediately; accepted/error execution acks are published by the runner.
-- `homeassistant/status=online` re-publishes discovery and latest state when known.
-- `mqtt_password` and `mqtt_tls_client_cert_key` stay redacted.
-- All twelve MQTT keys observe flag > env > yaml > default precedence.
-- `make test` and `make build` pass.
+ - `homeassistant/status=online` re-publishes discovery. (No latest-state cache is added by this change.)
 
 ## 2. Current State
 
@@ -36,7 +27,7 @@ Acceptance criteria from the TASK:
 | Schedule flags/config | [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | Registers and reads all twelve MQTT keys, builds `mqtt.Config`, calls `mqtt.InitWithCleanup`, logs startup parameters, constructs `Runner`, starts `Runner.Run`, and uses `crontabSchedule` for cron. |
 | Runner lifecycle | [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | `finalizeRunnerMode` stops the runner immediately when MQTT is disabled, and waits for signals when MQTT is enabled. `crontabSchedule` already submits `mqtt.IntentTick` and `mqtt.IntentSetDefaults` instead of running schedule work directly. |
 | Runner API | [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) | `NewRunner`, `Run`, `Submit`, `HandleCommand`, `Tick`, and `handleIntent` exist. `Submit` is non-blocking with queue size 16. `HandleCommand` parses with `mqtt.ParseIntent`, publishes rejected acks for parser failures or full queue, and submits accepted intents. `handleIntent` publishes accepted/error acks after execution. |
-| State/error publishing | [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go), [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | `Runner.publishState` delegates to `publishStateSnapshot`, which publishes retained `mqtt.StatePayload`. Despite its comment, no latest-state cache currently exists. |
+| State/error publishing | [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go), [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) | `Runner.publishState` delegates to `publishStateSnapshot`, which publishes retained `mqtt.StatePayload`. No latest-state cache exists; this change will not add one. |
 | MQTT init | [pkg/mqtt/init.go](../../../pkg/mqtt/init.go) | `InitWithCleanup` creates/connects the client, falls back to noop on setup/connect failure, and subscribes to `homeassistant/status` to re-publish discovery only. |
 | MQTT client API | [pkg/mqtt/client.go](../../../pkg/mqtt/client.go) | `Client` supports `Connect`, `Disconnect`, `Publish`, `Subscribe`, and `IsConnected`. Topic helpers are currently unexported. |
 | MQTT parser/ack | [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go) | `ParseIntent` supports `trigger_now`, `force_charge`, `set_defaults`, `pause`, and `resume`; `pause` accepts empty payload or `{}` as indefinite. `PublishAck` publishes `{ts, command, accepted, error}` to `<cmd-topic>/ack`. |
@@ -60,16 +51,14 @@ flowchart LR
 	Runner -->|state / ack / error| Broker
 	HA[homeassistant/status=online] --> HAHandler[HA status handler]
 	HAHandler -->|discovery| Broker
-	HAHandler -->|latest state if cached| Broker
 ```
 
 Implementation shape:
 
 - Keep the runner as the only owner of Fronius write operations.
 - Use `Runner.HandleCommand(ctx, topic, payload)` as the command entry point instead of duplicating parser/ack logic in `schedule.go`.
-- Add command subscription wiring in `schedule.go` after MQTT init and runner construction.
-- Add a small latest-state cache in `pkg/cmd` and store snapshots inside `Runner.publishState` before calling `mqtt.PublishState`.
-- Extend MQTT HA status handling so `homeassistant/status=online` can publish discovery and also call a schedule-owned latest-state republisher.
+ - Add command subscription wiring in `schedule.go` after MQTT init and runner construction.
+ - Do not add a latest-state cache; keep HA online handling limited to discovery re-publication only.
 - Keep MQTT init fallback behavior: setup/connect failures return a noop client and a non-fatal error to log.
 
 ## 4. Dependency Choices
@@ -120,8 +109,8 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 		 ```
 
 	 - In the existing `homeassistant/status` callback, copy `payload` with `append([]byte(nil), payload...)`, ignore non-`online`, publish discovery as today, then invoke each non-nil handler with the same short-lived context and connected client.
-	 - Keep existing behavior when no handler is passed.
-	 - Rationale: schedule needs a latest-state republish hook, but `pkg/mqtt` should still own the HA status topic helper and discovery publish behavior it already has.
+	- Keep existing behavior when no handler is passed.
+	- Rationale: schedule needs a way to re-publish discovery when HA signals online; `pkg/mqtt` should own the HA status subscription and discovery publish behavior.
 
 2. Add command topic filter helper in [pkg/mqtt/client.go](../../../pkg/mqtt/client.go).
 	 - Add:
@@ -155,7 +144,7 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 	- Do not publish accepted acks in this callback; `Runner.handleIntent` already does that.
 
 5. Tighten/adjust comments in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
-	 - Update the `publishStateSnapshot` comment so it no longer claims to store `latestState` unless the cache is actually passed/stored elsewhere.
+ 	 - Update the `publishStateSnapshot` comment so it no longer claims to store `latestState` (no cache is added by this change).
 	 - Keep comments succinct and tied to concurrency/state behavior.
 
 6. Extend MQTT init tests in [pkg/mqtt/init_test.go](../../../pkg/mqtt/init_test.go).
@@ -173,10 +162,9 @@ Home Assistant add-on schema and `run.sh` changes remain #89. This issue should 
 		 - expected: invoking the stored handler with `sbam/cmd/trigger_now` enqueues `mqtt.IntentTriggerNow` through `Runner.HandleCommand`.
 		 - failure: invalid payload publishes a rejected ack and leaves the runner queue empty.
 		 - failure: subscribe error is returned/loggable and does not panic.
-	 - Test latest-state cache:
-		 - before any state, HA online handler does not publish `state`.
-		 - after `Runner.publishState`, HA online handler publishes the cached state.
-		 - mutate original payload pointer values after storing and verify cached state does not change.
+	- Test HA online discovery republish:
+		- before any state, HA online handler does not publish `state`.
+		- discovery is re-published on `homeassistant/status=online` but no latest-state republish occurs.
 
 8. Extend precedence tests in [pkg/cmd/precedence_test.go](../../../pkg/cmd/precedence_test.go).
 	 - Replace the one-off MQTT discovery-prefix test with a table covering all twelve keys.
@@ -204,7 +192,7 @@ For every changed area, include expected, edge, and failure coverage.
 
 - Expected: command subscription uses `<mqtt_topic_prefix>/cmd/+` and routes `trigger_now` to the runner.
 - Expected: `pause`, `resume`, `force_charge`, and `set_defaults` still get accepted/execution acks from runner tests.
- - Edge: no latest state exists when HA comes online; discovery re-publishes and no empty state is sent.
+ - Edge: no cached state exists when HA comes online; discovery re-publishes and no empty state is sent.
 - Edge: a full runner queue returns `false` from `HandleCommand` and publishes a rejected ack.
 - Failure: invalid command topic/payload publishes rejected ack and does not enqueue an intent.
 - Failure: command subscription error is surfaced/logged and does not crash `schedule`.
@@ -233,7 +221,7 @@ make test
 make build
 ```
 
-If command subscription or latest-state cache introduces goroutine/channel-sensitive tests, also run:
+If command subscription introduces goroutine/channel-sensitive tests, also run:
 
 ```bash
 go test -race ./pkg/cmd
@@ -246,7 +234,7 @@ No Docker build is required for this issue unless implementation unexpectedly ch
 - `mqtt_enabled=false` remains the default and must not attempt any MQTT connection or command subscription.
 - Existing schedule cron behavior is already routed through the runner; #88 must preserve that behavior.
 - Existing MQTT command topics and ack payload shapes from #86 remain stable.
-- Existing `homeassistant/status=online` discovery re-publication remains; #88 adds latest-state re-publication only when a snapshot exists.
+- Existing `homeassistant/status=online` discovery re-publication remains; this change does not add latest-state re-publication.
 - No migration is required for users who do not enable MQTT.
 - No Home Assistant add-on schema migration is part of this issue.
 
@@ -256,15 +244,15 @@ No Docker build is required for this issue unless implementation unexpectedly ch
 - Keep command callbacks non-blocking enough for Paho receive goroutines. Use short contexts and rely on `Runner.Submit` queue-full handling.
 - Copy MQTT payload bytes before parsing/dispatch to avoid retaining or racing with broker/client buffers.
 - Do not log raw secret config values. `mqtt_password` and `mqtt_tls_client_cert_key` must remain in `utils.SecretKeys`.
-- Latest-state cache must deep-copy pointer fields to avoid data races or later mutation changing retained snapshots.
+- No latest-state cache is added; no deep-copy requirement applies.
 - No command path should execute shell commands, evaluate templates, or call reflection based on MQTT payload content.
 
 ## 11. Gotchas
 
-- `InitWithCleanup` currently owns the HA status subscription. Add the latest-state hook there rather than creating two subscriptions to `homeassistant/status` from the same client.
+- `InitWithCleanup` currently owns the HA status subscription. Keep that single subscription rather than creating additional subscriptions to `homeassistant/status` from other packages.
 - `Runner.HandleCommand` already publishes parser-failure acks and queue-full rejected acks; duplicating that logic in `schedule.go` would create double acks.
 - `Runner.handleIntent` already publishes accepted/error execution acks for command intents; the MQTT callback should stop after `HandleCommand` returns.
-- `publishStateSnapshot` currently has a stale comment about latest-state storage. Fix the comment while adding the actual cache.
+- `publishStateSnapshot` currently has a stale comment about latest-state storage. Fix the comment and do not add a cache.
 - Topic helper functions in `pkg/mqtt/client.go` are unexported today, so command subscription should use a small exported helper rather than hand-normalizing prefixes in `pkg/cmd`.
 - Shared Cobra command flags and Viper globals make precedence tests order-sensitive. Reset flag values and `Changed` state in `t.Cleanup`.
 - `mqtt.New` returns a noop client when disabled; guard subscriptions with both `cfg.Enabled` and `client.IsConnected()` to keep disabled behavior quiet.
@@ -276,14 +264,14 @@ No Docker build is required for this issue unless implementation unexpectedly ch
 - RESOLVED: pause `{}` already parses as indefinite pause in `pkg/mqtt/commands.go`.
 - RESOLVED: runner stays alive in no-cron MQTT mode through `finalizeRunnerMode`.
 - RISK: adding an HA online hook to `InitWithCleanup` touches `pkg/mqtt` tests; keep the variadic API backward-compatible.
-- RISK: latest-state cache cloning can miss a pointer field if `mqtt.StatePayload` grows; keep clone tests strict.
+- RISK: none specific to latest-state cache; keep HA discovery behaviour and subscription handling well-tested.
 - RISK: command subscription is non-fatal by design; document/log clearly so operators can diagnose missing remote control while state publishing still works.
 
 ## 13. Confidence Score
 
 9/10.
 
-The runner, parser, ack publisher, MQTT init, and most lifecycle behavior already exist and have focused tests. The remaining work is narrow. Confidence would rise further after implementation validates the exact latest-state cache shape under `go test -race ./pkg/cmd`.
+The runner, parser, ack publisher, MQTT init, and most lifecycle behavior already exist and have focused tests. The remaining work is narrow. Confidence would rise further after implementation validates pause semantics and command wiring under `go test -race ./pkg/cmd`.
 
 ## 14. Revision History
 

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
@@ -1,38 +1,141 @@
 # Feature: wire MQTT into schedule subcommand
 
 > Source issue: [#88](https://github.com/atbore-phx/sbam/issues/88)  
+> Fetched: 2026-05-13  
 > Parent issue: [#64](https://github.com/atbore-phx/sbam/issues/64)  
-> Reconciled: 2026-05-10  
+> Parent fetched: 2026-05-13  
+> Reconciled: 2026-05-13  
 > Slug: `88-issue-wire-mqtt-schedule`
 
 ## Summary
 
-Finish the schedule command MQTT integration after #87 introduces the single-goroutine runner. The codebase already has most flags, config loading, MQTT initialization, state publication, discovery publication, startup redaction, and basic docs from #85, so this issue should focus on command subscriptions, ack routing, runner hookup, and complete precedence tests.
+Finish the `schedule` command MQTT integration after #87 introduces the long-lived single-goroutine runner. The codebase already has most flags, config loading, MQTT initialization, availability/state publishing, Home Assistant discovery publishing, startup redaction, and basic documentation from #84/#85/#86, so this issue focuses on command subscriptions, parser-failure acknowledgements, runner handoff, latest-state re-publication on Home Assistant birth messages, and complete MQTT config precedence tests.
+
+## Motivation / User Story
+
+Issue #64 asks for MQTT so operators can monitor and record what sbam is doing, and control sbam from Home Assistant, Node-RED, Grafana, n8n, or similar automation tools without adding complex logic inside sbam. Issue #88 is the schedule-command wiring piece of that umbrella: once MQTT is enabled, inbound command topics should become a safe remote-control path into the same serialized runner used by cron ticks.
+
+## Reconciliation Notes
+
+- The issue body originally described broader `schedule` MQTT wiring, including flag/env/yaml registration, `mqtt.Config` construction, connection setup, availability, command subscriptions, Home Assistant status handling, and startup redaction.
+- The latest #64 and #88 comments narrow the remaining work because #84/#85/#86/#87 already delivered much of the original surface.
+- Current #88 scope is subscription plumbing: subscribe to `<mqtt_topic_prefix>/cmd/+`, parse with `pkg/mqtt.ParseIntent`, publish rejected acks immediately, submit accepted intents to the runner, and let the runner publish execution acks.
+- #87 owns runner lifecycle behavior. Its follow-up note says the runner remains active in no-cron mode when `mqtt_enabled=true`; #88 should wire MQTT command messages to `Runner.HandleCommand` or the equivalent accepted-intent path.
+- Standalone MQTT config has twelve keys, including `mqtt_ha_discovery_prefix`, so precedence coverage must cover all twelve keys.
+- `set_reserve` remains deferred to a later release and must not be exposed through MQTT in v2.0.0.
 
 ## Scope
 
-- Replace direct cron schedule callbacks with runner submissions.
+In scope:
+
 - Subscribe to `<mqtt_topic_prefix>/cmd/+` when MQTT is enabled and connected.
-- Parse commands with `pkg/mqtt.ParseIntent`.
-- Publish rejected acks for parser failures.
-- Submit accepted intents to the runner and let the runner publish execution acks.
-- Preserve `homeassistant/status=online` discovery re-publication and add latest-state re-publication when available.
-- Extend config precedence tests to all twelve standalone MQTT keys.
-- Keep disabled MQTT behavior unchanged: no broker connection, no command subscription, no extra INFO logs, no Modbus behavior changes.
+- Parse inbound command topics/payloads with `pkg/mqtt.ParseIntent`.
+- Publish rejected command acks immediately when parsing fails.
+- Submit accepted intents to the single-goroutine runner or call the runner command entry point added by #87.
+- Let the runner publish accepted/error execution acks after commands complete.
+- Ensure cron ticks submit through the runner when that is not already complete from #87.
+- Preserve `homeassistant/status=online` discovery re-publication and add latest known state re-publication when a state snapshot exists.
+- Extend `pkg/cmd` config precedence tests to all twelve standalone MQTT keys.
+- Preserve disabled MQTT behavior: no broker connection, no command subscription, no extra INFO logs, and no Modbus behavior changes.
 
 Out of scope:
 
-- Home Assistant add-on service auto-discovery (#89).
-- Full README release docs (#91).
+- Home Assistant add-on Mosquitto service auto-discovery and add-on UX cleanup (#89).
+- Full README MQTT topic/schema/command/migration documentation (#91).
 - `set_reserve` command support.
+- New MQTT client implementations or broker dependencies.
+- Changes to Solcast, Fronius Solar API, or Fronius Modbus register semantics.
+
+## Functional Requirements
+
+- When `mqtt_enabled=true` and MQTT initialization returns a connected client, subscribe to `<mqtt_topic_prefix>/cmd/+` at QoS 1.
+- Command messages must be copied out of the MQTT callback before parsing or dispatch so the callback does not retain broker-owned buffers.
+- Accepted command set is the v2.0.0 command surface from #64/#86: `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
+- Invalid topics, unknown commands, malformed JSON, oversize payloads, and out-of-range values must publish a rejected ack with the implemented #86 payload shape `{ts, command, accepted, error}` and must not reach the runner.
+- Accepted commands must be serialized through the runner so cron ticks and MQTT commands cannot race on Modbus writes.
+- `trigger_now` must run the same schedule path as a cron tick.
+- `pause`, `resume`, `force_charge`, and `set_defaults` must route through the runner command handling path added by #87.
+- `homeassistant/status=online` must re-publish discovery and the latest known state snapshot when one exists.
+- All twelve MQTT keys must continue to load through Viper with precedence `flag > env > yaml > default`.
+
+## Non-functional Requirements
+
+- Backward compatibility: default `mqtt_enabled=false` must preserve v1.x behavior, with no MQTT connection attempt and no Modbus behavior difference.
+- Safety / defaults: MQTT commands are untrusted input and must be validated before runner submission; rejected commands must not call Fronius write helpers.
+- Concurrency: all Modbus write paths must remain serialized by the runner.
+- Observability: rejected acks and publish/subscribe failures should be logged with structured zap fields without logging secrets.
+- Resource use: MQTT callbacks must remain small and non-blocking; a full runner queue should fail gracefully with an error ack or logged rejection rather than blocking the MQTT receive path.
+- Security: `mqtt_password` and `mqtt_tls_client_cert_key` must remain redacted in startup dumps.
+
+## Configuration Impact
+
+Standalone MQTT keys to cover in precedence tests:
+
+| YAML / flag | Env | Type | Default |
+| --- | --- | --- | --- |
+| `mqtt_enabled` | `MQTT_ENABLED` | bool | `false` |
+| `mqtt_broker` | `MQTT_BROKER` | string | `""` |
+| `mqtt_client_id` | `MQTT_CLIENT_ID` | string | `""` |
+| `mqtt_username` | `MQTT_USERNAME` | string | `""` |
+| `mqtt_password` | `MQTT_PASSWORD` | string | `""` |
+| `mqtt_tls_ca_file` | `MQTT_TLS_CA_FILE` | string | `""` |
+| `mqtt_tls_client_cert` | `MQTT_TLS_CLIENT_CERT` | string | `""` |
+| `mqtt_tls_client_cert_key` | `MQTT_TLS_CLIENT_CERT_KEY` | string | `""` |
+| `mqtt_tls_insecure_skip` | `MQTT_TLS_INSECURE_SKIP` | bool | `false` |
+| `mqtt_topic_prefix` | `MQTT_TOPIC_PREFIX` | string | `sbam` |
+| `mqtt_ha_discovery` | `MQTT_HA_DISCOVERY` | bool | `true` |
+| `mqtt_ha_discovery_prefix` | `MQTT_HA_DISCOVERY_PREFIX` | string | `homeassistant` |
+
+No new config keys are expected for this issue. Home Assistant add-on schema changes remain part of #89.
+
+## External Integrations Touched
+
+- Solcast: unchanged.
+- Fronius Solar API: unchanged.
+- Fronius Modbus registers: unchanged register semantics; write access remains serialized by the runner.
+- MQTT broker: subscribe to command topics and publish command acks/state/discovery through the existing `pkg/mqtt.Client` interface.
+- Home Assistant: respond to `homeassistant/status=online` by re-publishing discovery and latest state.
 
 ## Acceptance Criteria
 
 - [ ] With `mqtt_enabled=false`, schedule behavior is unchanged and no MQTT connection is attempted.
-- [ ] With MQTT enabled and a reachable broker, `schedule` connects, publishes availability, subscribes to command topics, and publishes state after ticks.
-- [ ] `cmd/trigger_now` submits an immediate tick.
+- [ ] With MQTT enabled and a reachable broker, `schedule` connects, publishes availability, subscribes to `<mqtt_topic_prefix>/cmd/+`, and publishes state after ticks.
+- [ ] `cmd/trigger_now` submits an immediate tick through the runner.
 - [ ] `cmd/pause`, `cmd/resume`, `cmd/force_charge`, and `cmd/set_defaults` route through the runner.
 - [ ] Bad command payloads publish rejected acks and do not reach the runner.
+- [ ] Accepted commands publish accepted/error acks from runner execution, not directly from the MQTT callback.
 - [ ] `homeassistant/status=online` re-publishes discovery and latest state when known.
+- [ ] `mqtt_password` and `mqtt_tls_client_cert_key` remain rendered as `***` in `DEBUG=true sbam schedule ...` startup dumps.
 - [ ] All twelve MQTT keys observe flag > env > yaml > default precedence.
 - [ ] `make test` and `make build` are green.
+
+## Test Strategy
+
+- Unit tests in `pkg/cmd` should use recording fakes or the existing noop/factory test hooks rather than a required external broker.
+- Expected case: MQTT enabled subscribes to `<prefix>/cmd/+`, accepted `trigger_now` reaches the runner, and a state snapshot is published after the tick.
+- Expected case: `pause`, `resume`, `force_charge`, and `set_defaults` route to the runner command path and produce execution acks from the runner.
+- Edge case: `homeassistant/status=online` before any state exists re-publishes discovery without publishing an empty state; after state exists it re-publishes both.
+- Edge case: disabled MQTT remains a no-connect/no-subscribe path and existing schedule lifecycle behavior remains green.
+- Failure case: malformed JSON, unknown command, invalid topic, and out-of-range payloads publish rejected acks immediately and do not reach the runner.
+- Failure case: MQTT subscribe/publish failures are logged and do not crash the `schedule` command.
+- Precedence tests in `pkg/cmd/precedence_test.go` must cover flag, env, yaml, and default sources for all twelve MQTT keys.
+- Validation commands: focused `go test ./pkg/cmd -run 'Test.*MQTT|Test.*Runner|Test.*Precedence|Test.*Schedule'`, `make test`, and `make build`.
+
+## Risks / Open Questions
+
+- Risk: the exact runner API from #87 may be `Submit`, `HandleCommand`, or both. The plan should bind to the actual code and avoid inventing a second command pathway.
+- Risk: command ack ownership must remain clear. Parser failures belong in the MQTT callback; execution success/failure belongs in the runner.
+- Risk: Paho callback goroutines must not block on a full runner queue.
+- Risk: Home Assistant birth re-publication needs a latest-state holder that does not race with runner updates.
+- No blocking open questions remain for planning; implementation should verify current #87 APIs before editing.
+
+## References
+
+- Issue #88: https://github.com/atbore-phx/sbam/issues/88
+- Parent issue #64: https://github.com/atbore-phx/sbam/issues/64
+- Parent TASK: [../64-issue-mqtt-feed/64-issue-mqtt-feed-TASK.md](../64-issue-mqtt-feed/64-issue-mqtt-feed-TASK.md)
+- Parent PLAN: [../64-issue-mqtt-feed/64-issue-mqtt-feed-PLAN.md](../64-issue-mqtt-feed/64-issue-mqtt-feed-PLAN.md)
+
+## Clarifications
+
+- 2026-05-13: User confirmed the TASK should keep the narrowed remaining scope from the latest #88 comments and asked that parent issue #64 plus its TASK and PLAN be read before PLAN generation.

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
@@ -94,7 +94,7 @@ No new config keys are expected for this issue. Home Assistant add-on schema cha
 - Fronius Solar API: unchanged.
 - Fronius Modbus registers: unchanged register semantics; write access remains serialized by the runner.
 - MQTT broker: subscribe to command topics and publish command acks/state/discovery through the existing `pkg/mqtt.Client` interface.
-- Home Assistant: respond to `homeassistant/status=online` by re-publishing discovery and latest state.
+- Home Assistant: respond to `homeassistant/status=online` by re-publishing discovery.
 
 ## Acceptance Criteria
 
@@ -104,7 +104,9 @@ No new config keys are expected for this issue. Home Assistant add-on schema cha
 - [ ] `cmd/pause`, `cmd/resume`, `cmd/force_charge`, and `cmd/set_defaults` route through the runner.
 - [ ] Bad command payloads publish rejected acks and do not reach the runner.
 - [ ] Accepted commands publish accepted/error acks from runner execution, not directly from the MQTT callback.
-- [ ] `homeassistant/status=online` re-publishes discovery and latest state when known.
+ - [ ] `homeassistant/status=online` re-publishes discovery (no latest-state cache is stored by this change).
+
+Note: Runner.Tick now checks the paused state early. When paused, a Tick will short-circuit before charge-window evaluation, forecast retrieval, and Fronius handler execution; tests must assert this behavior.
 - [ ] `mqtt_password` and `mqtt_tls_client_cert_key` remain rendered as `***` in `DEBUG=true sbam schedule ...` startup dumps.
 - [ ] All twelve MQTT keys observe flag > env > yaml > default precedence.
 - [ ] `make test` and `make build` are green.

--- a/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
+++ b/docs/implementations/88-issue-wire-mqtt-schedule/88-issue-wire-mqtt-schedule-TASK.md
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Finish the `schedule` command MQTT integration after #87 introduces the long-lived single-goroutine runner. The codebase already has most flags, config loading, MQTT initialization, availability/state publishing, Home Assistant discovery publishing, startup redaction, and basic documentation from #84/#85/#86, so this issue focuses on command subscriptions, parser-failure acknowledgements, runner handoff, latest-state re-publication on Home Assistant birth messages, and complete MQTT config precedence tests.
+Finish the `schedule` command MQTT integration after #87 introduces the long-lived single-goroutine runner. The codebase already has most flags, config loading, MQTT initialization, availability/state publishing, Home Assistant discovery publishing, startup redaction, and basic documentation from #84/#85/#86, so this issue focuses on command subscriptions, parser-failure acknowledgements, runner handoff, and complete MQTT config precedence tests.
 
 ## Motivation / User Story
 
@@ -34,7 +34,7 @@ In scope:
 - Submit accepted intents to the single-goroutine runner or call the runner command entry point added by #87.
 - Let the runner publish accepted/error execution acks after commands complete.
 - Ensure cron ticks submit through the runner when that is not already complete from #87.
-- Preserve `homeassistant/status=online` discovery re-publication and add latest known state re-publication when a state snapshot exists.
+ - Preserve `homeassistant/status=online` discovery re-publication.
 - Extend `pkg/cmd` config precedence tests to all twelve standalone MQTT keys.
 - Preserve disabled MQTT behavior: no broker connection, no command subscription, no extra INFO logs, and no Modbus behavior changes.
 
@@ -55,7 +55,7 @@ Out of scope:
 - Accepted commands must be serialized through the runner so cron ticks and MQTT commands cannot race on Modbus writes.
 - `trigger_now` must run the same schedule path as a cron tick.
 - `pause`, `resume`, `force_charge`, and `set_defaults` must route through the runner command handling path added by #87.
-- `homeassistant/status=online` must re-publish discovery and the latest known state snapshot when one exists.
+ - `homeassistant/status=online` must re-publish discovery.
 - All twelve MQTT keys must continue to load through Viper with precedence `flag > env > yaml > default`.
 
 ## Non-functional Requirements
@@ -114,7 +114,7 @@ No new config keys are expected for this issue. Home Assistant add-on schema cha
 - Unit tests in `pkg/cmd` should use recording fakes or the existing noop/factory test hooks rather than a required external broker.
 - Expected case: MQTT enabled subscribes to `<prefix>/cmd/+`, accepted `trigger_now` reaches the runner, and a state snapshot is published after the tick.
 - Expected case: `pause`, `resume`, `force_charge`, and `set_defaults` route to the runner command path and produce execution acks from the runner.
-- Edge case: `homeassistant/status=online` before any state exists re-publishes discovery without publishing an empty state; after state exists it re-publishes both.
+ - Edge case: `homeassistant/status=online` before any state exists re-publishes discovery without publishing an empty state.
 - Edge case: disabled MQTT remains a no-connect/no-subscribe path and existing schedule lifecycle behavior remains green.
 - Failure case: malformed JSON, unknown command, invalid topic, and out-of-range payloads publish rejected acks immediately and do not reach the runner.
 - Failure case: MQTT subscribe/publish failures are logged and do not crash the `schedule` command.
@@ -126,7 +126,7 @@ No new config keys are expected for this issue. Home Assistant add-on schema cha
 - Risk: the exact runner API from #87 may be `Submit`, `HandleCommand`, or both. The plan should bind to the actual code and avoid inventing a second command pathway.
 - Risk: command ack ownership must remain clear. Parser failures belong in the MQTT callback; execution success/failure belongs in the runner.
 - Risk: Paho callback goroutines must not block on a full runner queue.
-- Risk: Home Assistant birth re-publication needs a latest-state holder that does not race with runner updates.
+ - Risk: Home Assistant birth re-publication must be reliable; avoid races with runner updates if a future state cache is added.
 - No blocking open questions remain for planning; implementation should verify current #87 APIs before editing.
 
 ## References

--- a/pkg/cmd/precedence_test.go
+++ b/pkg/cmd/precedence_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -172,17 +173,117 @@ func TestBindFlags_RealScheduleCmd(t *testing.T) {
 	assert.Equal(t, "0 0 * * *", viper.GetString("crontab"))
 }
 
-func TestBindFlags_RealScheduleCmdMQTTDiscoveryPrefixPrecedence(t *testing.T) {
-	resetViper(t)
-	writeConfig(t, "mqtt_ha_discovery_prefix: from-yaml\n")
-	t.Setenv("MQTT_HA_DISCOVERY_PREFIX", "from-env")
+func TestBindFlags_RealScheduleCmdMQTTKeysPrecedence(t *testing.T) {
+	setScheduleFlag := func(t *testing.T, key, value string) {
+		t.Helper()
+		flag := scdCmd.Flags().Lookup(key)
+		require.NotNilf(t, flag, "flag %q must exist on schedule command", key)
+		require.NoError(t, scdCmd.Flags().Set(key, value))
+		t.Cleanup(func() {
+			_ = scdCmd.Flags().Set(key, flag.DefValue)
+			flag.Changed = false
+		})
+	}
 
-	require.NoError(t, scdCmd.Flags().Set("mqtt_ha_discovery_prefix", "from-flag"))
-	t.Cleanup(func() {
-		_ = scdCmd.Flags().Set("mqtt_ha_discovery_prefix", const_ha_discovery_prefix)
-		scdCmd.Flags().Lookup("mqtt_ha_discovery_prefix").Changed = false
+	t.Run("string keys", func(t *testing.T) {
+		cases := []struct {
+			key     string
+			env     string
+			def     string
+			yamlVal string
+			envVal  string
+			flagVal string
+		}{
+			{key: "mqtt_broker", env: "MQTT_BROKER", def: "", yamlVal: "yaml-broker", envVal: "env-broker", flagVal: "flag-broker"},
+			{key: "mqtt_client_id", env: "MQTT_CLIENT_ID", def: "", yamlVal: "yaml-client", envVal: "env-client", flagVal: "flag-client"},
+			{key: "mqtt_username", env: "MQTT_USERNAME", def: "", yamlVal: "yaml-user", envVal: "env-user", flagVal: "flag-user"},
+			{key: "mqtt_password", env: "MQTT_PASSWORD", def: "", yamlVal: "yaml-pass", envVal: "env-pass", flagVal: "flag-pass"},
+			{key: "mqtt_tls_ca_file", env: "MQTT_TLS_CA_FILE", def: "", yamlVal: "yaml-ca", envVal: "env-ca", flagVal: "flag-ca"},
+			{key: "mqtt_tls_client_cert", env: "MQTT_TLS_CLIENT_CERT", def: "", yamlVal: "yaml-cert", envVal: "env-cert", flagVal: "flag-cert"},
+			{key: "mqtt_tls_client_cert_key", env: "MQTT_TLS_CLIENT_CERT_KEY", def: "", yamlVal: "yaml-key", envVal: "env-key", flagVal: "flag-key"},
+			{key: "mqtt_topic_prefix", env: "MQTT_TOPIC_PREFIX", def: const_mqtt_topic_prefix, yamlVal: "yaml-prefix", envVal: "env-prefix", flagVal: "flag-prefix"},
+			{key: "mqtt_ha_discovery_prefix", env: "MQTT_HA_DISCOVERY_PREFIX", def: const_ha_discovery_prefix, yamlVal: "yaml-ha-prefix", envVal: "env-ha-prefix", flagVal: "flag-ha-prefix"},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.key+" default", func(t *testing.T) {
+				resetViper(t)
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.def, viper.GetString(tc.key))
+			})
+
+			t.Run(tc.key+" yaml", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": \""+tc.yamlVal+"\"\n")
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.yamlVal, viper.GetString(tc.key))
+			})
+
+			t.Run(tc.key+" env", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": \""+tc.yamlVal+"\"\n")
+				t.Setenv(tc.env, tc.envVal)
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.envVal, viper.GetString(tc.key))
+			})
+
+			t.Run(tc.key+" flag", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": \""+tc.yamlVal+"\"\n")
+				t.Setenv(tc.env, tc.envVal)
+				setScheduleFlag(t, tc.key, tc.flagVal)
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.flagVal, viper.GetString(tc.key))
+			})
+		}
 	})
 
-	require.NoError(t, bindFlags(scdCmd))
-	assert.Equal(t, "from-flag", viper.GetString("mqtt_ha_discovery_prefix"))
+	t.Run("bool keys", func(t *testing.T) {
+		cases := []struct {
+			key     string
+			env     string
+			def     bool
+			yamlVal bool
+			envVal  bool
+			flagVal bool
+		}{
+			{key: "mqtt_enabled", env: "MQTT_ENABLED", def: false, yamlVal: true, envVal: false, flagVal: true},
+			{key: "mqtt_tls_insecure_skip", env: "MQTT_TLS_INSECURE_SKIP", def: false, yamlVal: true, envVal: false, flagVal: true},
+			{key: "mqtt_ha_discovery", env: "MQTT_HA_DISCOVERY", def: true, yamlVal: false, envVal: true, flagVal: false},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.key+" default", func(t *testing.T) {
+				resetViper(t)
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.def, viper.GetBool(tc.key))
+			})
+
+			t.Run(tc.key+" yaml", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": "+strconv.FormatBool(tc.yamlVal)+"\n")
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.yamlVal, viper.GetBool(tc.key))
+			})
+
+			t.Run(tc.key+" env", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": "+strconv.FormatBool(tc.yamlVal)+"\n")
+				t.Setenv(tc.env, strconv.FormatBool(tc.envVal))
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.envVal, viper.GetBool(tc.key))
+			})
+
+			t.Run(tc.key+" flag", func(t *testing.T) {
+				resetViper(t)
+				writeConfig(t, tc.key+": "+strconv.FormatBool(tc.yamlVal)+"\n")
+				t.Setenv(tc.env, strconv.FormatBool(tc.envVal))
+				setScheduleFlag(t, tc.key, strconv.FormatBool(tc.flagVal))
+				require.NoError(t, bindFlags(scdCmd))
+				assert.Equal(t, tc.flagVal, viper.GetBool(tc.key))
+			})
+		}
+	})
 }

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -192,7 +192,6 @@ var scdCmd = &cobra.Command{
 				}
 				return
 			}
-			u.Log.Info("Scheduler started with crontab: " + crontab)
 		}
 
 		if err := finalizeRunnerMode(mqtt_enabled, runner, runDone, stop); err != nil {
@@ -437,7 +436,7 @@ func finalizeRunnerMode(mqttEnabled bool, runner *Runner, runDone <-chan error, 
 		return waitForRunnerDone(runDone)
 	}
 
-	u.Log.Info("MQTT integration enabled, waiting for commands...")
+	u.Log.Info("MQTT integration enabled, waiting for commands... press ctrl+c to exit...")
 	return waitForRunnerDone(runDone)
 }
 
@@ -498,7 +497,7 @@ func crontabSchedule(ctx context.Context, runner *Runner, crontab string, defaul
 		stopCtx := c.Stop()
 		<-stopCtx.Done()
 	}()
-
+	u.Log.Info("Scheduler started with crontab: " + crontab + " press ctrl+c to exit...")
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -192,6 +192,7 @@ var scdCmd = &cobra.Command{
 				}
 				return
 			}
+			u.Log.Info("Scheduler started with crontab: " + crontab)
 		}
 
 		if err := finalizeRunnerMode(mqtt_enabled, runner, runDone, stop); err != nil {

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -134,8 +134,17 @@ var scdCmd = &cobra.Command{
 			HADiscoveryPrefix: mqtt_ha_discovery_prefix,
 			FroniusIP:         fronius_ip,
 		}
+		latestState := newLatestStateCache()
 
-		mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(mqttCfg, appVersion, 3, 250*time.Millisecond)
+		mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(
+			mqttCfg,
+			appVersion,
+			3,
+			250*time.Millisecond,
+			func(ctx context.Context, client mqtt.Client) {
+				publishLatestState(ctx, client, mqttCfg, latestState)
+			},
+		)
 		defer mqttCleanup()
 		if err != nil {
 			u.HandleError(err, "mqtt homeassistant/status subscription failed")
@@ -167,6 +176,7 @@ var scdCmd = &cobra.Command{
 			CacheTime:          s_cache_time,
 			Defaults:           s_defaults,
 			MQTT:               mqttCfg,
+			LatestState:        latestState,
 			Now:                time.Now,
 		}
 
@@ -178,6 +188,10 @@ var scdCmd = &cobra.Command{
 		go func() {
 			runDone <- runner.Run(runCtx)
 		}()
+
+		if err := subscribeScheduleCommands(runCtx, mqttClient, mqttCfg, runner); err != nil {
+			u.HandleError(err, "mqtt command subscription failed")
+		}
 
 		if crontab != const_ct {
 			if err := crontabSchedule(runCtx, runner, crontab, s_defaults, end_hr); err != nil {
@@ -362,9 +376,7 @@ func checkScheduleschedule(crontab, apiKey, url, fronius_ip string, pw_consumpti
 // package tests (pkg/cmd/schedule_test.go). Tests should call the
 // wrapper or directly call `NewRunner(...).Tick(...)`.
 
-// publishStateSnapshot publishes the provided `payload` using the MQTT client
-// and stores a copy in `latestState` (if provided). The copy is used to
-// re-publish a cached snapshot when Home Assistant reconnects.
+// publishStateSnapshot publishes the provided `payload` using the MQTT client.
 func publishStateSnapshot(mqttClient mqtt.Client, mqttCfg mqtt.Config, payload mqtt.StatePayload) {
 	// Use a short-lived context so the publish operation cannot block
 	// indefinitely. This matches other MQTT operations which use
@@ -372,6 +384,58 @@ func publishStateSnapshot(mqttClient mqtt.Client, mqttCfg mqtt.Config, payload m
 	ctx, cancel := context.WithTimeout(context.Background(), const_mqtt_op_timeout)
 	defer cancel()
 	mqtt.PublishState(ctx, mqttClient, mqttCfg.TopicPrefix, payload)
+}
+
+// publishLatestState re-publishes the cached latest state snapshot, if one exists.
+func publishLatestState(ctx context.Context, mqttClient mqtt.Client, mqttCfg mqtt.Config, latestState *latestStateCache) bool {
+	if latestState == nil {
+		return false
+	}
+
+	payload, ok := latestState.Load()
+	if !ok {
+		return false
+	}
+
+	if ctx == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), const_mqtt_op_timeout)
+		defer cancel()
+	}
+
+	mqtt.PublishState(ctx, mqttClient, mqttCfg.TopicPrefix, payload)
+	return true
+}
+
+func subscribeScheduleCommands(ctx context.Context, mqttClient mqtt.Client, mqttCfg mqtt.Config, runner *Runner) error {
+	if !mqttCfg.Enabled || mqttClient == nil {
+		return nil
+	}
+	if runner == nil {
+		return errors.New("runner must not be nil")
+	}
+	if !mqttClient.IsConnected() {
+		return nil
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	commandFilter := mqtt.CommandTopicFilter(mqttCfg.TopicPrefix)
+	subCtx, cancel := context.WithTimeout(ctx, const_mqtt_op_timeout)
+	defer cancel()
+
+	if err := mqttClient.Subscribe(subCtx, commandFilter, byte(1), func(topic string, payload []byte) {
+		payloadCopy := append([]byte(nil), payload...)
+		opCtx, opCancel := context.WithTimeout(context.Background(), const_mqtt_op_timeout)
+		defer opCancel()
+		runner.HandleCommand(opCtx, topic, payloadCopy)
+	}); err != nil {
+		return fmt.Errorf("mqtt subscribe %q failed: %w", commandFilter, err)
+	}
+
+	return nil
 }
 
 // makeBasePayload builds a StatePayload with fields common to all

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -134,17 +134,7 @@ var scdCmd = &cobra.Command{
 			HADiscoveryPrefix: mqtt_ha_discovery_prefix,
 			FroniusIP:         fronius_ip,
 		}
-		latestState := newLatestStateCache()
-
-		mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(
-			mqttCfg,
-			appVersion,
-			3,
-			250*time.Millisecond,
-			func(ctx context.Context, client mqtt.Client) {
-				publishLatestState(ctx, client, mqttCfg, latestState)
-			},
-		)
+		mqttClient, mqttCleanup, err := mqtt.InitWithCleanup(mqttCfg, appVersion, 3, 250*time.Millisecond)
 		defer mqttCleanup()
 		if err != nil {
 			u.HandleError(err, "mqtt homeassistant/status subscription failed")
@@ -176,7 +166,6 @@ var scdCmd = &cobra.Command{
 			CacheTime:          s_cache_time,
 			Defaults:           s_defaults,
 			MQTT:               mqttCfg,
-			LatestState:        latestState,
 			Now:                time.Now,
 		}
 
@@ -387,25 +376,7 @@ func publishStateSnapshot(mqttClient mqtt.Client, mqttCfg mqtt.Config, payload m
 }
 
 // publishLatestState re-publishes the cached latest state snapshot, if one exists.
-func publishLatestState(ctx context.Context, mqttClient mqtt.Client, mqttCfg mqtt.Config, latestState *latestStateCache) bool {
-	if latestState == nil {
-		return false
-	}
-
-	payload, ok := latestState.Load()
-	if !ok {
-		return false
-	}
-
-	if ctx == nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), const_mqtt_op_timeout)
-		defer cancel()
-	}
-
-	mqtt.PublishState(ctx, mqttClient, mqttCfg.TopicPrefix, payload)
-	return true
-}
+// latest-state republish was removed; discovery publish remains in mqtt.InitWithCleanup
 
 func subscribeScheduleCommands(ctx context.Context, mqttClient mqtt.Client, mqttCfg mqtt.Config, runner *Runner) error {
 	if !mqttCfg.Enabled || mqttClient == nil {

--- a/pkg/cmd/schedule_mqtt_wiring_test.go
+++ b/pkg/cmd/schedule_mqtt_wiring_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"sbam/pkg/mqtt"
 
@@ -131,59 +130,4 @@ func TestSubscribeScheduleCommands_RequiresRunner(t *testing.T) {
 	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "runner must not be nil")
-}
-
-func TestPublishLatestState_NoSnapshot(t *testing.T) {
-	client := &recordingMQTTClient{connected: true}
-	latest := newLatestStateCache()
-
-	published := publishLatestState(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, latest)
-	assert.False(t, published)
-	assert.Empty(t, client.publishedTopics)
-}
-
-func TestPublishLatestState_PublishesCachedSnapshotCopy(t *testing.T) {
-	client := &recordingMQTTClient{connected: true}
-	latest := newLatestStateCache()
-
-	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
-	soc := 42.0
-	capacity := 10000.0
-	next := now.Add(30 * time.Minute)
-	payload := mqtt.StatePayload{
-		BatterySOCPct:      &soc,
-		BatteryCapacityWh:  &capacity,
-		LastDecision:       "idle",
-		LastDecisionReason: "cached",
-		NextRun:            &next,
-		Timestamp:          now,
-	}
-
-	runner := NewRunner(RunnerConfig{
-		StartHR:            "00:00",
-		EndHR:              "23:59",
-		BattReserveStartHR: "00:00",
-		BattReserveEndHR:   "23:59",
-		MQTT:               mqtt.Config{Enabled: true, TopicPrefix: "sbam"},
-		LatestState:        latest,
-		Now:                func() time.Time { return now },
-	}, client)
-
-	runner.publishState(payload)
-
-	soc = 88.0
-	capacity = 5000.0
-	next = now.Add(2 * time.Hour)
-
-	published := publishLatestState(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, latest)
-	require.True(t, published)
-	require.GreaterOrEqual(t, len(client.publishedBodies), 2)
-
-	republished := decodeStatePayload(t, client.publishedBodies[len(client.publishedBodies)-1])
-	require.NotNil(t, republished.BatterySOCPct)
-	require.NotNil(t, republished.BatteryCapacityWh)
-	require.NotNil(t, republished.NextRun)
-	assert.Equal(t, 42.0, *republished.BatterySOCPct)
-	assert.Equal(t, 10000.0, *republished.BatteryCapacityWh)
-	assert.Equal(t, now.Add(30*time.Minute), republished.NextRun.UTC())
 }

--- a/pkg/cmd/schedule_mqtt_wiring_test.go
+++ b/pkg/cmd/schedule_mqtt_wiring_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"sbam/pkg/mqtt"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingMQTTClient struct {
+	connected       bool
+	subscribeErr    error
+	subscribeCalls  int
+	subscribeTopic  string
+	subscribeHdlr   mqtt.MessageHandler
+	publishedTopics []string
+	publishedBodies [][]byte
+}
+
+func (c *recordingMQTTClient) Connect(context.Context) error { return nil }
+
+func (c *recordingMQTTClient) Disconnect(context.Context) error { return nil }
+
+func (c *recordingMQTTClient) Publish(ctx context.Context, topic string, qos byte, retained bool, payload []byte) error {
+	_ = ctx
+	_ = qos
+	_ = retained
+	c.publishedTopics = append(c.publishedTopics, topic)
+	c.publishedBodies = append(c.publishedBodies, append([]byte(nil), payload...))
+	return nil
+}
+
+func (c *recordingMQTTClient) Subscribe(ctx context.Context, topic string, qos byte, handler mqtt.MessageHandler) error {
+	_ = ctx
+	_ = qos
+	c.subscribeCalls++
+	c.subscribeTopic = topic
+	c.subscribeHdlr = handler
+	return c.subscribeErr
+}
+
+func (c *recordingMQTTClient) IsConnected() bool {
+	return c.connected
+}
+
+func TestSubscribeScheduleCommands_DefaultPrefixRoutesTriggerNow(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	runner := newRunnerForTests(client)
+
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: " "}, runner)
+	require.NoError(t, err)
+	require.Equal(t, 1, client.subscribeCalls)
+	assert.Equal(t, "sbam/cmd/+", client.subscribeTopic)
+	require.NotNil(t, client.subscribeHdlr)
+
+	client.subscribeHdlr("sbam/cmd/trigger_now", nil)
+	select {
+	case intent := <-runner.intents:
+		assert.Equal(t, mqtt.IntentTriggerNow, intent.Kind)
+		assert.Equal(t, "sbam/cmd/trigger_now", intent.CommandTopic)
+	default:
+		t.Fatal("expected trigger_now intent to be enqueued")
+	}
+}
+
+func TestSubscribeScheduleCommands_CustomPrefix(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	runner := newRunnerForTests(client)
+
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "house/sbam"}, runner)
+	require.NoError(t, err)
+	assert.Equal(t, "house/sbam/cmd/+", client.subscribeTopic)
+}
+
+func TestSubscribeScheduleCommands_ParseFailurePublishesRejectedAck(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	runner := newRunnerForTests(client)
+
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, runner)
+	require.NoError(t, err)
+	require.NotNil(t, client.subscribeHdlr)
+
+	client.subscribeHdlr("sbam/cmd/force_charge", []byte(`{"target_pct":"bad"}`))
+
+	select {
+	case <-runner.intents:
+		t.Fatal("invalid payload must not enqueue intents")
+	default:
+	}
+
+	require.NotEmpty(t, client.publishedTopics)
+	ackTopic := client.publishedTopics[len(client.publishedTopics)-1]
+	ackBody := client.publishedBodies[len(client.publishedBodies)-1]
+	assert.Equal(t, "sbam/cmd/force_charge/ack", ackTopic)
+	ack := decodeAckPayload(t, ackBody)
+	assert.False(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+	assert.Contains(t, ack.Error, mqtt.ErrInvalidPayload.Error())
+}
+
+func TestSubscribeScheduleCommands_SubscribeError(t *testing.T) {
+	client := &recordingMQTTClient{connected: true, subscribeErr: errors.New("subscribe failed")}
+	runner := newRunnerForTests(client)
+
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, runner)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "subscribe failed")
+}
+
+func TestSubscribeScheduleCommands_SkipsWhenDisabledOrDisconnected(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	runner := newRunnerForTests(client)
+
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: false, TopicPrefix: "sbam"}, runner)
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.subscribeCalls)
+
+	client.connected = false
+	err = subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, runner)
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.subscribeCalls)
+}
+
+func TestSubscribeScheduleCommands_RequiresRunner(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	err := subscribeScheduleCommands(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "runner must not be nil")
+}
+
+func TestPublishLatestState_NoSnapshot(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	latest := newLatestStateCache()
+
+	published := publishLatestState(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, latest)
+	assert.False(t, published)
+	assert.Empty(t, client.publishedTopics)
+}
+
+func TestPublishLatestState_PublishesCachedSnapshotCopy(t *testing.T) {
+	client := &recordingMQTTClient{connected: true}
+	latest := newLatestStateCache()
+
+	now := time.Date(2026, time.May, 14, 12, 0, 0, 0, time.UTC)
+	soc := 42.0
+	capacity := 10000.0
+	next := now.Add(30 * time.Minute)
+	payload := mqtt.StatePayload{
+		BatterySOCPct:      &soc,
+		BatteryCapacityWh:  &capacity,
+		LastDecision:       "idle",
+		LastDecisionReason: "cached",
+		NextRun:            &next,
+		Timestamp:          now,
+	}
+
+	runner := NewRunner(RunnerConfig{
+		StartHR:            "00:00",
+		EndHR:              "23:59",
+		BattReserveStartHR: "00:00",
+		BattReserveEndHR:   "23:59",
+		MQTT:               mqtt.Config{Enabled: true, TopicPrefix: "sbam"},
+		LatestState:        latest,
+		Now:                func() time.Time { return now },
+	}, client)
+
+	runner.publishState(payload)
+
+	soc = 88.0
+	capacity = 5000.0
+	next = now.Add(2 * time.Hour)
+
+	published := publishLatestState(context.Background(), client, mqtt.Config{Enabled: true, TopicPrefix: "sbam"}, latest)
+	require.True(t, published)
+	require.GreaterOrEqual(t, len(client.publishedBodies), 2)
+
+	republished := decodeStatePayload(t, client.publishedBodies[len(client.publishedBodies)-1])
+	require.NotNil(t, republished.BatterySOCPct)
+	require.NotNil(t, republished.BatteryCapacityWh)
+	require.NotNil(t, republished.NextRun)
+	assert.Equal(t, 42.0, *republished.BatterySOCPct)
+	assert.Equal(t, 10000.0, *republished.BatteryCapacityWh)
+	assert.Equal(t, now.Add(30*time.Minute), republished.NextRun.UTC())
+}

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -169,7 +169,16 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		return storageErr
 	}
 
-	paused, pauseUntil := r.pauseStateAt(now)
+	if paused, pauseUntil := r.pauseStateAt(now); paused {
+		payload := makeBasePayload("paused", "Forecast Charging execution skipped because sbam is paused", inChargeWindow, reserveWindowActive)
+		payload.BatterySOCPct = &socPct
+		payload.BatteryCapacityWh = &capacityMax
+		payload.Paused = true
+		payload.NextRun = pauseUntil
+		r.publishState(payload)
+		return nil
+	}
+
 	if !inChargeWindow {
 		u.Log.Info("The current time is outside the range defined by start_hr and end_hr.: " + r.cfg.StartHR + " <= t <= " + r.cfg.EndHR)
 		capMax := capacityMax
@@ -177,8 +186,6 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		payload := makeBasePayload(fronius.DecisionIdle.String(), "current time outside configured charging window", inChargeWindow, reserveWindowActive)
 		payload.BatterySOCPct = &socPct
 		payload.BatteryCapacityWh = &capMax
-		payload.Paused = paused
-		payload.NextRun = pauseUntil
 		r.publishState(payload)
 		return nil
 	}
@@ -190,17 +197,6 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		r.publishError(ctx, "power", forecastErr)
 		solarPowerProduction = 0.0
 		forecastRetrieved = false
-	}
-
-	if paused {
-		payload := makeBasePayload("paused", "schedule execution skipped because runner is paused", inChargeWindow, reserveWindowActive)
-		payload.BatterySOCPct = &socPct
-		payload.BatteryCapacityWh = &capacityMax
-		payload.ForecastTodayWh = &solarPowerProduction
-		payload.Paused = true
-		payload.NextRun = pauseUntil
-		r.publishState(payload)
-		return nil
 	}
 
 	u.Log.Infof("your Daily consumption is:%d Wh", int(r.cfg.PWConsumption))

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -8,6 +8,7 @@ import (
 	"sbam/pkg/mqtt"
 	u "sbam/src/utils"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -41,6 +42,7 @@ type RunnerConfig struct {
 	CacheTime          int32
 	Defaults           bool
 	MQTT               mqtt.Config
+	LatestState        *latestStateCache
 	Now                func() time.Time
 }
 
@@ -63,6 +65,85 @@ var newBatteryWriter = func() batteryWriter {
 	return froniusBatteryWriter{}
 }
 
+type latestStateCache struct {
+	mu      sync.RWMutex
+	payload *mqtt.StatePayload
+}
+
+func newLatestStateCache() *latestStateCache {
+	return &latestStateCache{}
+}
+
+func cloneFloat64Ptr(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	copyV := *v
+	return &copyV
+}
+
+func cloneInt16Ptr(v *int16) *int16 {
+	if v == nil {
+		return nil
+	}
+	copyV := *v
+	return &copyV
+}
+
+func cloneBoolPtr(v *bool) *bool {
+	if v == nil {
+		return nil
+	}
+	copyV := *v
+	return &copyV
+}
+
+func cloneTimePtr(v *time.Time) *time.Time {
+	if v == nil {
+		return nil
+	}
+	copyV := v.UTC()
+	return &copyV
+}
+
+func cloneStatePayload(payload mqtt.StatePayload) mqtt.StatePayload {
+	cloned := payload
+	cloned.BatterySOCPct = cloneFloat64Ptr(payload.BatterySOCPct)
+	cloned.BatteryCapacityWh = cloneFloat64Ptr(payload.BatteryCapacityWh)
+	cloned.ForecastTodayWh = cloneFloat64Ptr(payload.ForecastTodayWh)
+	cloned.PwNetWh = cloneFloat64Ptr(payload.PwNetWh)
+	cloned.ChargePct = cloneInt16Ptr(payload.ChargePct)
+	cloned.ChargeWindowActive = cloneBoolPtr(payload.ChargeWindowActive)
+	cloned.ReserveWindowActive = cloneBoolPtr(payload.ReserveWindowActive)
+	cloned.NextRun = cloneTimePtr(payload.NextRun)
+	return cloned
+}
+
+func (c *latestStateCache) Store(payload mqtt.StatePayload) {
+	if c == nil {
+		return
+	}
+	cloned := cloneStatePayload(payload)
+
+	c.mu.Lock()
+	c.payload = &cloned
+	c.mu.Unlock()
+}
+
+func (c *latestStateCache) Load() (mqtt.StatePayload, bool) {
+	if c == nil {
+		return mqtt.StatePayload{}, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.payload == nil {
+		return mqtt.StatePayload{}, false
+	}
+
+	return cloneStatePayload(*c.payload), true
+}
+
 // Runner owns serialized schedule and command execution.
 // Single-writer invariant: all Fronius Modbus write operations must be executed by this runner.
 type Runner struct {
@@ -76,6 +157,9 @@ type Runner struct {
 func NewRunner(cfg RunnerConfig, client mqtt.Client) *Runner {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
+	}
+	if cfg.LatestState == nil {
+		cfg.LatestState = newLatestStateCache()
 	}
 
 	return &Runner{
@@ -357,6 +441,9 @@ func (r *Runner) newCommandPayload(lastDecision, reason string, now time.Time) m
 }
 
 func (r *Runner) publishState(payload mqtt.StatePayload) {
+	if r.cfg.LatestState != nil {
+		r.cfg.LatestState.Store(payload)
+	}
 	publishStateSnapshot(r.client, r.cfg.MQTT, payload)
 }
 

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -8,7 +8,6 @@ import (
 	"sbam/pkg/mqtt"
 	u "sbam/src/utils"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -42,7 +41,6 @@ type RunnerConfig struct {
 	CacheTime          int32
 	Defaults           bool
 	MQTT               mqtt.Config
-	LatestState        *latestStateCache
 	Now                func() time.Time
 }
 
@@ -65,84 +63,7 @@ var newBatteryWriter = func() batteryWriter {
 	return froniusBatteryWriter{}
 }
 
-type latestStateCache struct {
-	mu      sync.RWMutex
-	payload *mqtt.StatePayload
-}
-
-func newLatestStateCache() *latestStateCache {
-	return &latestStateCache{}
-}
-
-func cloneFloat64Ptr(v *float64) *float64 {
-	if v == nil {
-		return nil
-	}
-	copyV := *v
-	return &copyV
-}
-
-func cloneInt16Ptr(v *int16) *int16 {
-	if v == nil {
-		return nil
-	}
-	copyV := *v
-	return &copyV
-}
-
-func cloneBoolPtr(v *bool) *bool {
-	if v == nil {
-		return nil
-	}
-	copyV := *v
-	return &copyV
-}
-
-func cloneTimePtr(v *time.Time) *time.Time {
-	if v == nil {
-		return nil
-	}
-	copyV := v.UTC()
-	return &copyV
-}
-
-func cloneStatePayload(payload mqtt.StatePayload) mqtt.StatePayload {
-	cloned := payload
-	cloned.BatterySOCPct = cloneFloat64Ptr(payload.BatterySOCPct)
-	cloned.BatteryCapacityWh = cloneFloat64Ptr(payload.BatteryCapacityWh)
-	cloned.ForecastTodayWh = cloneFloat64Ptr(payload.ForecastTodayWh)
-	cloned.PwNetWh = cloneFloat64Ptr(payload.PwNetWh)
-	cloned.ChargePct = cloneInt16Ptr(payload.ChargePct)
-	cloned.ChargeWindowActive = cloneBoolPtr(payload.ChargeWindowActive)
-	cloned.ReserveWindowActive = cloneBoolPtr(payload.ReserveWindowActive)
-	cloned.NextRun = cloneTimePtr(payload.NextRun)
-	return cloned
-}
-
-func (c *latestStateCache) Store(payload mqtt.StatePayload) {
-	if c == nil {
-		return
-	}
-	cloned := cloneStatePayload(payload)
-
-	c.mu.Lock()
-	c.payload = &cloned
-	c.mu.Unlock()
-}
-
-func (c *latestStateCache) Load() (mqtt.StatePayload, bool) {
-	if c == nil {
-		return mqtt.StatePayload{}, false
-	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.payload == nil {
-		return mqtt.StatePayload{}, false
-	}
-
-	return cloneStatePayload(*c.payload), true
-}
+// latest state caching was removed; the runner publishes state directly.
 
 // Runner owns serialized schedule and command execution.
 // Single-writer invariant: all Fronius Modbus write operations must be executed by this runner.
@@ -157,9 +78,6 @@ type Runner struct {
 func NewRunner(cfg RunnerConfig, client mqtt.Client) *Runner {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
-	}
-	if cfg.LatestState == nil {
-		cfg.LatestState = newLatestStateCache()
 	}
 
 	return &Runner{
@@ -441,9 +359,6 @@ func (r *Runner) newCommandPayload(lastDecision, reason string, now time.Time) m
 }
 
 func (r *Runner) publishState(payload mqtt.StatePayload) {
-	if r.cfg.LatestState != nil {
-		r.cfg.LatestState.Store(payload)
-	}
 	publishStateSnapshot(r.client, r.cfg.MQTT, payload)
 }
 

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"sbam/pkg/fronius"
 	"sbam/pkg/mqtt"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,15 @@ type fakeBatteryWriter struct {
 	lastTargetPct    int16
 	forceChargeErr   error
 	setDefaultsErr   error
+}
+
+// stubFroniusClient is a test helper that implements the froniusClient
+// interface and records the number of Handler calls.
+type stubFroniusClient struct{ calls int }
+
+func (s *stubFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, string, fronius.PowerState, error) {
+	s.calls++
+	return 0, fronius.DecisionIdle, "stub", fronius.PowerState{}, nil
 }
 
 func (f *fakeBatteryWriter) ForceCharge(froniusIP string, targetPct int16) error {
@@ -299,4 +309,40 @@ func TestRunner_HandleCommandUnknownTopicRejected(t *testing.T) {
 	assert.False(t, ack.Accepted)
 	assert.Equal(t, "not_known", ack.Command)
 	assert.Equal(t, mqtt.ErrUnknownCommand.Error(), ack.Error)
+}
+
+func TestRunner_TickSkipsForecastAndChargeWhenPaused(t *testing.T) {
+	client := newFakeClient()
+
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	fakePower := &fakePowerClient{forecastWh: 9999, retrieved: true}
+	oldPowerFactory := newPower
+	newPower = func() powerClient { return fakePower }
+	defer func() { newPower = oldPowerFactory }()
+
+	stub := &stubFroniusClient{}
+	oldFroniusFactory := newFronius
+	newFronius = func() froniusClient { return stub }
+	defer func() { newFronius = oldFroniusFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.setPause(nil) // indefinite pause
+
+	require.NoError(t, runner.Tick(context.Background(), runner.now()))
+
+	// storage should be called, but power and fronius should not be called
+	assert.Equal(t, 1, fakeStorage.calls)
+	assert.Equal(t, 0, fakePower.calls)
+	assert.Equal(t, 0, stub.calls)
+
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok)
+	state := decodeStatePayload(t, stateMsg.payload)
+	assert.True(t, state.Paused)
+	assert.Equal(t, "paused", state.LastDecision)
 }

--- a/pkg/mqtt/client.go
+++ b/pkg/mqtt/client.go
@@ -61,6 +61,10 @@ func availabilityTopic(prefix string) string {
 	return normalizePrefix(prefix) + "/availability"
 }
 
+func CommandTopicFilter(prefix string) string {
+	return normalizePrefix(prefix) + "/cmd/+"
+}
+
 func normalizeDiscoveryPrefix(prefix string) string {
 	trimmed := strings.Trim(strings.TrimSpace(prefix), "/")
 	if trimmed == "" {

--- a/pkg/mqtt/init.go
+++ b/pkg/mqtt/init.go
@@ -18,20 +18,6 @@ var (
 	newNoopFactory   = func() Client { return NewNoop() }
 )
 
-// HAOnlineHandler is invoked when a connected client receives
-// homeassistant/status = online.
-type HAOnlineHandler func(ctx context.Context, client Client)
-
-func hasHAOnlineHandlers(handlers []HAOnlineHandler) bool {
-	for _, handler := range handlers {
-		if handler != nil {
-			return true
-		}
-	}
-
-	return false
-}
-
 // connectWithRetries performs a small number of Connect attempts with
 // exponential backoff and returns the last error if all attempts fail.
 // It uses a short per-attempt timeout governed by defaultOpTimeout.
@@ -67,7 +53,7 @@ func connectWithRetries(client Client, maxAttempts int, baseBackoff time.Duratio
 // disconnect. On Home Assistant discovery it subscribes to the status
 // topic and publishes discovery when HA comes online. Optional handlers
 // are invoked after discovery publish in the same callback.
-func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration, haOnlineHandlers ...HAOnlineHandler) (Client, func(), error) {
+func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration) (Client, func(), error) {
 	client, newErr := newClientFactory(cfg, version)
 	var accErr error
 	if newErr != nil {
@@ -81,7 +67,7 @@ func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff ti
 			accErr = errors.Join(accErr, fmt.Errorf("mqtt connect failed after retries: %w", connErr))
 			u.Log.Warnw("mqtt connect failed after retries, using noop", "error", connErr)
 			client = newNoopFactory()
-		} else if client.IsConnected() && (cfg.HADiscovery || hasHAOnlineHandlers(haOnlineHandlers)) {
+		} else if client.IsConnected() && cfg.HADiscovery {
 			subCtx, subCancel := context.WithTimeout(context.Background(), defaultOpTimeout)
 			subErr := client.Subscribe(subCtx, haStatusTopic(), byte(1), func(topic string, payload []byte) {
 				_ = topic
@@ -92,11 +78,6 @@ func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff ti
 
 				ctx, cancel := context.WithTimeout(context.Background(), defaultOpTimeout)
 				PublishDiscovery(ctx, client, cfg, version)
-				for _, handler := range haOnlineHandlers {
-					if handler != nil {
-						handler(ctx, client)
-					}
-				}
 				cancel()
 			})
 			subCancel()

--- a/pkg/mqtt/init.go
+++ b/pkg/mqtt/init.go
@@ -18,6 +18,20 @@ var (
 	newNoopFactory   = func() Client { return NewNoop() }
 )
 
+// HAOnlineHandler is invoked when a connected client receives
+// homeassistant/status = online.
+type HAOnlineHandler func(ctx context.Context, client Client)
+
+func hasHAOnlineHandlers(handlers []HAOnlineHandler) bool {
+	for _, handler := range handlers {
+		if handler != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // connectWithRetries performs a small number of Connect attempts with
 // exponential backoff and returns the last error if all attempts fail.
 // It uses a short per-attempt timeout governed by defaultOpTimeout.
@@ -51,8 +65,9 @@ func connectWithRetries(client Client, maxAttempts int, baseBackoff time.Duratio
 // InitWithCleanup encapsulates client creation, initial connect (with
 // retries) and returns a cleanup function that attempts a graceful
 // disconnect. On Home Assistant discovery it subscribes to the status
-// topic and publishes discovery when HA comes online.
-func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration) (Client, func(), error) {
+// topic and publishes discovery when HA comes online. Optional handlers
+// are invoked after discovery publish in the same callback.
+func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff time.Duration, haOnlineHandlers ...HAOnlineHandler) (Client, func(), error) {
 	client, newErr := newClientFactory(cfg, version)
 	var accErr error
 	if newErr != nil {
@@ -66,15 +81,22 @@ func InitWithCleanup(cfg Config, version string, maxAttempts int, baseBackoff ti
 			accErr = errors.Join(accErr, fmt.Errorf("mqtt connect failed after retries: %w", connErr))
 			u.Log.Warnw("mqtt connect failed after retries, using noop", "error", connErr)
 			client = newNoopFactory()
-		} else if cfg.HADiscovery && client.IsConnected() {
+		} else if client.IsConnected() && (cfg.HADiscovery || hasHAOnlineHandlers(haOnlineHandlers)) {
 			subCtx, subCancel := context.WithTimeout(context.Background(), defaultOpTimeout)
 			subErr := client.Subscribe(subCtx, haStatusTopic(), byte(1), func(topic string, payload []byte) {
-				if strings.TrimSpace(string(payload)) != "online" {
+				_ = topic
+				payloadCopy := append([]byte(nil), payload...)
+				if strings.TrimSpace(string(payloadCopy)) != "online" {
 					return
 				}
 
 				ctx, cancel := context.WithTimeout(context.Background(), defaultOpTimeout)
 				PublishDiscovery(ctx, client, cfg, version)
+				for _, handler := range haOnlineHandlers {
+					if handler != nil {
+						handler(ctx, client)
+					}
+				}
 				cancel()
 			})
 			subCancel()

--- a/pkg/mqtt/init_test.go
+++ b/pkg/mqtt/init_test.go
@@ -271,3 +271,21 @@ func TestInitWithCleanupOnlineHandlerSubscribesWhenDiscoveryDisabled(t *testing.
 	assert.Equal(t, 1, handlerCalls)
 	assert.Equal(t, 0, client.publishCalls, "discovery publish stays disabled when HADiscovery=false")
 }
+
+func TestInitWithCleanupNoHandlersNoDiscoveryDoesNotSubscribe(t *testing.T) {
+	client := &fakeInitClient{connectErrs: []error{nil}}
+	withInitFactories(
+		t,
+		func(_ Config, _ ...string) (Client, error) {
+			return client, nil
+		},
+		nil,
+	)
+
+	cfg := Config{Enabled: true, HADiscovery: false}
+	_, cleanup, err := InitWithCleanup(cfg, "dev", 1, 0)
+	defer cleanup()
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, client.subscribeCalls, "should not subscribe when no handlers and discovery disabled")
+}

--- a/pkg/mqtt/init_test.go
+++ b/pkg/mqtt/init_test.go
@@ -206,3 +206,68 @@ func TestInitWithCleanupHADiscoveryPublishesOnOnline(t *testing.T) {
 	}
 	assert.True(t, foundConfigTopic)
 }
+
+func TestInitWithCleanupOnlineHandlerInvokedOnOnlineOnly(t *testing.T) {
+	client := &fakeInitClient{connectErrs: []error{nil}}
+	withInitFactories(
+		t,
+		func(_ Config, _ ...string) (Client, error) {
+			return client, nil
+		},
+		nil,
+	)
+
+	cfg := Config{
+		Enabled:           true,
+		HADiscovery:       true,
+		HADiscoveryPrefix: "homeassistant",
+		TopicPrefix:       "sbam",
+		FroniusIP:         "127.0.0.1",
+	}
+
+	handlerCalls := 0
+	_, cleanup, err := InitWithCleanup(cfg, "dev", 1, 0,
+		func(ctx context.Context, c Client) {
+			handlerCalls++
+			require.NotNil(t, ctx)
+			assert.Same(t, client, c)
+		},
+		nil,
+	)
+	defer cleanup()
+
+	require.NoError(t, err)
+	require.NotNil(t, client.subscribeHdlr)
+
+	client.subscribeHdlr(haStatusTopic(), []byte("offline"))
+	client.subscribeHdlr(haStatusTopic(), []byte(" online "))
+
+	assert.Equal(t, 1, handlerCalls)
+}
+
+func TestInitWithCleanupOnlineHandlerSubscribesWhenDiscoveryDisabled(t *testing.T) {
+	client := &fakeInitClient{connectErrs: []error{nil}}
+	withInitFactories(
+		t,
+		func(_ Config, _ ...string) (Client, error) {
+			return client, nil
+		},
+		nil,
+	)
+
+	cfg := Config{Enabled: true, HADiscovery: false}
+	handlerCalls := 0
+	_, cleanup, err := InitWithCleanup(cfg, "dev", 1, 0, func(context.Context, Client) {
+		handlerCalls++
+	})
+	defer cleanup()
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.subscribeCalls)
+	assert.Equal(t, haStatusTopic(), client.subscribeTopic)
+	require.NotNil(t, client.subscribeHdlr)
+
+	client.subscribeHdlr(haStatusTopic(), []byte("online"))
+	assert.Equal(t, 1, handlerCalls)
+	assert.Equal(t, 0, client.publishCalls, "discovery publish stays disabled when HADiscovery=false")
+}

--- a/pkg/mqtt/init_test.go
+++ b/pkg/mqtt/init_test.go
@@ -217,60 +217,13 @@ func TestInitWithCleanupOnlineHandlerInvokedOnOnlineOnly(t *testing.T) {
 		nil,
 	)
 
-	cfg := Config{
-		Enabled:           true,
-		HADiscovery:       true,
-		HADiscoveryPrefix: "homeassistant",
-		TopicPrefix:       "sbam",
-		FroniusIP:         "127.0.0.1",
-	}
-
-	handlerCalls := 0
-	_, cleanup, err := InitWithCleanup(cfg, "dev", 1, 0,
-		func(ctx context.Context, c Client) {
-			handlerCalls++
-			require.NotNil(t, ctx)
-			assert.Same(t, client, c)
-		},
-		nil,
-	)
-	defer cleanup()
-
-	require.NoError(t, err)
-	require.NotNil(t, client.subscribeHdlr)
-
-	client.subscribeHdlr(haStatusTopic(), []byte("offline"))
-	client.subscribeHdlr(haStatusTopic(), []byte(" online "))
-
-	assert.Equal(t, 1, handlerCalls)
+	// handler registration support removed; discovery publish is covered
+	// by TestInitWithCleanupHADiscoveryPublishesOnOnline.
 }
 
-func TestInitWithCleanupOnlineHandlerSubscribesWhenDiscoveryDisabled(t *testing.T) {
-	client := &fakeInitClient{connectErrs: []error{nil}}
-	withInitFactories(
-		t,
-		func(_ Config, _ ...string) (Client, error) {
-			return client, nil
-		},
-		nil,
-	)
-
-	cfg := Config{Enabled: true, HADiscovery: false}
-	handlerCalls := 0
-	_, cleanup, err := InitWithCleanup(cfg, "dev", 1, 0, func(context.Context, Client) {
-		handlerCalls++
-	})
-	defer cleanup()
-
-	require.NoError(t, err)
-	assert.Equal(t, 1, client.subscribeCalls)
-	assert.Equal(t, haStatusTopic(), client.subscribeTopic)
-	require.NotNil(t, client.subscribeHdlr)
-
-	client.subscribeHdlr(haStatusTopic(), []byte("online"))
-	assert.Equal(t, 1, handlerCalls)
-	assert.Equal(t, 0, client.publishCalls, "discovery publish stays disabled when HADiscovery=false")
-}
+// handler-based registration removed; subscription behavior is covered
+// by TestInitWithCleanupHADiscoveryPublishesOnOnline and
+// TestInitWithCleanupSubscribeErrorIsReturned.
 
 func TestInitWithCleanupNoHandlersNoDiscoveryDoesNotSubscribe(t *testing.T) {
 	client := &fakeInitClient{connectErrs: []error{nil}}

--- a/pkg/mqtt/mqtt_test.go
+++ b/pkg/mqtt/mqtt_test.go
@@ -81,6 +81,8 @@ func TestNormalizePrefix(t *testing.T) {
 	assert.Equal(t, defaultTopicPrefix+"/state", stateTopic(" /// "))
 	assert.Equal(t, "custom/error", errorTopic(" /custom/ "))
 	assert.Equal(t, "custom/availability", availabilityTopic(" /custom/ "))
+	assert.Equal(t, defaultTopicPrefix+"/cmd/+", CommandTopicFilter(" /// "))
+	assert.Equal(t, "custom/cmd/+", CommandTopicFilter(" /custom/ "))
 }
 
 func TestPublishStateRoundTrip(t *testing.T) {


### PR DESCRIPTION
Closes #88

This PR wires MQTT command subscription into the `schedule` runner and adds related tests and precedence coverage. The previously-introduced "latest-state" cache and HA-online republish were removed per upstream request; discovery republishing remains handled by `mqtt.InitWithCleanup`.

Related: #64

Validation: ran `go test ./...` and `make build` locally; tests passed and binary built to `bin/sbam`.
