### PR TITLE
fix(schedule): evaluate cron windows using local wall-clock

### DIFF
--- a/docs/implementations/115-issue-fix-crontab-timezone-window/115-issue-fix-crontab-timezone-window-PLAN.md
+++ b/docs/implementations/115-issue-fix-crontab-timezone-window/115-issue-fix-crontab-timezone-window-PLAN.md
@@ -1,0 +1,258 @@
+# Plan: Fix Crontab Timezone Window Evaluation
+
+Date: 2026-05-16
+
+Task: [115-issue-fix-crontab-timezone-window-TASK.md](./115-issue-fix-crontab-timezone-window-TASK.md)
+
+Issue: https://github.com/atbore-phx/sbam/issues/115
+
+## 1. Task Analysis
+
+Goal: fix a `release/v2.0.0` regression where schedule ticks inside the intended local charge window can be evaluated as outside the window because runner time is normalized to UTC before window checks.
+
+Acceptance criteria from the TASK:
+
+- A local `00:00` CET/CEST tick is inside a `00:00`-`06:00` charging window.
+- A local `01:00` CET/CEST tick is inside the same charging window.
+- Local ticks after the configured end time, such as `07:00` and `08:00`, are outside the charging window.
+- Reserve-window checks use the same corrected timezone semantics.
+- Existing UTC-based behavior and invalid-time errors continue to pass.
+- A regression unit test prevents the UTC/local mismatch from returning.
+
+Non-goals:
+
+- Do not add a timezone config key.
+- Do not alter cron expression parsing semantics.
+- Do not implement cross-midnight window support in this issue.
+- Do not change Solcast, Fronius Solar API, Modbus register, MQTT topic, or payload schemas.
+
+## 2. Current State
+
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) builds `RunnerConfig` with `Now: time.Now` and uses robfig cron via `cron.New()`.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) uses `checkTimeRangeAt(time.Now(), start_hr, end_hr)` in `CheckTimeRange`, which already preserves local `time.Now()` behavior.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) constructs MQTT state payload timestamps with `time.Now().UTC()` in `makeBasePayload`.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) calls `r.now()` for cron ticks, MQTT trigger commands, pause checks, command payloads, and MQTT error timestamps.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) currently implements `func (r *Runner) now() time.Time { return r.cfg.Now().UTC() }`, which discards the configured/local location before `checkTimeRangeAt` runs.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) calls `checkTimeRangeAt` for both charge-window and reserve-window evaluation in `Tick` and `newCommandPayload`.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) implements `checkTimeRangeAt` by parsing `startHR` and `endHR`, rebuilding same-day `time.Date` values in `now.Location()`, and comparing inclusively.
+- [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go) already contains runner helper factories, fake MQTT client helpers, payload decoders, and runner command tests.
+- [pkg/cmd/schedule_cron_test.go](../../../pkg/cmd/schedule_cron_test.go) covers cron lifecycle behavior but does not validate window timezone semantics.
+- [Makefile](../../../Makefile) defines `test`, `build`, `vet`, and `all`; `make test` runs `go test -cover -race ./...`.
+
+External references:
+
+- Go `time` package docs: https://pkg.go.dev/time
+  - `time.Now()` returns current local time.
+  - `Time.UTC()` returns the same instant interpreted in UTC.
+  - `time.Date` uses the provided `*time.Location` for wall-clock construction.
+- robfig cron v3 docs: https://pkg.go.dev/github.com/robfig/cron/v3
+  - `cron.New()` interprets schedules in `time.Local` by default.
+  - `cron.WithLocation` and `CRON_TZ=` are available, but this issue does not add explicit timezone configuration.
+
+## 3. Target Architecture
+
+Keep wall-clock window checks local to the time value supplied by the runner, while preserving UTC for serialized timestamps and pause deadlines where the existing code already expects UTC.
+
+```mermaid
+flowchart TD
+    Cron[robfig cron / trigger_now] --> RunnerNow[Runner.now preserves cfg.Now location]
+    RunnerNow --> Tick[Runner.Tick]
+    Tick --> ChargeCheck[checkTimeRangeAt start_hr/end_hr]
+    Tick --> ReserveCheck[checkTimeRangeAt batt reserve start/end]
+    ChargeCheck --> Decision[Schedule decision gate]
+    ReserveCheck --> Fronius[Fronius Handler reserve flag]
+    Decision --> State[MQTT state payload]
+    Fronius --> State
+```
+
+Package affected: `pkg/cmd`.
+
+Expected production code shape:
+
+- `Runner.now()` should return the configured clock value without forcing `.UTC()`.
+- Timestamp serialization points should keep their current UTC behavior explicitly, either because they already call `time.Now().UTC()` or by calling `.UTC()` at the serialization boundary.
+- `checkTimeRangeAt` can remain unchanged unless tests reveal a boundary bug; its use of `now.Location()` is correct once `now` is no longer UTC-normalized prematurely.
+
+## 4. Dependency Choices
+
+No new dependency is required.
+
+- Use the existing Go standard library `time` package.
+- Keep existing `github.com/robfig/cron/v3 v3.0.1`; no cron configuration change is required for this issue.
+- Keep existing `github.com/stretchr/testify v1.11.1` for assertions in tests.
+
+## 5. Configuration Changes
+
+No configuration changes.
+
+- Existing CLI flags remain unchanged: `--start_hr`, `--end_hr`, `--batt_reserve_start_hr`, `--batt_reserve_end_hr`, `--crontab`.
+- Existing `config.yaml` keys remain unchanged: `start_hr`, `end_hr`, `batt_reserve_start_hr`, `batt_reserve_end_hr`, `crontab`.
+- Existing environment variables remain unchanged through Viper automatic env binding.
+- Home Assistant add-on schema changes: none.
+- Precedence remains unchanged: CLI flags > environment variables > `config.yaml`.
+
+Do not add a `timezone`, `tz`, `schedule_timezone`, or similar config key for this issue.
+
+## 6. Implementation Blueprint
+
+1. Update [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go)
+
+   Change `func (r *Runner) now() time.Time` so it preserves the location returned by `r.cfg.Now()`:
+
+   ```go
+   func (r *Runner) now() time.Time {
+       return r.cfg.Now()
+   }
+   ```
+
+   Rationale: `checkTimeRangeAt` already constructs start/end boundaries using `now.Location()`. The bug is caused by converting local runtime time to UTC before those boundaries are built.
+
+2. Review UTC serialization boundaries in [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go)
+
+   Keep pause deadlines normalized to UTC in `setPause`, `handleIntent` pause payload `NextRun`, and `pauseStateAt`.
+
+   In `publishError`, ensure `mqtt.ErrorPayload.Timestamp` remains UTC if serialized MQTT timestamps are expected to stay UTC. With the `Runner.now()` change, use this shape if needed:
+
+   ```go
+   Timestamp: r.now().UTC(),
+   ```
+
+   Rationale: window checks need local wall-clock interpretation, while serialized timestamps and stored pause deadlines should remain stable instants.
+
+3. Add regression tests in [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go)
+
+   Add a table-driven test using a deterministic non-UTC fixed zone, for example:
+
+   ```go
+   loc := time.FixedZone("CEST", 2*60*60)
+   ```
+
+   Test `Runner.newCommandPayload(..., runner.now())` with `RunnerConfig.Now` returning local fixed times and these expectations:
+
+   - `2026-05-16 00:00 +0200` with `00:00`-`06:00` returns charge window active and reserve window active.
+   - `2026-05-16 01:00 +0200` with `00:00`-`06:00` returns both active.
+   - `2026-05-16 06:00 +0200` remains active because existing comparisons are inclusive.
+   - `2026-05-16 07:00 +0200` returns both inactive.
+
+   Use `require.NotNil` before dereferencing `ChargeWindowActive` and `ReserveWindowActive`, then `assert.Equal` or `assert.True` / `assert.False`.
+
+   Rationale: this fails before the fix because `runner.now()` converts `00:00 +0200` to `22:00 UTC`, outside the configured window.
+
+4. Add focused boundary/error tests in [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go)
+
+   Add or extend tests for `checkTimeRangeAt` to cover:
+
+   - exact start boundary is in range
+   - exact end boundary is in range
+   - immediately after end is out of range
+   - invalid `startHR` returns an error containing `invalid start time`
+   - invalid `endHR` returns an error containing `invalid end time`
+
+   Rationale: these cover the expected, edge, and failure categories required by repository conventions without needing HTTP or Modbus mocks.
+
+5. Update release-note surface if this fix is shipping through the Home Assistant add-on
+
+   Append a bugfix bullet to [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md), either under a new upcoming version section or an `Unreleased` section if that convention is introduced during implementation.
+
+   Suggested wording:
+
+   ```markdown
+   - Fixed schedule charge and reserve window evaluation so local-time cron ticks are not compared as UTC.
+   ```
+
+   Rationale: the behavior affects add-on users even though the schema and docs do not change.
+
+## 7. Test Plan
+
+Package: `pkg/cmd`
+
+Expected cases:
+
+- `Runner.newCommandPayload` reports `ChargeWindowActive=true` and `ReserveWindowActive=true` for non-UTC local `00:00` and `01:00` ticks when configured as `00:00`-`06:00`.
+- Existing UTC-location calls to `checkTimeRangeAt` continue to behave correctly.
+
+Edge cases:
+
+- Exact start boundary is inclusive.
+- Exact end boundary is inclusive.
+- First time after the end boundary is out of range.
+- Reserve window uses the same wall-clock semantics as charge window.
+
+Failure cases:
+
+- Invalid `startHR` returns a non-nil error and includes `invalid start time`.
+- Invalid `endHR` returns a non-nil error and includes `invalid end time`.
+
+Mocks:
+
+- No `httptest.NewServer` is needed because the focused tests avoid storage/power HTTP calls.
+- No `tbrandon/mbserver` is needed because the focused tests avoid Fronius Modbus calls.
+- Use existing fake MQTT client helpers only if a test needs to decode published state; direct `newCommandPayload` testing should avoid MQTT entirely.
+
+Cleanup:
+
+- Restore any package-level test factory overrides with `defer` if a runner-level `Tick` test is added later.
+- No server cleanup is required for the focused tests above.
+
+## 8. Validation Gates
+
+Run these commands and fix any failures before declaring implementation complete:
+
+```bash
+go test ./pkg/cmd -run 'TestRunner.*Window|TestCheckTimeRangeAt'
+go test ./pkg/cmd
+make test
+make build
+```
+
+If the Home Assistant changelog is updated, no Docker build is required because no Dockerfile or add-on runtime file changes are planned.
+
+## 9. Rollout / Backward Compatibility
+
+- Defaults remain unchanged.
+- Existing config files remain valid.
+- CLI, env var, and YAML precedence remains unchanged.
+- No migration is required.
+- The runtime behavior changes only by evaluating configured charge/reserve windows in the local wall-clock location instead of UTC-normalized time.
+- Add a Home Assistant add-on changelog bullet if this fix is included in an add-on release.
+- README updates are not required unless the implementation discovers existing docs that explicitly state the incorrect UTC behavior.
+
+## 10. Security Considerations
+
+- No secrets, credentials, API keys, MQTT credentials, or network endpoints are introduced.
+- No new external input parser is introduced.
+- Invalid time strings must keep returning errors.
+- Modbus write safety must not be relaxed. The change should only correct the existing schedule/reserve gates that determine whether charging logic runs.
+- Do not broaden behavior to cross-midnight windows in this issue; doing so could unintentionally expand charging periods.
+
+## 11. Gotchas
+
+- `Runner.now()` is used for more than charge-window checks. Keep UTC conversion at serialization/storage boundaries rather than inside `Runner.now()`.
+- `time.Time` comparisons compare instants correctly across locations, so pause deadlines can remain stored as UTC while `now` is local.
+- `makeBasePayload` already uses `time.Now().UTC()` for state timestamps; do not change it unless tests or requirements explicitly demand injected timestamps.
+- `checkTimeRangeAt` uses `now.Location()` already; changing it to `time.Local` would make direct tests with fixed zones less precise and could break injected-clock behavior.
+- `cron.New()` defaults to `time.Local`; `CRON_TZ=` support exists in robfig cron, but deriving that schedule timezone inside the callback is out of scope because callbacks do not receive the scheduled time.
+- Daylight-saving transition days can have skipped or repeated local wall-clock times; use deterministic fixed-zone tests for the regression and avoid testing ambiguous DST transition instants in this issue.
+
+## 12. Open Questions / Risks
+
+- RESOLVED: reserve-window evaluation is in scope.
+- RESOLVED: no new timezone configuration is needed.
+- RESOLVED: cross-midnight windows are out of scope.
+- RISK: changing `Runner.now()` can alter `publishError` timestamps unless UTC conversion is kept at that boundary.
+- RISK: users with `CRON_TZ=` different from the process local timezone may still need a separate feature if they expect windows to follow that explicit cron timezone.
+
+## 13. Implementation Checklist
+
+- [ ] Update `Runner.now()` to preserve configured clock location.
+- [ ] Keep MQTT error timestamps UTC if necessary after the `Runner.now()` change.
+- [ ] Add non-UTC local wall-clock regression tests covering charge and reserve windows.
+- [ ] Add boundary and invalid-time tests for `checkTimeRangeAt`.
+- [ ] Add Home Assistant add-on changelog bullet if shipping this behavior through the add-on.
+- [ ] Run validation gates.
+
+## 14. Confidence Score
+
+Confidence: 9/10.
+
+The root cause is localized and the existing `checkTimeRangeAt` helper already has the right location-aware shape once `Runner.now()` stops forcing UTC. The remaining caution is timestamp behavior because `Runner.now()` is also used outside the window checks; the plan addresses that by keeping UTC normalization at serialization boundaries.

--- a/docs/implementations/115-issue-fix-crontab-timezone-window/115-issue-fix-crontab-timezone-window-TASK.md
+++ b/docs/implementations/115-issue-fix-crontab-timezone-window/115-issue-fix-crontab-timezone-window-TASK.md
@@ -1,0 +1,74 @@
+# Feature: Fix Crontab Timezone Window Evaluation
+
+> Source issue: [#115](https://github.com/atbore-phx/sbam/issues/115)
+> Fetched: 2026-05-16
+> Slug: `115-issue-fix-crontab-timezone-window` · Created: 2026-05-16
+
+## Summary
+In `release/v2.0.0`, schedule ticks that occur inside the configured local charging window can be treated as outside the window because `start_hr` and `end_hr` are expressed as local wall-clock times while the runner compares them against `now.UTC()`. For a Central European timezone example, `00:00` and `01:00` local ticks for a `00:00`-`06:00` window are skipped as outside the charging window.
+
+## Motivation / User Story
+Users configure `start_hr`, `end_hr`, and cron schedules as local operating times. The scheduler should evaluate charge and reserve windows in the same timezone as the schedule tick/local runtime so grid charging decisions happen during the intended wall-clock period.
+
+## Scope
+- In scope: fix charge-window evaluation for `start_hr` / `end_hr` so valid local ticks are recognized as in-window.
+- In scope: apply the same timezone semantics to reserve-window evaluation for `batt_reserve_start_hr` / `batt_reserve_end_hr`.
+- In scope: add regression tests for a non-UTC timezone such as CET/CEST and boundary cases.
+- Out of scope: adding a new explicit timezone configuration key.
+- Out of scope: changing cron expression parsing or scheduling semantics beyond preserving the tick location for window checks.
+- Out of scope: implementing cross-midnight window support; keep this issue focused on the UTC/local mismatch.
+
+## Functional Requirements
+- `start_hr` and `end_hr` must be compared against the schedule tick's local wall-clock time instead of a forced UTC time.
+- With `start_hr: 00:00`, `end_hr: 06:00`, and a Central European schedule tick, local ticks from `00:00` through `06:00` must be considered inside the charge window.
+- Local ticks after the configured end time, such as `07:00` and `08:00` for a `00:00`-`06:00` window, must be considered outside the charge window.
+- Reserve-window checks must use the same timezone behavior as charge-window checks.
+- Invalid time strings must continue to return errors rather than silently falling back to a default.
+
+## Non-functional Requirements
+- Backward compatibility: keep existing configuration keys, CLI flags, environment variables, and default values unchanged.
+- Safety / defaults: do not broaden Modbus write behavior beyond the correctly evaluated charge/reserve windows.
+- Performance: keep timezone/window checks local and allocation-light; no network or external service dependency is required.
+
+## Configuration Impact
+- New CLI flags: none.
+- New config keys (`config.yaml`): none.
+- New env vars: none.
+- Home Assistant add-on schema changes (`home-assistant/addons/sbam/config.json`): none.
+
+## External Integrations Touched
+- Solcast: none.
+- Fronius Solar API: none.
+- Fronius Modbus registers: no protocol or register changes; scheduling gates around existing behavior must be corrected.
+- MQTT: no topic or payload schema changes expected, but published `in_charge_window` and reserve-window state should reflect the corrected timezone calculation.
+
+## Acceptance Criteria
+- [ ] A schedule tick at `00:00` CET/CEST with `start_hr: 00:00` and `end_hr: 06:00` is evaluated as inside the charging window.
+- [ ] A schedule tick at `01:00` CET/CEST with the same window is evaluated as inside the charging window.
+- [ ] Schedule ticks after the configured local end time, such as `07:00` and `08:00`, are evaluated as outside the charging window.
+- [ ] Reserve-window checks use the same corrected timezone semantics.
+- [ ] Existing UTC-based tests and invalid-time error behavior continue to pass.
+- [ ] A regression unit test prevents the UTC/local mismatch from returning.
+
+## Test Strategy
+- Unit tests (`pkg/cmd`): add table-driven coverage for `checkTimeRangeAt` or the runner-level window calculation using a fixed non-UTC location.
+- Expected case: `00:00` and `01:00` local ticks are in-window for `00:00`-`06:00`.
+- Edge cases: exact start and end boundaries are inclusive; ticks immediately after the local end time are out-of-window.
+- Failure cases: invalid `start_hr` or `end_hr` strings still return errors.
+- Integration mocks: no `httptest` or `mbserver` needed for the focused timezone/window unit tests.
+- Validation commands: `go test ./pkg/cmd`, `make test`, and `make build`.
+
+## Risks / Open Questions
+- Risk: `Runner.now()` currently normalizes time to UTC. The implementation should avoid unintentionally changing MQTT timestamp expectations or pause-deadline comparisons while fixing wall-clock window evaluation.
+- Risk: daylight-saving transitions can create ambiguous local times; tests should use deterministic fixed dates and locations.
+- Resolved: reserve-window evaluation is in scope.
+- Resolved: new timezone configuration is out of scope.
+- Resolved: cross-midnight window support is out of scope for this issue.
+
+## References
+- https://github.com/atbore-phx/sbam/issues/115
+
+## Clarifications
+- 2026-05-16: Include both charge-window and reserve-window checks in the fix.
+- 2026-05-16: Treat `start_hr` / `end_hr` and reserve-window times as wall-clock values in the same timezone as the schedule tick/local runtime.
+- 2026-05-16: Keep cross-midnight window behavior out of scope for this issue.

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,5 +1,9 @@
 [sbam](https://github.com/atbore-phx/sbam/releases/latest)
 
+## Unreleased
+
+- Fixed schedule charge and reserve window evaluation so local-time cron ticks are not compared as UTC.
+
 ## 2.0.0 - 2026-05-06
 
 - Added MQTT and Home Assistant discovery options to add-on config.

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -372,7 +372,7 @@ func (r *Runner) publishError(ctx context.Context, source string, err error) {
 	mqtt.PublishError(opCtx, r.client, r.cfg.MQTT.TopicPrefix, mqtt.ErrorPayload{
 		Error:     err.Error(),
 		Source:    source,
-		Timestamp: r.now(),
+		Timestamp: r.now().UTC(),
 	})
 }
 
@@ -389,7 +389,7 @@ func (r *Runner) publishIntentAck(ctx context.Context, intent mqtt.Intent, parse
 }
 
 func (r *Runner) now() time.Time {
-	return r.cfg.Now().UTC()
+	return r.cfg.Now()
 }
 
 func (r *Runner) setPause(pauseUntil *time.Time) {

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -346,3 +346,87 @@ func TestRunner_TickSkipsForecastAndChargeWhenPaused(t *testing.T) {
 	assert.True(t, state.Paused)
 	assert.Equal(t, "paused", state.LastDecision)
 }
+
+func TestRunner_NewCommandPayloadUsesLocalWallClockWindow(t *testing.T) {
+	loc := time.FixedZone("CEST", 2*60*60)
+
+	tests := []struct {
+		name         string
+		now          time.Time
+		wantInCharge bool
+		wantReserve  bool
+	}{
+		{
+			name:         "00:00 local inside window",
+			now:          time.Date(2026, time.May, 16, 0, 0, 0, 0, loc),
+			wantInCharge: true,
+			wantReserve:  true,
+		},
+		{
+			name:         "01:00 local inside window",
+			now:          time.Date(2026, time.May, 16, 1, 0, 0, 0, loc),
+			wantInCharge: true,
+			wantReserve:  true,
+		},
+		{
+			name:         "06:00 local inclusive end boundary",
+			now:          time.Date(2026, time.May, 16, 6, 0, 0, 0, loc),
+			wantInCharge: true,
+			wantReserve:  true,
+		},
+		{
+			name:         "07:00 local outside window",
+			now:          time.Date(2026, time.May, 16, 7, 0, 0, 0, loc),
+			wantInCharge: false,
+			wantReserve:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewRunner(RunnerConfig{
+				StartHR:            "00:00",
+				EndHR:              "06:00",
+				BattReserveStartHR: "00:00",
+				BattReserveEndHR:   "06:00",
+				Now: func() time.Time {
+					return tt.now
+				},
+			}, nil)
+
+			payload := runner.newCommandPayload("decision", "reason", runner.now())
+
+			require.NotNil(t, payload.ChargeWindowActive)
+			require.NotNil(t, payload.ReserveWindowActive)
+			assert.Equal(t, tt.wantInCharge, *payload.ChargeWindowActive)
+			assert.Equal(t, tt.wantReserve, *payload.ReserveWindowActive)
+		})
+	}
+}
+
+func TestCheckTimeRangeAt_BoundariesAndErrors(t *testing.T) {
+	loc := time.FixedZone("UTC+1", 1*60*60)
+
+	startBoundary := time.Date(2026, time.May, 16, 0, 0, 0, 0, loc)
+	inRange, err := checkTimeRangeAt(startBoundary, "00:00", "06:00")
+	require.NoError(t, err)
+	assert.True(t, inRange)
+
+	endBoundary := time.Date(2026, time.May, 16, 6, 0, 0, 0, loc)
+	inRange, err = checkTimeRangeAt(endBoundary, "00:00", "06:00")
+	require.NoError(t, err)
+	assert.True(t, inRange)
+
+	afterEnd := time.Date(2026, time.May, 16, 6, 1, 0, 0, loc)
+	inRange, err = checkTimeRangeAt(afterEnd, "00:00", "06:00")
+	require.NoError(t, err)
+	assert.False(t, inRange)
+
+	_, err = checkTimeRangeAt(startBoundary, "bad", "06:00")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid start time")
+
+	_, err = checkTimeRangeAt(startBoundary, "00:00", "bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid end time")
+}


### PR DESCRIPTION
Fixes #115 — Preserve local wall-clock when evaluating charge and reserve windows.\n\nSummary:\n- Preserve the Runner.now() location (no UTC coercion) so time-range checks use local wall-clock.\n- Ensure MQTT/error timestamps remain UTC at serialization boundary.\n- Added regression tests covering non-UTC zones and boundary parsing.\n\nValidation: local `go test`, `make test`, and `make build` passed.\n\nFiles changed: pkg/cmd/schedule_runner.go, pkg/cmd/schedule_runner_test.go, home-assistant/addons/sbam/CHANGELOG.md\n