### PR TITLE
feat: support cross-midnight start_hr/end_hr windows (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Flags:
       --mqtt_ha_discovery_prefix       Home Assistant MQTT discovery prefix (default "homeassistant")
 ```
 
+Time windows can span midnight for both charge and reserve ranges. Example:
+`--start_hr 22:00 --end_hr 06:00` and optionally
+`--batt_reserve_start_hr 23:00 --batt_reserve_end_hr 05:00`.
+Equal start/end values remain invalid.
+
 #### Debug Logs
 
 To increase the log level to debug, just set the DEBUG environment variable to true.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Time windows can span midnight for both charge and reserve ranges. Example:
 `--batt_reserve_start_hr 23:00 --batt_reserve_end_hr 05:00`.
 Equal start/end values remain invalid.
 
+Forecast selection currently uses a fixed noon threshold: before 12:00 local
+time, `schedule` evaluates the forecast for the current day; from 12:00 local
+time onward, it evaluates the forecast for the next day. This behavior is kept
+for compatibility and is independent from whether the charging window spans
+midnight.
+
 #### Debug Logs
 
 To increase the log level to debug, just set the DEBUG environment variable to true.

--- a/docs/implementations/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-PLAN.md
+++ b/docs/implementations/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-PLAN.md
@@ -1,0 +1,360 @@
+# Plan: Cross-Midnight Charge and Reserve Windows
+
+Date: 2026-05-16
+Task: [116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-TASK.md](./116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-TASK.md)
+Issue: [#116](https://github.com/atbore-phx/sbam/issues/116)
+
+## Task Analysis
+
+Goal: allow schedule windows such as `start_hr: "22:00"` and `end_hr: "06:00"` to mean an overnight window that starts today and ends after midnight, while preserving existing same-day behavior.
+
+Non-goals:
+
+- Do not change the charging or reserve decision algorithm beyond window validation and active-window evaluation.
+- Do not add or rename CLI flags, environment variables, `config.yaml` keys, or Home Assistant add-on schema fields.
+- Do not change Solcast, Fronius Solar API, or Fronius Modbus register mappings.
+- Do not define all-day behavior for equal start/end times; equal times remain invalid.
+
+Acceptance criteria from the TASK:
+
+- `22:00` to `06:00` is accepted for the charge window.
+- `22:00` to `06:00` is active at `23:00` and `02:00`, and inactive at `12:00`.
+- Same-day windows still work.
+- Invalid time strings still fail validation.
+- Equal start/end times remain invalid.
+- Battery reserve windows support the same cross-midnight semantics.
+- No config, env, CLI, or Home Assistant schema fields are added or renamed.
+
+## Current State
+
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) wires `start_hr`, `end_hr`, `batt_reserve_start_hr`, and `batt_reserve_end_hr` from Viper into `RunnerConfig`. Empty reserve start/end values default to the main charge window.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) currently validates time ordering in `checkScheduleschedule(...)` with `isStartBeforeEnd(...)`; this rejects every `start > end` range.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) also validates reserve-window containment with simple same-day comparisons: `start_hr <= batt_reserve_start_hr` and `batt_reserve_end_hr <= end_hr`. Those comparisons are not sufficient once either window can wrap over midnight.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) contains `checkTimeRangeAt(now, startHR, endHR) (bool, error)`. It builds `startAt` and `endAt` on the same date and checks `startAt <= now <= endAt`, so cross-midnight ranges are always inactive before midnight.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) uses `checkTimeRangeAt` in `Runner.Tick(...)` for both charge and reserve windows, and in `Runner.newCommandPayload(...)` for MQTT state flags.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) contains `crontabSchedule(...)`, which schedules defaults at `end_hr - 5 minutes`. For `end_hr: "06:00"`, this already produces `55 5 * * *`; keep this behavior and add a focused regression check if practical.
+- [pkg/cmd/schedule_validation_test.go](../../../pkg/cmd/schedule_validation_test.go) currently expects `start_hr > end_hr` and reserve `start > end` validation failures. These cases need to be replaced with cross-midnight acceptance and equal-time rejection tests.
+- [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go) already has local wall-clock tests for same-day windows and boundary/error tests for `checkTimeRangeAt`; extend those tables for cross-midnight behavior.
+- [README.md](../../../README.md) and [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md) describe start/end options and should mention that `22:00` to `06:00` is valid.
+- [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json) already validates the individual time strings and does not enforce ordering, so no schema change is needed.
+
+## Target Architecture
+
+Keep the change inside `pkg/cmd` with private helpers that all charge/reserve validation and runtime checks share.
+
+Recommended helper model:
+
+- Parse configured `HH:MM` values once per check into comparable clock values.
+- Treat `start < end` as a same-day window.
+- Treat `start > end` as a cross-midnight window.
+- Treat `start == end` as invalid.
+- Expand windows into one or two inclusive minute ranges for containment checks.
+- Use the same `checkTimeRangeAt(...)` behavior for `Runner.Tick(...)`, MQTT command payloads, and `CheckTimeRange(...)`.
+
+```mermaid
+flowchart TD
+    Config[start/end config] --> Validate[checkScheduleschedule]
+    Validate --> RangeHelpers[shared clock-window helpers]
+    RunnerTick[Runner.Tick] --> Check[checkTimeRangeAt]
+    CommandPayload[Runner.newCommandPayload] --> Check
+    Check --> RangeHelpers
+    RangeHelpers --> ChargeFlag[charge_window_active]
+    RangeHelpers --> ReserveFlag[batt_reserve_window_active]
+    ChargeFlag --> MQTT[mqtt.StatePayload]
+    ReserveFlag --> MQTT
+```
+
+## Dependency Choices
+
+No new dependencies are needed.
+
+Existing dependencies to preserve:
+
+- Go standard library `time`: use `time.Parse`, `time.Date`, `Time.Before`, `Time.After`, and `Time.Equal`. Reference: https://pkg.go.dev/time
+- `github.com/robfig/cron/v3 v3.0.1`: keep current cron scheduling. Reference: https://pkg.go.dev/github.com/robfig/cron/v3
+- `github.com/stretchr/testify v1.11.1`: continue using `assert` and `require` in tests.
+
+Relevant external notes:
+
+- `time.Parse("15:04", value)` returns an error for malformed values; use that error path instead of panicking in validation helpers.
+- `time.Date(...)` uses the supplied `Location`; keep `now.Location()` so the timezone fix from issue #115 is preserved.
+- `robfig/cron/v3` uses five-field standard cron specs by default and interprets schedules in `time.Local` unless configured otherwise; `CRON_TZ=` can override a single schedule.
+
+## Configuration Changes
+
+No new configuration surfaces.
+
+Existing CLI flags whose semantics change only by accepting cross-midnight values:
+
+- `--start_hr`
+- `--end_hr`
+- `--batt_reserve_start_hr`
+- `--batt_reserve_end_hr`
+
+Existing `config.yaml` keys whose semantics change only by accepting cross-midnight values:
+
+- `start_hr`
+- `end_hr`
+- `batt_reserve_start_hr`
+- `batt_reserve_end_hr`
+
+Existing env vars keep the same Viper binding and precedence:
+
+- `START_HR`
+- `END_HR`
+- `BATT_RESERVE_START_HR`
+- `BATT_RESERVE_END_HR`
+
+Home Assistant add-on:
+
+- [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json): no option or schema changes. The schema validates individual `HH:MM` values and already permits `start_hr > end_hr` because ordering is not encoded there.
+- `run.sh` exports: no changes.
+
+Precedence remains CLI flags > environment variables > `config.yaml`.
+
+## Implementation Blueprint
+
+1. Update private schedule-window helpers in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+
+   Add private helpers near the existing `isStartBeforeEnd` / `isStartAfterEnd` block. Prefer replacing use of the panic-based helpers in validation with non-panicking helpers.
+
+   Suggested signatures:
+
+   ```go
+   const scheduleClockLayout = "15:04"
+
+   func parseScheduleClock(value, field string) (time.Time, error)
+   func validateScheduleWindow(startField, startValue, endField, endValue string) (time.Time, time.Time, error)
+   func isCrossMidnightWindow(startTime, endTime time.Time) bool
+   func isWindowContainedIn(innerStart, innerEnd, outerStart, outerEnd string) (bool, error)
+   ```
+
+   Rationale: validation should return clear `error` values for malformed times and equal start/end times. It should no longer panic through `isStartBeforeEnd` when user input is malformed.
+
+2. Implement containment using expanded clock segments in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+
+   Add a small private type and helpers if useful:
+
+   ```go
+   type clockSegment struct {
+       startMinute int
+       endMinute   int
+   }
+
+   func clockMinute(t time.Time) int
+   func expandClockWindow(startMinute, endMinute int) []clockSegment
+   func segmentContains(outer, inner clockSegment) bool
+   ```
+
+   Algorithm:
+
+   - Reject `start == end` before expansion.
+   - For same-day windows, expand to one segment: `[start, end]`.
+   - For cross-midnight windows, expand to two segments: `[start, 1439]` and `[0, end]`.
+   - `isWindowContainedIn(inner, outer)` returns true only when every inner segment is fully contained by at least one outer segment.
+
+   Required examples:
+
+   - Outer `22:00`-`06:00`, inner `23:00`-`05:00`: contained.
+   - Outer `22:00`-`06:00`, inner `02:00`-`05:00`: contained.
+   - Outer `22:00`-`06:00`, inner `02:00`-`08:00`: not contained.
+   - Outer `08:00`-`18:00`, inner `10:00`-`12:00`: contained.
+   - Outer `08:00`-`18:00`, inner `17:00`-`07:00`: not contained.
+
+3. Update `checkScheduleschedule(...)` in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+
+   Replace the charge-window `!isStartBeforeEnd(start_hr, end_hr)` check with `validateScheduleWindow("start_hr", start_hr, "end_hr", end_hr)`.
+
+   Replace the reserve-window `!isStartBeforeEnd(...)` check with `validateScheduleWindow("batt_reserve_start_hr", batt_reserve_start_hr, "batt_reserve_end_hr", batt_reserve_end_hr)`.
+
+   Replace the two same-day containment comparisons with a single containment check:
+
+   ```go
+   contained, err := isWindowContainedIn(batt_reserve_start_hr, batt_reserve_end_hr, start_hr, end_hr)
+   ```
+
+   Return errors that include the affected field names. Suggested messages:
+
+   - `start_hr/end_hr must not be equal`
+   - `invalid start_hr "bad": ...`
+   - `batt_reserve_start_hr/batt_reserve_end_hr must be contained within start_hr/end_hr`
+
+   Rationale: reserve containment is the behavior most likely to regress if implemented as simple `Before` / `After` comparisons.
+
+4. Update `checkTimeRangeAt(...)` in [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go).
+
+   Keep the existing signature:
+
+   ```go
+   func checkTimeRangeAt(now time.Time, startHR, endHR string) (bool, error)
+   ```
+
+   Implementation requirements:
+
+   - Parse both times with the same helper used by validation.
+   - Return an error when start and end are equal.
+   - Build `startAt` and `endAt` with `now.Location()`.
+   - For same-day windows, keep existing inclusive behavior: `startAt <= now <= endAt`.
+   - For cross-midnight windows, return true when `now >= startAt || now <= endAt`.
+   - Preserve exact boundary behavior: exactly at `start_hr` and exactly at `end_hr` are active.
+
+   Rationale: `Runner.Tick(...)` and `Runner.newCommandPayload(...)` already call this helper for charge and reserve flags, so one fix updates schedule execution and MQTT state reporting.
+
+5. Review `crontabSchedule(...)` in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go).
+
+   No behavior change is expected. Confirm the implementation still parses `end_hr`, subtracts five minutes, and builds a daily cron expression such as `55 5 * * *` for `end_hr: "06:00"`.
+
+   Add a focused test if practical, but avoid invasive changes to the cron runner. A helper extraction is acceptable if it stays private, for example:
+
+   ```go
+   func defaultsCronForEndHR(endHR string) (string, error)
+   ```
+
+   If extracted, test `defaultsCronForEndHR("06:00") == "55 5 * * *"` and `defaultsCronForEndHR("00:03") == "58 23 * * *"`.
+
+6. Update [pkg/cmd/schedule_validation_test.go](../../../pkg/cmd/schedule_validation_test.go).
+
+   Required changes:
+
+   - Replace the old `start must be before end` rejection case with an equal-time rejection case.
+   - Add `TestCheckScheduleScheduleCrossMidnightChargeWindowValid` using `startHr: "22:00"`, `endHr: "06:00"`, and reserve default globals inside that outer window.
+   - Add reserve containment tests covering:
+     - `22:00`-`06:00` outer with `23:00`-`05:00` reserve accepted.
+     - `22:00`-`06:00` outer with `02:00`-`05:00` reserve accepted.
+     - `22:00`-`06:00` outer with `02:00`-`08:00` reserve rejected.
+     - `08:00`-`18:00` outer with `17:00`-`07:00` reserve rejected.
+   - Add malformed-time validation tests for both charge and reserve windows, asserting returned errors rather than panics.
+   - Keep `withScheduleValidationGlobals(...)` cleanup behavior.
+
+7. Update [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go).
+
+   Extend `TestCheckTimeRangeAt_BoundariesAndErrors` or convert it to table-driven tests covering:
+
+   - Same-day start boundary active.
+   - Same-day end boundary active.
+   - Same-day after-end inactive.
+   - Cross-midnight before midnight active, e.g. `2026-05-16 23:00` with `22:00`-`06:00`.
+   - Cross-midnight after midnight active, e.g. `2026-05-16 02:00` with `22:00`-`06:00`.
+   - Cross-midnight daytime inactive, e.g. `12:00`.
+   - Cross-midnight just before start inactive, e.g. `21:59`.
+   - Cross-midnight exact start active and exact end active.
+   - Equal start/end returns an error.
+   - Invalid start and invalid end strings return errors containing `invalid start time` / `invalid end time`, or the updated equivalent field-specific text.
+
+   Extend `TestRunner_NewCommandPayloadUsesLocalWallClockWindow` with a second table or subtest where `RunnerConfig` uses `StartHR: "22:00"`, `EndHR: "06:00"`, `BattReserveStartHR: "23:00"`, and `BattReserveEndHR: "05:00"`. Assert both `ChargeWindowActive` and `ReserveWindowActive` for `23:00`, `02:00`, and `12:00` local times.
+
+8. Update [pkg/cmd/schedule_cron_test.go](../../../pkg/cmd/schedule_cron_test.go) only if `defaultsCronForEndHR(...)` is extracted.
+
+   Add expected cases:
+
+   - `06:00` maps to `55 5 * * *`.
+   - `00:03` maps to `58 23 * * *`.
+   - malformed `end_hr` returns an error.
+
+   Rationale: cross-midnight support should not accidentally reinterpret the defaults reset time relative to `start_hr`.
+
+9. Update user-facing documentation.
+
+   - [README.md](../../../README.md): in the schedule flag/config description area, add a short note that time windows can span midnight, for example `--start_hr 22:00 --end_hr 06:00`.
+   - [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md): add the same cross-midnight example to `start_hr`, `end_hr`, `batt_reserve_start_hr`, and `batt_reserve_end_hr` descriptions.
+   - [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md): add an Unreleased bullet such as `Added support for cross-midnight charge and reserve windows, for example 22:00-06:00.`
+
+   Do not change [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json) unless implementation discovers a schema-level issue, because it already accepts individual time strings independently.
+
+10. Run formatting and validation.
+
+   Run `gofmt` on changed Go files or `make fmt` if broader formatting is desired. Then run focused tests before the full gates listed below.
+
+## Test Plan
+
+Package `pkg/cmd` is the primary test target.
+
+Expected cases:
+
+- `checkScheduleschedule(...)` accepts `start_hr: "22:00"`, `end_hr: "06:00"`.
+- `checkScheduleschedule(...)` accepts cross-midnight reserve windows contained within a cross-midnight charge window.
+- `checkTimeRangeAt(...)` returns true at `23:00` and `02:00` for `22:00`-`06:00`.
+- `Runner.newCommandPayload(...)` publishes correct charge/reserve window booleans for cross-midnight windows.
+- Same-day ranges such as `00:00`-`06:00` and `08:00`-`18:00` still behave as they do today.
+
+Edge cases:
+
+- Exactly at `start_hr` is active.
+- Exactly at `end_hr` is active.
+- Just before `start_hr` is inactive.
+- Just after `end_hr` is inactive.
+- `end_hr` near midnight, such as `00:03`, still produces a defaults reset schedule five minutes earlier on the previous wall-clock hour if helper extraction is tested.
+
+Failure cases:
+
+- Equal charge start/end returns a validation error.
+- Equal reserve start/end returns a validation error.
+- Malformed charge start/end returns a validation error.
+- Malformed reserve start/end returns a validation error.
+- Reserve window that extends outside the charge window is rejected for same-day and cross-midnight outer windows.
+
+Mocks and cleanup:
+
+- No `httptest.NewServer` or `mbserver` is needed for the core window tests.
+- Existing scheduler tests that use fake MQTT clients and injected factories should continue to use `t.Cleanup` / `defer` to restore globals such as `newStorage`, `newPower`, `newFronius`, and `newBatteryWriter`.
+- Continue using `require.NotNil` before dereferencing `ChargeWindowActive` and `ReserveWindowActive`.
+
+## Validation Gates
+
+Focused gates:
+
+```bash
+go test ./pkg/cmd -run 'TestCheckTimeRangeAt|TestCheckScheduleSchedule|TestRunner_NewCommandPayload|TestCrontabSchedule|TestStartEndHelpers'
+```
+
+Full gates:
+
+```bash
+make test
+make build
+```
+
+No Docker build is required unless implementation changes the Dockerfile or Home Assistant image build files.
+
+## Rollout / Backward Compatibility
+
+- Existing same-day configurations keep working.
+- Existing config keys, env vars, and CLI flags keep their names and precedence.
+- Existing Home Assistant add-on options and schema remain compatible.
+- Users gain the ability to configure overnight tariffs directly, for example `start_hr: "22:00"` and `end_hr: "06:00"`.
+- Add an Unreleased changelog entry in [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md).
+- Add README and Home Assistant documentation notes so users know `start_hr > end_hr` is intentional and supported.
+
+## Security Considerations
+
+- Secrets are unaffected; no API key, MQTT credential, or Fronius credential handling changes are needed.
+- Invalid time inputs must return validation errors rather than causing panics or silently broadening the active charging window.
+- Modbus write safety depends on preserving the existing runner decision flow. The implementation must not add direct Fronius Modbus writes to validation, helper functions, documentation examples, or MQTT payload generation.
+- A miscomputed cross-midnight window could cause charging at unintended times. The strongest mitigation is table-driven validation for inside/outside times and reserve containment.
+- Home Assistant schema regex remains strict for individual `HH:MM` strings and continues to reject malformed input before sbam starts where possible.
+
+## Gotchas
+
+- Reserve containment is not the same as comparing two start values and two end values once either range can wrap around midnight. Use segment expansion or equivalent modulo-day logic.
+- `checkTimeRangeAt(...)` must use `now.Location()` when constructing boundary times so issue #115's local wall-clock behavior is preserved.
+- Equal start/end is explicitly invalid for this feature. Do not accidentally turn it into always-on behavior through `now >= start || now <= end` logic.
+- `time.Parse("15:04", value)` creates a time in UTC with a dummy date. It is fine for comparing clock values, but runtime range checks should still construct boundaries with `time.Date(..., now.Location())`.
+- `crontabSchedule(...)` defaults reset should stay tied to `end_hr - 5 minutes`, not to the start of a cross-midnight window.
+- `robfig/cron/v3` supports `CRON_TZ=` in specs. This feature should not attempt to redesign cron timezone handling.
+- Existing panic-based helpers may still be covered by tests. Prefer updating tests toward non-panicking validation helpers instead of preserving panic behavior for user input.
+- The Home Assistant add-on schema allows one-digit hours, but current Go parsing may be stricter depending on `time.Parse("15:04", value)`. Do not broaden accepted formats in this feature unless tests and docs are updated deliberately.
+
+## Open Questions / Risks
+
+- RESOLVED: both charge and reserve windows are in scope.
+- RESOLVED: equal start and end times remain invalid.
+- RESOLVED: no new configuration surfaces are required.
+- RISK: reserve-window containment can be implemented incorrectly for split cross-midnight intervals; table-driven tests should cover contained and outside cases.
+- RISK: changing validation from panic-based helper calls to returned errors may update some test expectations, but this is consistent with the project's error-handling standards.
+- RISK: users with explicit `CRON_TZ=` schedules may expect window checks to follow that timezone exactly. This plan preserves current local-time interpretation and does not add cron timezone configuration.
+
+## Confidence Score
+
+9/10.
+
+The behavior is localized to `pkg/cmd` validation and window evaluation, and the runner already centralizes charge/reserve active-state checks through `checkTimeRangeAt(...)`. The main implementation risk is reserve containment across split intervals; the plan calls that out directly with concrete acceptance and rejection tests.

--- a/docs/implementations/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-TASK.md
+++ b/docs/implementations/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window/116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window-TASK.md
@@ -1,0 +1,85 @@
+# Feature: start_hr and end_hr should produce a cross-midnight window
+
+> Source issue: [#116](https://github.com/atbore-phx/sbam/issues/116)
+> Fetched: 2026-05-16
+
+> Slug: `116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window` · Created: 2026-05-16
+
+## Summary
+Support cross-midnight charging windows for `start_hr` and `end_hr`, so a range such as `22:00` to `06:00` is treated as a valid window spanning midnight instead of being rejected because the start time is later than the end time.
+
+## Motivation / User Story
+Users need charging and reserve windows that align with overnight electricity provider tariffs and longer overnight charging periods. The current implementation assumes `start_hr < end_hr` within the same day, which prevents charging between the configured start time and midnight when an intended window spans into the following day.
+
+## Scope
+- In scope: accept cross-midnight time ranges for the main charge window (`start_hr` / `end_hr`).
+- In scope: apply the same cross-midnight semantics to the battery reserve window (`batt_reserve_start_hr` / `batt_reserve_end_hr`).
+- In scope: preserve same-day time range behavior where the start time is before the end time.
+- In scope: keep invalid time strings rejected with clear errors.
+- In scope: keep equal start and end times invalid.
+- Out of scope: changing the charging or reserve decision algorithm beyond time-window validation and active-window evaluation.
+- Out of scope: adding, renaming, or changing precedence for CLI flags, environment variables, `config.yaml` keys, or Home Assistant add-on schema fields.
+
+## Functional Requirements
+- The scheduler must accept `start_hr` values later than `end_hr` as a valid cross-midnight charge window.
+- The runtime charge-window check must treat a cross-midnight window as active from `start_hr` through `23:59:59...` and from `00:00` through `end_hr`.
+- The reserve-window validation and runtime reserve-window check must use the same cross-midnight semantics as the charge window.
+- Same-day windows where `start_hr` is before `end_hr` must keep their current behavior.
+- Equal start and end times must remain invalid unless a future feature explicitly defines all-day semantics.
+- Malformed time values must continue to fail validation instead of silently becoming inactive or active.
+- MQTT state payload fields that report charge/reserve window activity must reflect the corrected active-window semantics.
+
+## Non-functional Requirements
+- Backward compatibility: existing valid same-day configurations must continue to work without migration.
+- Safety / defaults: the change must not add any new path that writes Fronius Modbus registers outside the existing schedule decision flow.
+- Performance: the window check should remain simple local time arithmetic and avoid network or persistent storage dependencies.
+- Maintainability: prefer a shared helper for validation/evaluation so charge and reserve windows cannot drift in behavior.
+
+## Configuration Impact
+- New CLI flags: none.
+- New config keys (`config.yaml`): none.
+- New env vars: none.
+- Home Assistant add-on schema changes (`home-assistant/addons/sbam/config.json`): none.
+- Existing keys and flags affected by semantics only: `start_hr`, `end_hr`, `batt_reserve_start_hr`, `batt_reserve_end_hr`.
+
+## External Integrations Touched
+- Solcast: none.
+- Fronius Solar API: none.
+- Fronius Modbus registers: no register address or write-sequence changes; existing writes may occur during newly valid overnight windows only through the existing scheduler decision flow.
+- MQTT: state payload window-active booleans should report the corrected charge and reserve window status.
+
+## Acceptance Criteria
+- [ ] `start_hr: "22:00"` and `end_hr: "06:00"` are accepted as a valid schedule charge window.
+- [ ] A `22:00`-`06:00` window is active at `23:00` and `02:00` local time.
+- [ ] A `22:00`-`06:00` window is inactive at `12:00` local time.
+- [ ] Same-day windows such as `00:00`-`06:00` and `08:00`-`18:00` keep their existing behavior.
+- [ ] Invalid time strings still return validation errors.
+- [ ] Equal start and end times remain invalid.
+- [ ] Battery reserve windows support the same cross-midnight behavior as charge windows.
+- [ ] The change does not add or rename config keys, env vars, CLI flags, or Home Assistant add-on schema fields.
+
+## Test Strategy
+- Unit tests (`pkg/cmd`): cover `checkTimeRangeAt` or its successor for same-day, cross-midnight, boundary, outside-window, equal-time, and malformed-time cases.
+- Unit tests (`pkg/cmd`): cover schedule validation so cross-midnight charge and reserve windows are accepted while malformed and equal windows are rejected.
+- Unit tests (`pkg/cmd`): cover runner/MQTT payload window flags for cross-midnight charge and reserve windows if those flags depend on the same helper.
+- Expected cases: `22:00`-`06:00` active at `23:00` and `02:00`; same-day windows unchanged.
+- Edge cases: just before start, exactly at start, exactly at end, just after end, and equal start/end.
+- Failure cases: malformed `HH:MM` strings for charge and reserve windows.
+
+## Risks / Open Questions
+- RESOLVED: both charge and reserve windows are in scope.
+- RESOLVED: equal start and end times remain invalid.
+- RESOLVED: no new configuration surfaces are required.
+- Risk: validation currently checks ordering relationships between charge and reserve windows; those comparisons may need to be reinterpreted carefully for nested cross-midnight windows.
+- Risk: cron default-reset scheduling based on `end_hr` may need review so cross-midnight windows still reset defaults at the intended local end time.
+
+## References
+- [GitHub issue #116](https://github.com/atbore-phx/sbam/issues/116)
+- Related prior plan: [115-issue-fix-crontab-timezone-window](../115-issue-fix-crontab-timezone-window/115-issue-fix-crontab-timezone-window-PLAN.md)
+
+## Clarifications
+- 2026-05-16: Use slug `116-issue-feature-start-hr-and-end-hr-should-produce-a-cross-midnight-window`.
+- 2026-05-16: Apply cross-midnight support to both charge and reserve windows.
+- 2026-05-16: Preserve current invalid behavior for equal start and end times.
+- 2026-05-16: Do not add or rename configuration, environment, CLI, or Home Assistant schema fields.
+- 2026-05-16: Include acceptance examples for validation acceptance, active times on both sides of midnight, outside-window behavior, invalid strings, and same-day behavior.

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed schedule charge and reserve window evaluation so local-time cron ticks are not compared as UTC.
+- Added support for cross-midnight charge and reserve windows, for example 22:00-06:00.
 
 ## 2.0.0 - 2026-05-06
 

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -65,16 +65,16 @@ Before starting, open the Configuration tab and set options as needed.
 - **url**: Solcast forecast site address (replace <YOUR-SITE> with your identifier). Multiple addresses are supported (max 2), separated by comma.
 - **apikey**: Solcast API key.
 - **fronius_ip**: Fronius inverter LAN IP.
-- **start_hr**: Start time of the advantageous network operator rate (default 00:00).
-- **end_hr**: End time of the advantageous network operator rate (default 06:00).
+- **start_hr**: Start time of the advantageous network operator rate (default 00:00). Cross-midnight ranges are supported.
+- **end_hr**: End time of the advantageous network operator rate (default 06:00). Cross-midnight ranges are supported.
 - **crontab**: Schedule to run sbam (default 00 00-05 * * *).
 - **pw_consumption**: Daily electrical consumption in Wh (default 11000).
 - **max_charge**: Maximum grid charging power in W (default 3500).
 - **pw_lwt**: Hysteresis lower threshold offset in Wh to stop charging (default 0).
 - **pw_upt**: Hysteresis upper threshold offset in Wh to start charging (default 0).
 - **pw_batt_reserve**: Minimum battery capacity to maintain in Wh (default 4000).
-- **batt_reserve_start_hr**: Start time for reserve window (empty uses start_hr).
-- **batt_reserve_end_hr**: End time for reserve window (empty uses end_hr).
+- **batt_reserve_start_hr**: Start time for reserve window (empty uses start_hr). Uses the same cross-midnight behavior as the main window.
+- **batt_reserve_end_hr**: End time for reserve window (empty uses end_hr). Uses the same cross-midnight behavior as the main window.
 - **defaults**: At end of crontab cycle, reconfigure Fronius inverter to defaults.
 - **reset**: At add-on startup, reconfigure Fronius inverter to defaults.
 - **debug**: Increase log level.
@@ -92,6 +92,10 @@ Before starting, open the Configuration tab and set options as needed.
 - **mqtt_ha_discovery_prefix**: Home Assistant discovery root topic prefix (default homeassistant).
 
 Save the configuration after editing options.
+
+Example overnight configuration: `start_hr: 22:00` and `end_hr: 06:00`.
+Reserve windows can also cross midnight, for example `batt_reserve_start_hr: 23:00`
+and `batt_reserve_end_hr: 05:00`. Equal start and end values are invalid.
 
 ![sbam-conf](https://github.com/user-attachments/assets/d0eab452-7b77-4d2c-9b24-7ac44fd50b7a)
 

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -41,7 +41,13 @@ const (
 	const_mqtt_topic_prefix   = "sbam"
 	const_ha_discovery_prefix = "homeassistant"
 	const_mqtt_op_timeout     = 5 * time.Second
+	scheduleClockLayout       = "15:04"
 )
+
+type clockSegment struct {
+	startMinute int
+	endMinute   int
+}
 
 // froniusClient abstracts the subset of Fronius behavior used by the
 // scheduler. It's defined here so tests can inject a fake implementation
@@ -291,6 +297,87 @@ func isStartAfterEnd(start, end string) bool {
 	return startTime.After(endTime)
 }
 
+func parseScheduleClock(value, field string) (time.Time, error) {
+	parsed, err := time.Parse(scheduleClockLayout, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid %s %q: %w", field, value, err)
+	}
+
+	return parsed, nil
+}
+
+func validateScheduleWindow(startField, startValue, endField, endValue string) (time.Time, time.Time, error) {
+	startTime, err := parseScheduleClock(startValue, startField)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+
+	endTime, err := parseScheduleClock(endValue, endField)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+
+	if startTime.Equal(endTime) {
+		return time.Time{}, time.Time{}, fmt.Errorf("%s %q must not be equal to %s %q", startField, startValue, endField, endValue)
+	}
+
+	return startTime, endTime, nil
+}
+
+func isCrossMidnightWindow(startTime, endTime time.Time) bool {
+	return startTime.After(endTime)
+}
+
+func clockMinute(t time.Time) int {
+	return t.Hour()*60 + t.Minute()
+}
+
+func expandClockWindow(startMinute, endMinute int) []clockSegment {
+	if startMinute < endMinute {
+		return []clockSegment{{startMinute: startMinute, endMinute: endMinute}}
+	}
+
+	return []clockSegment{
+		{startMinute: startMinute, endMinute: 1439},
+		{startMinute: 0, endMinute: endMinute},
+	}
+}
+
+func segmentContains(outer, inner clockSegment) bool {
+	return outer.startMinute <= inner.startMinute && inner.endMinute <= outer.endMinute
+}
+
+func isWindowContainedIn(innerStart, innerEnd, outerStart, outerEnd string) (bool, error) {
+	innerStartTime, innerEndTime, err := validateScheduleWindow("inner_start", innerStart, "inner_end", innerEnd)
+	if err != nil {
+		return false, err
+	}
+
+	outerStartTime, outerEndTime, err := validateScheduleWindow("outer_start", outerStart, "outer_end", outerEnd)
+	if err != nil {
+		return false, err
+	}
+
+	innerSegments := expandClockWindow(clockMinute(innerStartTime), clockMinute(innerEndTime))
+	outerSegments := expandClockWindow(clockMinute(outerStartTime), clockMinute(outerEndTime))
+
+	for _, innerSeg := range innerSegments {
+		covered := false
+		for _, outerSeg := range outerSegments {
+			if segmentContains(outerSeg, innerSeg) {
+				covered = true
+				break
+			}
+		}
+
+		if !covered {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 // CheckTimeRange returns true when the current local time is within the
 // inclusive interval between `start_hr` and `end_hr` (both in "15:04" format).
 //
@@ -322,8 +409,7 @@ func checkScheduleschedule(crontab, apiKey, url, fronius_ip string, pw_consumpti
 	} else if len(strings.TrimSpace(url)) == 0 {
 		err := errors.New("the --url flag must be set")
 		return err
-	} else if !isStartBeforeEnd(start_hr, end_hr) {
-		err := errors.New("start_hr: " + start_hr + " is not before end_hr: " + end_hr)
+	} else if _, _, err := validateScheduleWindow("start_hr", start_hr, "end_hr", end_hr); err != nil {
 		return err
 	} else if len(crontab) == 0 {
 		fmt.Printf("the --crontab must be set")
@@ -344,14 +430,12 @@ func checkScheduleschedule(crontab, apiKey, url, fronius_ip string, pw_consumpti
 	} else if pw_batt_reserve < 0 {
 		err := errors.New("pw_batt_reserve must to be float > 0")
 		return err
-	} else if !isStartBeforeEnd(batt_reserve_start_hr, batt_reserve_end_hr) {
-		err := errors.New("batt_reserve_start_hr: " + batt_reserve_start_hr + " is not before batt_reserve_end_hr: " + batt_reserve_end_hr)
+	} else if _, _, err := validateScheduleWindow("batt_reserve_start_hr", batt_reserve_start_hr, "batt_reserve_end_hr", batt_reserve_end_hr); err != nil {
 		return err
-	} else if isStartAfterEnd(start_hr, batt_reserve_start_hr) {
-		err := errors.New("start_hr: " + start_hr + " is not before or equal batt_reserve_start_hr: " + batt_reserve_start_hr)
+	} else if contained, err := isWindowContainedIn(batt_reserve_start_hr, batt_reserve_end_hr, start_hr, end_hr); err != nil {
 		return err
-	} else if isStartAfterEnd(batt_reserve_end_hr, end_hr) {
-		err := errors.New("batt_reserve_end_hr: " + batt_reserve_end_hr + " is not before or equal end_hr: " + end_hr)
+	} else if !contained {
+		err := errors.New("batt_reserve_start_hr/batt_reserve_end_hr must be contained within start_hr/end_hr")
 		return err
 	} else if (s_cache_time < 0) || (s_cache_time > 86400) {
 		err := errors.New("The cache_time must be between 0 and 86400 seconds")

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -428,19 +428,19 @@ func (r *Runner) pauseStateAt(now time.Time) (bool, *time.Time) {
 }
 
 func checkTimeRangeAt(now time.Time, startHR, endHR string) (bool, error) {
-	layout := "15:04"
-	startTime, err := time.Parse(layout, startHR)
+	startTime, endTime, err := validateScheduleWindow("start time", startHR, "end time", endHR)
 	if err != nil {
-		return false, fmt.Errorf("invalid start time %q: %w", startHR, err)
-	}
-
-	endTime, err := time.Parse(layout, endHR)
-	if err != nil {
-		return false, fmt.Errorf("invalid end time %q: %w", endHR, err)
+		return false, err
 	}
 
 	startAt := time.Date(now.Year(), now.Month(), now.Day(), startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
 	endAt := time.Date(now.Year(), now.Month(), now.Day(), endTime.Hour(), endTime.Minute(), 0, 0, now.Location())
+
+	if isCrossMidnightWindow(startTime, endTime) {
+		inRange := (now.After(startAt) || now.Equal(startAt)) || (now.Before(endAt) || now.Equal(endAt))
+		return inRange, nil
+	}
+
 	inRange := (now.After(startAt) || now.Equal(startAt)) && (now.Before(endAt) || now.Equal(endAt))
 	return inRange, nil
 }

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -404,29 +404,166 @@ func TestRunner_NewCommandPayloadUsesLocalWallClockWindow(t *testing.T) {
 	}
 }
 
+func TestRunner_NewCommandPayloadUsesLocalWallClockWindowCrossMidnight(t *testing.T) {
+	loc := time.FixedZone("CEST", 2*60*60)
+
+	tests := []struct {
+		name         string
+		now          time.Time
+		wantInCharge bool
+		wantReserve  bool
+	}{
+		{
+			name:         "23:00 local inside cross-midnight windows",
+			now:          time.Date(2026, time.May, 16, 23, 0, 0, 0, loc),
+			wantInCharge: true,
+			wantReserve:  true,
+		},
+		{
+			name:         "02:00 local inside cross-midnight windows",
+			now:          time.Date(2026, time.May, 16, 2, 0, 0, 0, loc),
+			wantInCharge: true,
+			wantReserve:  true,
+		},
+		{
+			name:         "12:00 local outside cross-midnight windows",
+			now:          time.Date(2026, time.May, 16, 12, 0, 0, 0, loc),
+			wantInCharge: false,
+			wantReserve:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewRunner(RunnerConfig{
+				StartHR:            "22:00",
+				EndHR:              "06:00",
+				BattReserveStartHR: "23:00",
+				BattReserveEndHR:   "05:00",
+				Now: func() time.Time {
+					return tt.now
+				},
+			}, nil)
+
+			payload := runner.newCommandPayload("decision", "reason", runner.now())
+
+			require.NotNil(t, payload.ChargeWindowActive)
+			require.NotNil(t, payload.ReserveWindowActive)
+			assert.Equal(t, tt.wantInCharge, *payload.ChargeWindowActive)
+			assert.Equal(t, tt.wantReserve, *payload.ReserveWindowActive)
+		})
+	}
+}
+
 func TestCheckTimeRangeAt_BoundariesAndErrors(t *testing.T) {
 	loc := time.FixedZone("UTC+1", 1*60*60)
 
-	startBoundary := time.Date(2026, time.May, 16, 0, 0, 0, 0, loc)
-	inRange, err := checkTimeRangeAt(startBoundary, "00:00", "06:00")
-	require.NoError(t, err)
-	assert.True(t, inRange)
+	tests := []struct {
+		name      string
+		now       time.Time
+		startHR   string
+		endHR     string
+		want      bool
+		errSubstr string
+	}{
+		{
+			name:    "same-day start boundary inclusive",
+			now:     time.Date(2026, time.May, 16, 0, 0, 0, 0, loc),
+			startHR: "00:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:    "same-day end boundary inclusive",
+			now:     time.Date(2026, time.May, 16, 6, 0, 0, 0, loc),
+			startHR: "00:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:    "same-day after end inactive",
+			now:     time.Date(2026, time.May, 16, 6, 1, 0, 0, loc),
+			startHR: "00:00",
+			endHR:   "06:00",
+			want:    false,
+		},
+		{
+			name:    "cross-midnight before midnight active",
+			now:     time.Date(2026, time.May, 16, 23, 0, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:    "cross-midnight after midnight active",
+			now:     time.Date(2026, time.May, 16, 2, 0, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:    "cross-midnight daytime inactive",
+			now:     time.Date(2026, time.May, 16, 12, 0, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    false,
+		},
+		{
+			name:    "cross-midnight just before start inactive",
+			now:     time.Date(2026, time.May, 16, 21, 59, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    false,
+		},
+		{
+			name:    "cross-midnight exact start active",
+			now:     time.Date(2026, time.May, 16, 22, 0, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:    "cross-midnight exact end active",
+			now:     time.Date(2026, time.May, 16, 6, 0, 0, 0, loc),
+			startHR: "22:00",
+			endHR:   "06:00",
+			want:    true,
+		},
+		{
+			name:      "invalid start format",
+			now:       time.Date(2026, time.May, 16, 0, 0, 0, 0, loc),
+			startHR:   "bad",
+			endHR:     "06:00",
+			errSubstr: "invalid start time",
+		},
+		{
+			name:      "invalid end format",
+			now:       time.Date(2026, time.May, 16, 0, 0, 0, 0, loc),
+			startHR:   "00:00",
+			endHR:     "bad",
+			errSubstr: "invalid end time",
+		},
+		{
+			name:      "equal start and end rejected",
+			now:       time.Date(2026, time.May, 16, 0, 0, 0, 0, loc),
+			startHR:   "06:00",
+			endHR:     "06:00",
+			errSubstr: "must not be equal",
+		},
+	}
 
-	endBoundary := time.Date(2026, time.May, 16, 6, 0, 0, 0, loc)
-	inRange, err = checkTimeRangeAt(endBoundary, "00:00", "06:00")
-	require.NoError(t, err)
-	assert.True(t, inRange)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			inRange, err := checkTimeRangeAt(tt.now, tt.startHR, tt.endHR)
+			if tt.errSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
 
-	afterEnd := time.Date(2026, time.May, 16, 6, 1, 0, 0, loc)
-	inRange, err = checkTimeRangeAt(afterEnd, "00:00", "06:00")
-	require.NoError(t, err)
-	assert.False(t, inRange)
-
-	_, err = checkTimeRangeAt(startBoundary, "bad", "06:00")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid start time")
-
-	_, err = checkTimeRangeAt(startBoundary, "00:00", "bad")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid end time")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, inRange)
+		})
+	}
 }

--- a/pkg/cmd/schedule_validation_test.go
+++ b/pkg/cmd/schedule_validation_test.go
@@ -124,9 +124,19 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 			errSubstr: "--url",
 		},
 		{
-			name:      "start must be before end",
-			prepare:   func(a *scheduleValidationArgs) { a.startHr = "12:00"; a.endHr = "11:00" },
-			errSubstr: "is not before end_hr",
+			name:      "start and end cannot be equal",
+			prepare:   func(a *scheduleValidationArgs) { a.startHr = "12:00"; a.endHr = "12:00" },
+			errSubstr: "must not be equal",
+		},
+		{
+			name:      "invalid start format",
+			prepare:   func(a *scheduleValidationArgs) { a.startHr = "bad" },
+			errSubstr: "invalid start_hr",
+		},
+		{
+			name:      "invalid end format",
+			prepare:   func(a *scheduleValidationArgs) { a.endHr = "bad" },
+			errSubstr: "invalid end_hr",
 		},
 		{
 			name:      "missing crontab",
@@ -161,22 +171,28 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 			errSubstr: "pw_batt_reserve",
 		},
 		{
-			name:      "reserve range must be increasing",
+			name:      "reserve start and end cannot be equal",
 			prepare:   func(a *scheduleValidationArgs) {},
-			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "07:00", "06:00", 0, 0, 0) },
-			errSubstr: "batt_reserve_start_hr",
+			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "06:00", "06:00", 0, 0, 0) },
+			errSubstr: "must not be equal",
 		},
 		{
-			name:      "start must be before reserve start",
-			prepare:   func(a *scheduleValidationArgs) { a.startHr = "07:00" },
-			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "05:00", "06:00", 0, 0, 0) },
-			errSubstr: "start_hr",
+			name:      "invalid reserve start format",
+			prepare:   func(a *scheduleValidationArgs) {},
+			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "bad", "06:00", 0, 0, 0) },
+			errSubstr: "invalid batt_reserve_start_hr",
 		},
 		{
-			name:      "reserve end must be before end",
-			prepare:   func(a *scheduleValidationArgs) { a.endHr = "06:30" },
-			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "05:00", "07:00", 0, 0, 0) },
-			errSubstr: "batt_reserve_end_hr",
+			name:      "invalid reserve end format",
+			prepare:   func(a *scheduleValidationArgs) {},
+			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "05:00", "bad", 0, 0, 0) },
+			errSubstr: "invalid batt_reserve_end_hr",
+		},
+		{
+			name:      "reserve window must be contained in charge window",
+			prepare:   func(a *scheduleValidationArgs) { a.startHr = "22:00"; a.endHr = "06:00" },
+			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "02:00", "08:00", 0, 0, 0) },
+			errSubstr: "must be contained",
 		},
 		{
 			name:      "cache_time upper bound",
@@ -218,6 +234,101 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errSubstr)
+		})
+	}
+}
+
+func TestCheckScheduleScheduleCrossMidnightChargeWindowValid(t *testing.T) {
+	withScheduleValidationGlobals(t, "23:00", "05:00", 0, 0, 0)
+	args := validScheduleValidationArgs()
+	args.startHr = "22:00"
+	args.endHr = "06:00"
+
+	err := checkScheduleschedule(
+		args.crontab,
+		args.apiKey,
+		args.url,
+		args.froniusIP,
+		args.pwConsumption,
+		args.maxCharge,
+		args.pwBattReserve,
+		args.startHr,
+		args.endHr,
+	)
+
+	require.NoError(t, err)
+}
+
+func TestCheckScheduleScheduleReserveWindowContainment(t *testing.T) {
+	tests := []struct {
+		name         string
+		startHr      string
+		endHr        string
+		reserveStart string
+		reserveEnd   string
+		wantErr      bool
+	}{
+		{
+			name:         "cross-midnight reserve contained",
+			startHr:      "22:00",
+			endHr:        "06:00",
+			reserveStart: "23:00",
+			reserveEnd:   "05:00",
+			wantErr:      false,
+		},
+		{
+			name:         "same-day reserve segment contained in cross-midnight outer",
+			startHr:      "22:00",
+			endHr:        "06:00",
+			reserveStart: "02:00",
+			reserveEnd:   "05:00",
+			wantErr:      false,
+		},
+		{
+			name:         "reserve exceeds cross-midnight outer end",
+			startHr:      "22:00",
+			endHr:        "06:00",
+			reserveStart: "02:00",
+			reserveEnd:   "08:00",
+			wantErr:      true,
+		},
+		{
+			name:         "cross-midnight reserve outside same-day outer",
+			startHr:      "08:00",
+			endHr:        "18:00",
+			reserveStart: "17:00",
+			reserveEnd:   "07:00",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			withScheduleValidationGlobals(t, tt.reserveStart, tt.reserveEnd, 0, 0, 0)
+			args := validScheduleValidationArgs()
+			args.startHr = tt.startHr
+			args.endHr = tt.endHr
+
+			err := checkScheduleschedule(
+				args.crontab,
+				args.apiKey,
+				args.url,
+				args.froniusIP,
+				args.pwConsumption,
+				args.maxCharge,
+				args.pwBattReserve,
+				args.startHr,
+				args.endHr,
+			)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "must be contained")
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Implements cross-midnight windows for `start_hr`/`end_hr` and `batt_reserve_*` windows. Tests and docs updated. Closes #116.