### PR TITLE
docs(mqtt): document MQTT feed & HA discovery (#91)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,11 @@ Use the following structure and feel free to add, modify and improve as needed:
   prompts/                    - Copilot workflow prompts (`generate-plan-*`, `implement-plan`)
   workflows/                  - CI/CD workflow definitions
 
+docs/
+  prereq.md                   - Prerequisites required to run sbam
+  mqtt.md                     - Detailed MQTT feed and Home Assistant discovery documentation
+  vibe/                       - Contributor workflow docs for TASK/PLAN prompt usage
+
 main.go                      # Entry point, version vars, delegates to pkg/cmd
 main_test.go                 # CLI-level tests
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Sbam is available as an add-on for HAOS (Home Assistant OS).
 
 follow this guide to install and configure in HAOS: [link](home-assistant/addons/sbam/DOCS.md)
 
+### MQTT Feed
+----
+sbam can publish schedule telemetry and accept control commands over MQTT when
+`mqtt_enabled=true`.
+
+For full setup, topic mapping, payload schemas, command examples, and migration
+details, see [MQTT documentation](docs/mqtt.md).
+
+
 ### Stand Alone:
 ----
 **sbam** can be run via cli with the following parameters:
@@ -209,24 +218,4 @@ Configuration values are resolved with the following precedence (highest first):
 2. Environment variable (e.g. `URL=http://example/`)
 3. `config.yaml` in the working directory
 4. Built-in default
-
-#### MQTT and Home Assistant discovery
-
-When `mqtt_enabled=true`, `schedule` publishes state updates to MQTT:
-
-- `sbam/state`
-- `sbam/availability`
-- `sbam/error`
-
-Use `mqtt_topic_prefix` to change `sbam` to a site-specific path.
-
-When `mqtt_ha_discovery=true`, sbam also publishes Home Assistant discovery payloads
-under `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config`.
-Defaults:
-
-- `mqtt_topic_prefix=sbam`
-- `mqtt_ha_discovery_prefix=homeassistant`
-
-sbam subscribes to `homeassistant/status` and republishes discovery/state when
-Home Assistant comes online.
 

--- a/docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-PLAN.md
+++ b/docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-PLAN.md
@@ -1,41 +1,278 @@
 # PLAN: MQTT docs and migration note
 
-> Feature slug: `91-issue-docs-mqtt`  
-> TASK: [91-issue-docs-mqtt-TASK.md](91-issue-docs-mqtt-TASK.md)  
-> Issue: https://github.com/atbore-phx/sbam/issues/91  
-> Parent issue: https://github.com/atbore-phx/sbam/issues/64  
-> Reconciled: 2026-05-10
+> Date: 2026-05-17
+> Feature slug: `91-issue-docs-mqtt`
+> TASK: [91-issue-docs-mqtt-TASK.md](91-issue-docs-mqtt-TASK.md)
+> Issue: https://github.com/atbore-phx/sbam/issues/91
+> Parent issue: https://github.com/atbore-phx/sbam/issues/64
 
-## 1. Current State
+## 1. Task Analysis
 
-`README.md` has a short MQTT/Home Assistant discovery section and the schedule help lists MQTT flags. `.github/copilot-instructions.md` already lists `pkg/mqtt` source/test files, but runner files do not exist yet.
+Issue #91 is a documentation-polish task for the v2.0.0 MQTT feed introduced under #64. The implementation must update user-facing documentation so standalone, Docker, and Home Assistant users can enable MQTT intentionally, understand topic and payload contracts, publish supported commands, and upgrade from v1.x without surprises.
 
-Missing: complete topic map, payload schemas, command examples, HA discovery explanation, and migration callout.
+Goals:
 
-## 2. Implementation Steps
+- Expand the README MQTT section with quick-start configuration, topic map, payload examples, command examples, Home Assistant discovery notes, and a migration callout.
+- Verify `.github/copilot-instructions.md` Project Structure against current MQTT and schedule-runner files; update it only if stale.
+- Keep the task documentation-only unless a stale documentation surface forces a small docs edit outside README.
 
-1. Expand README with an `MQTT feed` section or enrich the existing section.
-2. Add enablement examples for CLI flags, env vars, and YAML.
-3. Add topic map:
-   - `<prefix>/availability`
-   - `<prefix>/state`
-   - `<prefix>/error`
-   - `<prefix>/cmd/<name>`
-   - `<prefix>/cmd/<name>/ack`
-   - `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config`
-4. Add JSON examples for state and ack payloads.
-5. Add command examples with `mosquitto_pub` for all implemented v2.0 commands.
-6. Add HA Discovery note: retained discovery payloads, device grouping, and `homeassistant/status=online` re-publication.
-7. Add migration note from v1.x and list the twelve standalone MQTT keys.
-8. Update `.github/copilot-instructions.md` Project Structure after #87/#88 create runner files.
+Non-goals:
 
-## 3. Test Plan
+- Do not change MQTT runtime behavior, topic helpers, payload structs, command parsing, scheduler behavior, Home Assistant discovery generation, or add-on schema.
+- Do not implement `set_reserve`; document that it is deferred beyond v2.0.0.
+- Do not perform the Home Assistant add-on DOCS cleanup tracked by #89.
 
-- Cross-check README topic names against `pkg/mqtt/client.go`, `discovery.go`, and `commands.go`.
-- Cross-check JSON examples against `mqtt.StatePayload` and `mqtt.AckPayload` structs.
-- Render/preview README markdown for table and code block correctness.
-- Run `make test` only if documentation changes are bundled with source changes.
+Acceptance criteria copied from the TASK:
 
-## 4. Validation
+- README topic map matches `pkg/mqtt` helper topics.
+- README state, error, and ack payload examples match `mqtt.StatePayload`, `mqtt.ErrorPayload`, and `mqtt.AckPayload` JSON fields.
+- Command examples use implemented command names only and include `mosquitto_pub` examples for `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
+- README notes that `set_reserve` is deferred beyond v2.0.0.
+- Migration note explains `mqtt_enabled=false` backward compatibility and lists the twelve standalone MQTT keys.
+- README markdown tables and fenced code blocks render correctly.
 
-No source validation is required for documentation-only changes, but the final PR should mention the cross-checks performed.
+## 2. Current State
+
+- [README.md](../../../README.md) already lists the `schedule` command MQTT flags and has a short `MQTT and Home Assistant discovery` section. That section currently names `sbam/state`, `sbam/availability`, `sbam/error`, default prefixes, and `homeassistant/status`, but lacks a topic map table, payload examples, command examples, and migration callout.
+- [config.yaml](../../../config.yaml) already contains twelve standalone `mqtt_*` keys: `mqtt_enabled`, `mqtt_broker`, `mqtt_client_id`, `mqtt_username`, `mqtt_password`, `mqtt_tls_ca_file`, `mqtt_tls_client_cert`, `mqtt_tls_client_cert_key`, `mqtt_tls_insecure_skip`, `mqtt_topic_prefix`, `mqtt_ha_discovery`, and `mqtt_ha_discovery_prefix`.
+- [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) wires all twelve MQTT CLI flags into Viper-backed config and builds `mqtt.Config` for the runner.
+- [pkg/cmd/precedence_test.go](../../../pkg/cmd/precedence_test.go) covers MQTT config precedence for flag > env > yaml.
+- [pkg/mqtt/types.go](../../../pkg/mqtt/types.go) defines the public payload structs and command intent constants that README examples must mirror.
+- [pkg/mqtt/client.go](../../../pkg/mqtt/client.go) defines the topic helper behavior: default prefix `sbam`, default Home Assistant discovery prefix `homeassistant`, runtime topics, command filter, and discovery config topic shape.
+- [pkg/mqtt/publisher.go](../../../pkg/mqtt/publisher.go) publishes state retained with QoS 1, error non-retained with QoS 1, availability retained with QoS 1, and discovery retained with QoS 1.
+- [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go) builds 18 Home Assistant entities: ten sensors, three binary sensors, and five buttons.
+- [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go) implements command parsing and ack publishing for `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`; `set_reserve` exists as an intent constant but is not accepted by the parser.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) routes accepted intents, publishes acks after execution, publishes errors for rejected execution paths, and no longer has latest-state republish caching.
+- [.github/copilot-instructions.md](../../../.github/copilot-instructions.md) already lists `pkg/mqtt` files and current `pkg/cmd` runner source/test files. No Project Structure update is expected unless this changes before implementation.
+- [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json) exposes only eight MQTT add-on options and omits TLS options; that gap belongs to #89 and should be mentioned only as out of scope if relevant.
+
+## 3. Target Architecture
+
+This is a documentation-only update. The implementation should treat the existing code as the source of truth and make README explain it.
+
+Affected files:
+
+- [README.md](../../../README.md): main implementation target.
+- [.github/copilot-instructions.md](../../../.github/copilot-instructions.md): verification target only; edit only if Project Structure is stale at implementation time.
+- [docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-TASK.md](91-issue-docs-mqtt-TASK.md) and this PLAN: already prepared for `/implement-plan` and should not need further change during implementation unless facts change.
+
+Documentation data flow:
+
+```mermaid
+flowchart LR
+  Config[CLI/env/config.yaml mqtt_* keys] --> Schedule[pkg/cmd schedule]
+  Schedule --> Runner[pkg/cmd Runner]
+  Runner --> Publisher[pkg/mqtt publisher]
+  Publisher --> Topics[MQTT topics under prefix]
+  Topics --> README[README examples and topic map]
+  Discovery[pkg/mqtt discovery] --> README
+  Commands[pkg/mqtt commands] --> README
+```
+
+## 4. Dependency Choices
+
+No new Go modules, tools, or runtime dependencies are required.
+
+Use existing code and tests as references:
+
+- MQTT topic/payload behavior: [pkg/mqtt](../../../pkg/mqtt)
+- CLI/config behavior: [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go)
+- Precedence behavior: [pkg/cmd/precedence_test.go](../../../pkg/cmd/precedence_test.go)
+- Documentation target: [README.md](../../../README.md)
+
+## 5. Configuration Changes
+
+No new configuration is introduced by this task. Document the existing configuration surface accurately.
+
+Precedence remains: CLI flag > environment variable > `config.yaml` > built-in default.
+
+Document these keys, env vars, flags, and defaults:
+
+| Config key | Env var | CLI flag | Default / note |
+| --- | --- | --- | --- |
+| `mqtt_enabled` | `MQTT_ENABLED` | `--mqtt_enabled` | `false`; MQTT is opt-in |
+| `mqtt_broker` | `MQTT_BROKER` | `--mqtt_broker` | Empty; required when enabled |
+| `mqtt_client_id` | `MQTT_CLIENT_ID` | `--mqtt_client_id` | Empty; runtime generates a default client ID |
+| `mqtt_username` | `MQTT_USERNAME` | `--mqtt_username` | Empty |
+| `mqtt_password` | `MQTT_PASSWORD` | `--mqtt_password` | Empty; secret |
+| `mqtt_tls_ca_file` | `MQTT_TLS_CA_FILE` | `--mqtt_tls_ca_file` | Empty; TLS broker CA file |
+| `mqtt_tls_client_cert` | `MQTT_TLS_CLIENT_CERT` | `--mqtt_tls_client_cert` | Empty; client cert file |
+| `mqtt_tls_client_cert_key` | `MQTT_TLS_CLIENT_CERT_KEY` | `--mqtt_tls_client_cert_key` | Empty; client key file, secret-sensitive |
+| `mqtt_tls_insecure_skip` | `MQTT_TLS_INSECURE_SKIP` | `--mqtt_tls_insecure_skip` | `false`; skips TLS verification when true |
+| `mqtt_topic_prefix` | `MQTT_TOPIC_PREFIX` | `--mqtt_topic_prefix` | `sbam` |
+| `mqtt_ha_discovery` | `MQTT_HA_DISCOVERY` | `--mqtt_ha_discovery` | `true` |
+| `mqtt_ha_discovery_prefix` | `MQTT_HA_DISCOVERY_PREFIX` | `--mqtt_ha_discovery_prefix` | `homeassistant` |
+
+Home Assistant add-on schema:
+
+- Do not change [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json) for #91.
+- If README mentions add-on options, keep it high level: the add-on exposes MQTT options and requests the Home Assistant MQTT service; TLS option parity belongs to #89.
+
+## 6. Implementation Blueprint
+
+1. Target: [README.md](../../../README.md)
+   - Replace or expand the existing `MQTT and Home Assistant discovery` section.
+   - Keep it near the existing config/env documentation so users see precedence and examples together.
+   - Rationale: README is the user-facing release documentation requested by issue #91.
+
+2. Target: [README.md](../../../README.md)
+   - Add a quick-start subsection with one compact env/CLI example and one YAML snippet.
+   - Include `mqtt_enabled=true` and `MQTT_BROKER=tcp://127.0.0.1:1883` in the quick start.
+   - Mention that `mqtt_broker` is required when MQTT is enabled.
+   - Rationale: The issue explicitly asks for enablement guidance and an example broker URL.
+
+3. Target: [README.md](../../../README.md)
+   - Add a topic map table using `<prefix>` and default `sbam` examples:
+     - `<prefix>/availability`: retained QoS 1, payload `online` or `offline`.
+     - `<prefix>/state`: retained QoS 1, `StatePayload` JSON.
+     - `<prefix>/error`: non-retained QoS 1, `ErrorPayload` JSON.
+     - `<prefix>/cmd/<name>`: subscribed command topic filter is `<prefix>/cmd/+`.
+     - `<prefix>/cmd/<name>/ack`: non-retained QoS 1 ack payload.
+     - `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config`: retained QoS 1 discovery config.
+   - Mention default prefixes `mqtt_topic_prefix=sbam` and `mqtt_ha_discovery_prefix=homeassistant`.
+   - Rationale: Mirrors [pkg/mqtt/client.go](../../../pkg/mqtt/client.go), [pkg/mqtt/publisher.go](../../../pkg/mqtt/publisher.go), and [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+
+4. Target: [README.md](../../../README.md)
+   - Add representative state payload JSON with these exact field names: `battery_soc_pct`, `battery_capacity_wh`, `forecast_today_wh`, `pw_net_wh`, `charge_pct`, `last_decision`, `last_decision_reason`, `charge_window_active`, `batt_reserve_window_active`, `paused`, `next_run`, and `ts`.
+   - Use realistic example values and `null` only where pointer-backed fields may be absent.
+   - Rationale: Mirrors `mqtt.StatePayload` in [pkg/mqtt/types.go](../../../pkg/mqtt/types.go).
+
+5. Target: [README.md](../../../README.md)
+   - Add error payload JSON with `error`, optional `source`, and `ts`.
+   - Add accepted and rejected ack payload examples with `ts`, `command`, `accepted`, and optional `error`.
+   - Rationale: Mirrors `mqtt.ErrorPayload` and `mqtt.AckPayload` in [pkg/mqtt/types.go](../../../pkg/mqtt/types.go), plus rejected ack behavior in [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go).
+
+6. Target: [README.md](../../../README.md)
+   - Add `mosquitto_pub` examples for all implemented commands:
+     - `trigger_now`: empty object `{}` or empty payload.
+     - `pause`: `{}` for indefinite pause and an example `{"until":"1h"}` or RFC3339 timestamp.
+     - `resume`: `{}`.
+     - `force_charge`: `{"target_pct":80,"duration_s":3600}`.
+     - `set_defaults`: `{}`.
+   - Document constraints: command payload max is 4096 bytes; `force_charge.target_pct` is 1..100; `force_charge.duration_s` is optional and 0..86400; `pause.until` accepts RFC3339 or Go duration and must be in the future.
+   - Explicitly state that `set_reserve` is deferred beyond v2.0.0 and should not be documented as a usable command.
+   - Rationale: Mirrors [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go) and [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go).
+
+7. Target: [README.md](../../../README.md)
+   - Add Home Assistant discovery behavior:
+     - Discovery is enabled by default when MQTT is enabled unless `mqtt_ha_discovery=false`.
+     - Discovery config topics are retained.
+     - Device grouping uses a stable `sbam_` identifier derived from Fronius IP, client ID, or topic prefix.
+     - Discovery entities currently include sensors, binary sensors, and buttons for implemented commands.
+     - The app subscribes to `homeassistant/status` and republishes discovery when Home Assistant publishes `online`.
+   - Do not claim latest state is re-published on HA status; current code republishes discovery only.
+   - Rationale: Mirrors [pkg/mqtt/init.go](../../../pkg/mqtt/init.go) and [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+
+8. Target: [README.md](../../../README.md)
+   - Add `Migration from v1.x` callout:
+     - v2.0.0 remains backward compatible when `mqtt_enabled=false`.
+     - Existing users do not need to change config unless opting into MQTT.
+     - List the twelve standalone MQTT keys and mention they can be set via CLI flags, env vars, or `config.yaml`.
+     - Note that Home Assistant users get auto-discovered entities when MQTT and discovery are enabled, with no manual YAML needed for those entities.
+   - Rationale: Direct issue #91 requirement.
+
+9. Target: [.github/copilot-instructions.md](../../../.github/copilot-instructions.md)
+   - Verify Project Structure still lists `pkg/mqtt/`, `pkg/cmd/schedule_runner.go`, `pkg/cmd/schedule_runner_test.go`, `pkg/cmd/schedule_mqtt_wiring_test.go`, and `pkg/cmd/schedule_lifecycle_test.go`.
+   - Do not add `pkg/cmd/intent.go` unless the file exists by implementation time.
+   - Based on current research, no edit is expected because the Project Structure is already current.
+   - Rationale: Issue body requested a structure update, but current repository state has already caught up.
+
+10. Target: [docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-PLAN.md](91-issue-docs-mqtt-PLAN.md)
+    - If implementation discovers a changed source-of-truth fact, update this PLAN with a short revision note before continuing.
+    - Rationale: Keeps the implementation artifact honest without expanding scope.
+
+## 7. Test Plan
+
+No source tests are required for the expected documentation-only implementation. If source files are changed, run the relevant automated tests listed below.
+
+README expected case:
+
+- Cross-check topic names against [pkg/mqtt/client.go](../../../pkg/mqtt/client.go) and retained/QoS behavior against [pkg/mqtt/publisher.go](../../../pkg/mqtt/publisher.go).
+- Cross-check state, error, and ack JSON fields against [pkg/mqtt/types.go](../../../pkg/mqtt/types.go).
+- Cross-check command names, payload constraints, and ack examples against [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go).
+- Cross-check Home Assistant entity and discovery behavior against [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go) and [pkg/mqtt/init.go](../../../pkg/mqtt/init.go).
+
+Edge cases:
+
+- Prefix customization: ensure the topic map uses `<prefix>` and explains the default `sbam` prefix rather than hard-coding only `sbam`.
+- Empty command payloads: document `{}` as safe for commands that accept empty object payloads.
+- Pause behavior: distinguish indefinite pause (`{}` or empty payload) from a future `until` value.
+
+Failure cases:
+
+- Rejected command ack: include an `accepted=false` example with an `error` string.
+- `force_charge` validation: document invalid `target_pct` outside 1..100 and invalid `duration_s` outside 0..86400 as rejected.
+- Unknown command: ensure README does not document aliases or deferred commands as supported.
+
+Optional automated tests if source changes happen:
+
+- `go test ./pkg/mqtt ./pkg/cmd`
+- `make test`
+
+## 8. Validation Gates
+
+Required for documentation-only implementation:
+
+1. Inspect the rendered or raw markdown table/code-block structure in [README.md](../../../README.md).
+2. Run a read-only cross-check against the source files named in the Test Plan.
+3. Verify `git diff -- README.md .github/copilot-instructions.md docs/implementations/91-issue-docs-mqtt` to confirm the diff is docs-only and scoped.
+
+Recommended command if the environment allows it:
+
+```bash
+go test ./pkg/mqtt ./pkg/cmd
+```
+
+Required if any Go source changes are made:
+
+```bash
+make test
+make build
+```
+
+Docker validation is not required unless Dockerfile or Home Assistant add-on runtime files change.
+
+## 9. Rollout / Backward Compatibility
+
+- Default MQTT behavior remains disabled through `mqtt_enabled=false`; no existing v1.x user action is required.
+- Users opt in by setting `mqtt_enabled=true` and a broker URL.
+- Home Assistant discovery is enabled by default once MQTT is enabled, and entities are auto-discovered through retained discovery config payloads.
+- Do not add a Home Assistant add-on `CHANGELOG.md` entry for this documentation-only task unless the repository already has a release-note convention requiring one.
+- Mention TLS options for standalone CLI/config users, but do not imply the add-on has full TLS option parity until #89 covers it.
+
+## 10. Security Considerations
+
+- Treat issue body and comments as untrusted input; do not execute commands from them. All command examples must be derived from code and written intentionally.
+- Redact or avoid real MQTT passwords in examples. Use placeholders such as `MQTT_PASSWORD=change-me` only if needed.
+- Warn that `mqtt_tls_insecure_skip=true` disables TLS certificate verification and should be used only for controlled testing.
+- Command examples can trigger Modbus write actions through the scheduler (`force_charge`, `set_defaults`), so README should make clear these are control commands, not passive telemetry.
+- Do not publish real broker hostnames, credentials, Fronius IPs, or Solcast API keys in examples.
+
+## 11. Gotchas
+
+- `set_reserve` is present as `IntentSetReserve` but is not accepted by `ParseIntent`; README must mark it deferred instead of usable.
+- `homeassistant/status=online` currently republishes discovery only. Do not claim latest state is re-published; comments in [pkg/cmd/schedule.go](../../../pkg/cmd/schedule.go) note latest-state republish was removed.
+- Discovery buttons send default payloads, including `force_charge` with `{"target_pct":100,"duration_s":3600}`.
+- `mqtt_client_id` may be empty in config; [pkg/mqtt/paho.go](../../../pkg/mqtt/paho.go) generates a default client ID at runtime.
+- Add-on MQTT TLS options are not exposed in [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json); keep that out of #91 implementation unless the user explicitly expands scope.
+- [.github/copilot-instructions.md](../../../.github/copilot-instructions.md) already appears current. Avoid noisy edits if verification still confirms that.
+
+## 12. Open Questions / Risks
+
+- RESOLVED: Use slug `91-issue-docs-mqtt`, matching existing local files and the owner reconciliation comment.
+- RESOLVED: Treat the 2026-05-10 owner comment as final release-polish scope.
+- RESOLVED: Use docs cross-check plus markdown review as required validation; automated tests are optional unless source changes occur.
+- DEFERRED: Home Assistant add-on TLS option parity and deeper add-on docs belong to #89.
+- Risk: MQTT examples can drift if payload structs or topic helpers change after this plan. Mitigation: final implementation must cross-check source immediately before editing README.
+- Risk: README can become too long. Mitigation: use compact tables and representative examples instead of exhaustive generated payload dumps.
+
+## 13. Confidence Score
+
+Confidence: 9/10.
+
+The implementation is low risk because it is documentation-only and all source-of-truth behavior is already implemented and covered by tests. The remaining risk is documentation drift if MQTT code changes before `/implement-plan 91-issue-docs-mqtt` runs.
+
+## Revision History
+
+- 2026-05-10: Initial local TASK/PLAN created from #64 sync and issue #91 scope.
+- 2026-05-17: Reconciled with issue #91, the owner comment, current MQTT implementation, and the full generate-plan template; retained docs-only release-polish scope.

--- a/docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-TASK.md
+++ b/docs/implementations/91-issue-docs-mqtt/91-issue-docs-mqtt-TASK.md
@@ -1,35 +1,98 @@
 # Feature: MQTT docs and migration note
 
-> Source issue: [#91](https://github.com/atbore-phx/sbam/issues/91)  
-> Parent issue: [#64](https://github.com/atbore-phx/sbam/issues/64)  
-> Reconciled: 2026-05-10  
+> Source issue: [#91](https://github.com/atbore-phx/sbam/issues/91)
+> Fetched: 2026-05-17
+> Parent issue: [#64](https://github.com/atbore-phx/sbam/issues/64)
+> Reconciled: 2026-05-17
 > Slug: `91-issue-docs-mqtt`
 
 ## Summary
 
-Finish release documentation for the v2.0.0 MQTT feed. The README and project structure already contain some MQTT text from #85, but they need a complete topic map, state/ack payload schemas, command examples, Home Assistant notes, and a migration callout.
+Finish release documentation for the v2.0.0 MQTT feed. The README and project structure already contain partial MQTT text from earlier #64 work, but they need release-polish coverage for the topic map, implemented payload schemas, command examples, Home Assistant discovery behavior, and a v1.x migration callout.
+
+## Motivation / User Story
+
+As a standalone, Docker, or Home Assistant user upgrading to v2.0.0, I need to understand that MQTT is opt-in and backward compatible by default. If I choose to enable MQTT, I need copyable configuration examples, accurate topic names, payload shapes, and command examples that match the implemented runtime behavior.
 
 ## Scope
 
-- Expand the README MQTT section.
-- Document all runtime topics: availability, state, error, `cmd/<name>`, `cmd/<name>/ack`, and HA discovery config topics.
-- Document `StatePayload` fields as implemented by `pkg/mqtt` and `schedule`.
-- Document the #86 ack shape: `ts`, `command`, `accepted`, optional `error`.
-- Add `mosquitto_pub` examples for `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
-- Note that `set_reserve` is deferred beyond v2.0.0.
-- Add migration note: v1.x users need no changes while `mqtt_enabled=false`.
-- Update `.github/copilot-instructions.md` only for new source/test files added by #87/#88.
+- In scope: Expand the README MQTT section with quick-start enablement examples, topic map, state/error/ack payload examples, command publishing examples, Home Assistant discovery notes, and migration guidance.
+- In scope: Document all runtime topics: `availability`, `state`, `error`, `cmd/<name>`, `cmd/<name>/ack`, and Home Assistant discovery config topics.
+- In scope: Document `mqtt.StatePayload`, `mqtt.ErrorPayload`, and `mqtt.AckPayload` JSON fields as implemented.
+- In scope: Add `mosquitto_pub` examples for `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
+- In scope: State that `set_reserve` is deferred beyond v2.0.0 even though an internal intent constant exists.
+- In scope: Add a migration note explaining that v1.x users need no changes while `mqtt_enabled=false`.
+- In scope: Verify `.github/copilot-instructions.md` Project Structure includes the MQTT package and runner files created by #87/#88; update it only if the current list is stale.
+- Out of scope: Changing MQTT source behavior, command parsing, payload structs, or Home Assistant discovery generation.
+- Out of scope: Home Assistant add-on DOCS cleanup tracked separately by #89.
 
-Out of scope:
+## Functional Requirements
 
-- Changing source behavior.
-- Home Assistant add-on DOCS cleanup (#89).
+- README must show how to enable MQTT with at least one CLI/env/YAML-oriented quick-start example, including `mqtt_enabled=true` and `MQTT_BROKER=tcp://127.0.0.1:1883`.
+- README must include a topic map for the default `sbam` prefix and note that `mqtt_topic_prefix` changes that prefix.
+- README must describe Home Assistant discovery topics as `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config` and note the default prefix `homeassistant`.
+- README must include representative JSON examples for state, error, and ack payloads using the implemented field names.
+- README command examples must use only implemented v2.0.0 command names: `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
+- README must document that command ack payloads include `ts`, `command`, `accepted`, and optional `error`.
+- README migration note must list the twelve standalone MQTT keys available through config, env, and CLI flags: `mqtt_enabled`, `mqtt_broker`, `mqtt_client_id`, `mqtt_username`, `mqtt_password`, `mqtt_tls_ca_file`, `mqtt_tls_client_cert`, `mqtt_tls_client_cert_key`, `mqtt_tls_insecure_skip`, `mqtt_topic_prefix`, `mqtt_ha_discovery`, and `mqtt_ha_discovery_prefix`.
+- The implementation must verify the Project Structure list against current files and update it only if required.
+
+## Non-functional Requirements
+
+- Backward compatibility: Default behavior remains unchanged for v1.x users because `mqtt_enabled=false` disables MQTT.
+- Safety / defaults: Documentation must avoid implying that MQTT commands are active unless MQTT is explicitly enabled and connected.
+- Accuracy: Examples must be cross-checked against existing `pkg/mqtt` structs and topic helpers rather than invented from the issue text.
+- Maintainability: Documentation should be concise enough to maintain alongside the MQTT implementation and should avoid duplicating large implementation details.
+
+## Configuration Impact
+
+- New CLI flags: None introduced by this documentation task; document the existing MQTT flags already wired for `schedule`.
+- New config keys (`config.yaml`): None introduced by this documentation task; document the existing twelve `mqtt_*` keys.
+- New env vars: None introduced by this documentation task; document the uppercase forms of the existing `mqtt_*` keys.
+- Home Assistant add-on schema changes (`home-assistant/addons/sbam/config.json`): None in this task; HA add-on documentation cleanup is tracked by #89.
+
+## External Integrations Touched
+
+- Solcast: Not touched.
+- Fronius Solar API: Not touched.
+- Fronius Modbus registers: Not touched.
+- MQTT broker: Documentation only; describe published topics, subscribed command topics, acknowledgements, retained availability/discovery behavior, and Home Assistant discovery integration.
 
 ## Acceptance Criteria
 
 - [ ] README topic map matches `pkg/mqtt` helper topics.
 - [ ] README state payload example matches `mqtt.StatePayload` JSON fields.
+- [ ] README error payload example matches `mqtt.ErrorPayload` JSON fields.
 - [ ] README ack example matches `mqtt.AckPayload` JSON fields.
-- [ ] Command examples use implemented command names only.
+- [ ] Command examples use implemented command names only and include `mosquitto_pub` examples for all implemented commands.
+- [ ] README notes that `set_reserve` is deferred beyond v2.0.0.
 - [ ] Migration note explains the opt-in default and twelve standalone MQTT keys.
-- [ ] `.github/copilot-instructions.md` Project Structure includes any runner files created by #87/#88.
+- [ ] `.github/copilot-instructions.md` Project Structure includes `pkg/mqtt` and current `pkg/cmd` runner source/test files, or the implementation notes that no update was needed.
+- [ ] README markdown tables and fenced code blocks render correctly.
+
+## Test Strategy
+
+- Documentation review: Preview or inspect README markdown for table and code block formatting.
+- Cross-check expected case: Compare documented topic names against `pkg/mqtt/client.go`, command parsing against `pkg/mqtt/commands.go`, and payload fields against `pkg/mqtt/types.go`.
+- Edge case: Verify examples mention prefix customization and do not hard-code `sbam` without explaining `mqtt_topic_prefix`.
+- Failure case: Verify rejected command acknowledgements show `accepted=false` with an `error` field.
+- Automated tests: No source tests are required for documentation-only changes; run focused tests only if implementation touches source files.
+
+## Risks / Open Questions
+
+- RESOLVED: Use `91-issue-docs-mqtt` as the slug, matching the existing local directory and owner reconciliation comment.
+- RESOLVED: Treat the 2026-05-10 owner comment as final scope for release polish.
+- RESOLVED: Use docs cross-check plus markdown review as the required validation level.
+- Risk: README examples can drift if MQTT structs or helper topics change after this plan is implemented.
+- Risk: `.github/copilot-instructions.md` may already be current; the implementer should verify before editing.
+
+## References
+
+- Issue: [#91](https://github.com/atbore-phx/sbam/issues/91)
+- Parent issue: [#64](https://github.com/atbore-phx/sbam/issues/64)
+- Existing MQTT implementation: `pkg/mqtt`
+- Existing schedule runner wiring: `pkg/cmd/schedule_runner.go`
+
+## Clarifications
+
+- 2026-05-17: User confirmed the existing slug `91-issue-docs-mqtt`, the owner comment as final release-polish scope, and docs cross-check plus markdown review as the required validation path.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -1,0 +1,201 @@
+# MQTT Feed and Home Assistant Discovery
+
+This document contains the detailed MQTT integration guide for sbam.
+
+## Quick Start
+
+MQTT is opt-in. Set `mqtt_enabled=true` and provide a broker URL.
+
+Environment variables example:
+
+```bash
+export MQTT_ENABLED=true
+export MQTT_BROKER=tcp://127.0.0.1:1883
+bin/sbam schedule
+```
+
+CLI flags example:
+
+```bash
+bin/sbam schedule \
+  --mqtt_enabled \
+  --mqtt_broker tcp://127.0.0.1:1883
+```
+
+`config.yaml` example:
+
+```yaml
+mqtt_enabled: true
+mqtt_broker: "tcp://127.0.0.1:1883"
+mqtt_topic_prefix: "sbam"
+mqtt_ha_discovery: true
+mqtt_ha_discovery_prefix: "homeassistant"
+```
+
+## Topic Map
+
+Use `mqtt_topic_prefix` to change the default `sbam` prefix.
+
+| Topic | Direction | Retained / QoS | Payload |
+| --- | --- | --- | --- |
+| `<prefix>/availability` (default `sbam/availability`) | sbam publishes | retained, qos 1 | `online` or `offline` |
+| `<prefix>/state` (default `sbam/state`) | sbam publishes | retained, qos 1 | `StatePayload` JSON |
+| `<prefix>/error` (default `sbam/error`) | sbam publishes | not retained, qos 1 | `ErrorPayload` JSON |
+| `<prefix>/cmd/+` (default `sbam/cmd/+`) | sbam subscribes | qos 1 | command payload JSON |
+| `<prefix>/cmd/<name>/ack` | sbam publishes | not retained, qos 1 | `AckPayload` JSON |
+| `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config` | sbam publishes | retained, qos 1 | Home Assistant discovery config |
+
+Defaults:
+
+- `mqtt_topic_prefix=sbam`
+- `mqtt_ha_discovery_prefix=homeassistant`
+
+## Payload Examples
+
+State payload (`<prefix>/state`):
+
+```json
+{
+  "battery_soc_pct": 42.5,
+  "battery_capacity_wh": 10000,
+  "forecast_today_wh": 5100,
+  "pw_net_wh": -5900,
+  "charge_pct": 80,
+  "last_decision": "force_charge",
+  "last_decision_reason": "force charge command executed",
+  "charge_window_active": true,
+  "batt_reserve_window_active": false,
+  "paused": false,
+  "next_run": null,
+  "ts": "2026-05-18T21:00:00Z"
+}
+```
+
+Error payload (`<prefix>/error`):
+
+```json
+{
+  "error": "invalid payload: target_pct must be between 1 and 100",
+  "source": "force_charge",
+  "ts": "2026-05-18T21:01:00Z"
+}
+```
+
+Accepted ack payload (`<prefix>/cmd/trigger_now/ack`):
+
+```json
+{
+  "ts": "2026-05-18T21:01:05Z",
+  "command": "trigger_now",
+  "accepted": true
+}
+```
+
+Rejected ack payload (`<prefix>/cmd/force_charge/ack`):
+
+```json
+{
+  "ts": "2026-05-18T21:01:10Z",
+  "command": "force_charge",
+  "accepted": false,
+  "error": "invalid payload: target_pct must be between 1 and 100"
+}
+```
+
+## Command Examples (`mosquitto_pub`)
+
+```bash
+BROKER_HOST=127.0.0.1
+BROKER_PORT=1883
+PREFIX=sbam
+
+# trigger_now
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/trigger_now" -m '{}'
+
+# pause indefinitely
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/pause" -m '{}'
+
+# pause for one hour (duration format)
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/pause" -m '{"until":"1h"}'
+
+# resume
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/resume" -m '{}'
+
+# force_charge
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/force_charge" -m '{"target_pct":80}'
+
+# set_defaults
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/set_defaults" -m '{}'
+```
+
+Command payload constraints:
+
+- Maximum payload size is 4096 bytes.
+- `force_charge.target_pct` is required and must be between 1 and 100.
+- `pause.until` is optional; when set, it must be a future RFC3339 timestamp or a positive Go duration.
+
+## Home Assistant Discovery Behavior
+
+When MQTT is enabled and `mqtt_ha_discovery=true`, sbam publishes retained Home Assistant discovery payloads under:
+
+- `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config`
+
+Current discovery set includes:
+
+- 10 sensors
+- 3 binary sensors
+- 5 buttons (`trigger_now`, `pause`, `resume`, `force_charge`, `set_defaults`)
+
+### Discovery button actions
+
+Each Home Assistant button publishes to `<prefix>/cmd/<name>`, and sbam publishes
+an acknowledgement on `<prefix>/cmd/<name>/ack`.
+
+- `trigger_now`: requests one immediate schedule evaluation run.
+- `pause`: pauses indefinitely the automatic schedule processing.
+- `resume`: clears pause state and resumes automatic schedule processing.
+- `force_charge`: requests a manual force charge at 100%. The button sends `{"target_pct":100}`.
+- `set_defaults`: restores inverter defaults via the configured Modbus write path.
+
+### Command sequencing note (schedule active)
+
+> [!IMPORTANT]
+> sbam serializes incoming commands and scheduled ticks in one runner queue, so
+> write operations are not executed concurrently. If the schedule remains active,
+> later ticks can still apply new decisions after a manual command.
+
+For a manual force-charge workflow with minimal scheduler interference:
+
+1. Send `force_charge` first.
+2. Wait for an accepted ack on `<prefix>/cmd/force_charge/ack`.
+3. Send `pause` to suppress subsequent automatic runs.
+4. Send `resume` when the manual window ends.
+5. Send `trigger_now` (or wait for the next scheduled tick) to let scheduler logic re-evaluate state.
+
+Do not pause before `force_charge`: `force_charge` is rejected while paused.
+
+Device grouping uses a stable `sbam_` identifier derived from Fronius IP, client ID, or topic prefix.
+
+sbam subscribes to `homeassistant/status` and republishes discovery when Home Assistant publishes `online`.
+
+## Migration from v1.x
+
+> [!NOTE]
+> v2.0.0 remains backward compatible while `mqtt_enabled=false` (default). Existing v1.x users do not need to change configuration unless opting into MQTT.
+
+MQTT configuration keys in standalone mode (CLI flags, environment variables, and `config.yaml`):
+
+- `mqtt_enabled` (`MQTT_ENABLED`, `--mqtt_enabled`)
+- `mqtt_broker` (`MQTT_BROKER`, `--mqtt_broker`)
+- `mqtt_client_id` (`MQTT_CLIENT_ID`, `--mqtt_client_id`)
+- `mqtt_username` (`MQTT_USERNAME`, `--mqtt_username`)
+- `mqtt_password` (`MQTT_PASSWORD`, `--mqtt_password`)
+- `mqtt_tls_ca_file` (`MQTT_TLS_CA_FILE`, `--mqtt_tls_ca_file`)
+- `mqtt_tls_client_cert` (`MQTT_TLS_CLIENT_CERT`, `--mqtt_tls_client_cert`)
+- `mqtt_tls_client_cert_key` (`MQTT_TLS_CLIENT_CERT_KEY`, `--mqtt_tls_client_cert_key`)
+- `mqtt_tls_insecure_skip` (`MQTT_TLS_INSECURE_SKIP`, `--mqtt_tls_insecure_skip`)
+- `mqtt_topic_prefix` (`MQTT_TOPIC_PREFIX`, `--mqtt_topic_prefix`)
+- `mqtt_ha_discovery` (`MQTT_HA_DISCOVERY`, `--mqtt_ha_discovery`)
+- `mqtt_ha_discovery_prefix` (`MQTT_HA_DISCOVERY_PREFIX`, `--mqtt_ha_discovery_prefix`)
+
+For Home Assistant users, entities are auto-discovered when MQTT and discovery are enabled; no manual YAML is required for those entities.

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -3,10 +3,10 @@
 ### Prerequisites
 
 sbam requires the following prerequisites to function correctly:
-https://github.com/atbore-phx/sbam/blob/main/docs/prereq.md
+[sbam prerequisites](../../../docs/prereq.md)
 
 For MQTT features in Home Assistant, enable MQTT support first:
-https://www.home-assistant.io/integrations/mqtt/
+[Home Assistant MQTT integration](https://www.home-assistant.io/integrations/mqtt/)
 
 The recommended broker for Home Assistant users is the Mosquitto add-on.
 
@@ -18,7 +18,7 @@ Sbam is available as an App (formerly known as add-ons) for HAOS (Home Assistant
 
 
 Official guide:
-https://www.home-assistant.io/common-tasks/os#installing-a-third-party-app-repository
+[Install a third-party Home Assistant app repository](https://www.home-assistant.io/common-tasks/os#installing-a-third-party-app-repository)
 
 1. Settings
 2. Apps
@@ -99,53 +99,19 @@ and `batt_reserve_end_hr: 05:00`. Equal start and end values are invalid.
 
 ![sbam-conf](https://github.com/user-attachments/assets/d0eab452-7b77-4d2c-9b24-7ac44fd50b7a)
 
-### MQTT Behavior in the Add-on
+### MQTT in the Home Assistant Add-on
 
-When MQTT is enabled:
+For complete MQTT reference (topic map, payload schemas, command examples,
+and migration notes), see:
+[MQTT Feed and Home Assistant Discovery](../../../docs/mqtt.md)
 
-- If mqtt_broker is already set, sbam keeps user-provided broker and credentials.
+Add-on specific behavior:
+
+- If mqtt_broker is already set, sbam keeps the configured broker and credentials.
 - If mqtt_broker is empty, sbam tries to auto-fill broker and credentials from Home Assistant service data via bashio::services mqtt.
-- Auto-fill only applies to empty values and does not overwrite manual broker, username, or password.
-
-TLS add-on options are intentionally not exposed in the Home Assistant add-on UI for v2.0.0.
-Standalone sbam still supports TLS options via CLI, env vars, and config.yaml.
-
-### MQTT Topic Map
-
-Assuming default mqtt_topic_prefix=sbam:
-
-- State: sbam/state
-- Errors: sbam/error
-- Availability: sbam/availability (retained online/offline)
-- Commands:
-  - sbam/cmd/trigger_now
-  - sbam/cmd/force_charge
-  - sbam/cmd/set_defaults
-  - sbam/cmd/pause
-  - sbam/cmd/resume
-- Command acknowledgements: sbam/cmd/<command>/ack
-
-Discovery entities are published under mqtt_ha_discovery_prefix, for example:
-homeassistant/<component>/sbam/<object_id>/config
-
-### MQTT Examples
-
-Read state updates:
-
-```bash
-mosquitto_sub -h <broker-host> -t 'sbam/state' -v
-```
-
-Send force charge command:
-
-```bash
-mosquitto_pub -h <broker-host> -t 'sbam/cmd/force_charge' -m '{"target_pct":100,"duration_s":3600}'
-```
-
-### About Show in Sidebar and Auto Update
-
-- Show in sidebar: sbam currently has no ingress web UI. There is no sidebar panel to expose for this add-on.
-- Auto update: this toggle is managed by Home Assistant per installation. It is not controlled by sbam repository metadata.
+- Auto-fill applies only to empty values and does not overwrite manual broker, username, or password.
+- `mqtt_topic_prefix` controls state, error, availability, and command topics (default `sbam`).
+- `mqtt_ha_discovery_prefix` controls Home Assistant discovery topics (default `homeassistant`).
 
 ### Start sbam
 


### PR DESCRIPTION
Documentation-only PR for issue #91. Adds docs/mqtt.md (detailed MQTT guide and HA discovery), updates README.md, home-assistant/addons/sbam/DOCS.md, and .github/copilot-instructions.md. Updated docs/implementations/91-issue-docs-mqtt TASK/PLAN. Cross-checked against implementation: duration_s is parsed but not used as an auto-stop timer. Validation run: go mod tidy; go vet ./...; make test; make build — all passed locally.