### PR TITLE
fix(mqtt:force_charge): we limit force_charge button using max_charge

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -132,6 +132,7 @@ Command payload constraints:
 
 - Maximum payload size is 4096 bytes.
 - `force_charge.target_pct` is required and must be between 1 and 100.
+- sbam always caps `force_charge.target_pct` by `max_charge` using live battery max capacity: effective target is `min(requested_target_pct, max_charge*100/pw_batt_max)`.
 - `pause.until` is optional; when set, it must be a future RFC3339 timestamp or a positive Go duration.
 
 ## Home Assistant Discovery Behavior
@@ -154,7 +155,7 @@ an acknowledgement on `<prefix>/cmd/<name>/ack`.
 - `trigger_now`: requests one immediate schedule evaluation run.
 - `pause`: pauses indefinitely the automatic schedule processing.
 - `resume`: clears pause state and resumes automatic schedule processing.
-- `force_charge`: requests a manual force charge at 100%. The button sends `{"target_pct":100}`.
+- `force_charge`: requests a manual force charge. The button sends `{"target_pct":100}` which is the maximum load percentage. NB: sbam caps the effective target by `max_charge` (see configuration) and battery capacity at runtime.
 - `set_defaults`: restores inverter defaults via the configured Modbus write path.
 
 ### Command sequencing note (schedule active)

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -329,16 +329,49 @@ func (r *Runner) handleForceCharge(ctx context.Context, intent mqtt.Intent) erro
 		return err
 	}
 
-	if err := r.writer.ForceCharge(r.cfg.FroniusIP, intent.TargetPct); err != nil {
+	targetPct, err := r.resolveForceChargeTargetPct(intent.TargetPct)
+	if err != nil {
+		r.publishError(ctx, "force_charge", err)
+		return err
+	}
+
+	if err := r.writer.ForceCharge(r.cfg.FroniusIP, targetPct); err != nil {
 		r.publishError(ctx, "force_charge", err)
 		return err
 	}
 
 	payload := r.newCommandPayload(string(mqtt.IntentForceCharge), "force charge command executed", r.now())
 	payload.Paused = false
-	payload.ChargePct = &intent.TargetPct
+	payload.ChargePct = &targetPct
 	r.publishState(payload)
 	return nil
+}
+
+// resolveForceChargeTargetPct caps any requested force charge percentage
+// by configured max_charge and current battery max capacity.
+//
+// Effective target is:
+// min(requestedPct, max_charge*100/pw_batt_max)
+//
+// When max_charge is 0 the effective target becomes 0 (no charge).
+func (r *Runner) resolveForceChargeTargetPct(requestedPct int16) (int16, error) {
+	if r.cfg.MaxCharge < 0 {
+		return 0, fmt.Errorf("invalid max_charge %.2f: must be greater than or equal to 0", r.cfg.MaxCharge)
+	}
+
+	storageHandler := newStorage()
+	_, capacityMax, _, err := storageHandler.Handler(r.cfg.FroniusIP)
+	if err != nil {
+		return 0, fmt.Errorf("unable to resolve force_charge target from battery capacity: %w", err)
+	}
+	if capacityMax <= 0 {
+		return 0, fmt.Errorf("invalid battery capacity %.2f: must be greater than 0", capacityMax)
+	}
+
+	requestedLoad := capacityMax * float64(requestedPct) / 100.0
+	targetPct := fronius.SetChargePower(capacityMax, requestedLoad, r.cfg.MaxCharge)
+
+	return targetPct, nil
 }
 
 // handleSetDefaults triggers the battery writer to restore inverter

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -141,10 +142,15 @@ func TestRunner_HandleIntentPausePublishesStateAndAck(t *testing.T) {
 func TestRunner_ForceChargeCommandExecutesWriterAndPublishesAck(t *testing.T) {
 	client := newFakeClient()
 	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
 
 	oldFactory := newBatteryWriter
 	newBatteryWriter = func() batteryWriter { return fakeWriter }
 	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
 
 	runner := newRunnerForTests(client)
 	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":42}`))
@@ -153,16 +159,146 @@ func TestRunner_ForceChargeCommandExecutesWriterAndPublishesAck(t *testing.T) {
 	intent := <-runner.intents
 	runner.handleIntent(context.Background(), intent)
 
+	assert.Equal(t, 1, fakeStorage.calls)
 	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
 	assert.Equal(t, "127.0.0.1", fakeWriter.lastFroniusIP)
-	assert.Equal(t, int16(42), fakeWriter.lastTargetPct)
+	assert.Equal(t, int16(35), fakeWriter.lastTargetPct)
 
 	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	require.NotNil(t, state.ChargePct)
+	assert.Equal(t, int16(35), *state.ChargePct)
+
 	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
 	require.True(t, ok, "expected ack publish")
 	ack := decodeAckPayload(t, ackMsg.payload)
 	assert.True(t, ack.Accepted)
 	assert.Equal(t, "force_charge", ack.Command)
+}
+
+func TestRunner_ForceChargeCommandBelowCapKeepsRequestedPct(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":20}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 1, fakeStorage.calls)
+	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
+	assert.Equal(t, int16(20), fakeWriter.lastTargetPct)
+}
+
+func TestRunner_ForceChargeCommandWithZeroMaxChargeResolvesToZero(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.cfg.MaxCharge = 0
+
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":80}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 1, fakeStorage.calls)
+	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
+	assert.Equal(t, int16(0), fakeWriter.lastTargetPct)
+}
+
+func TestRunner_ForceChargeCommandAt100UsesMaxChargeCap(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":100}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 1, fakeStorage.calls)
+	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
+	assert.Equal(t, "127.0.0.1", fakeWriter.lastFroniusIP)
+	assert.Equal(t, int16(35), fakeWriter.lastTargetPct)
+
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	require.NotNil(t, state.ChargePct)
+	assert.Equal(t, int16(35), *state.ChargePct)
+
+	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
+	require.True(t, ok, "expected ack publish")
+	ack := decodeAckPayload(t, ackMsg.payload)
+	assert.True(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+}
+
+func TestRunner_ForceChargeCommandAt100RejectedWhenCapacityUnavailable(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{err: errors.New("storage unavailable")}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":100}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 1, fakeStorage.calls)
+	assert.Equal(t, 0, fakeWriter.forceChargeCalls)
+
+	msgs := drainPublishes(client)
+	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
+	require.True(t, ok, "expected ack publish")
+	ack := decodeAckPayload(t, ackMsg.payload)
+	assert.False(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+	assert.Contains(t, ack.Error, "unable to resolve force_charge target")
 }
 
 func TestRunner_SetDefaultsCommandExecutesWriterAndPublishesAck(t *testing.T) {


### PR DESCRIPTION
Summary

- Enforce `max_charge` for Home Assistant `force_charge` commands. HA button presses no longer force 100% charge.
- Effective target is computed as `min(requested_pct, max_charge * 100 / pw_batt_max)` using live battery capacity. `max_charge=0` disables charging.
- Convert percentage → energy (Wh) and call `fronius.SetChargePower` to compute the final setpoint; single Modbus write used.

Changes

- pkg/cmd/schedule_runner.go: added `resolveForceChargeTargetPct` and updated `handleForceCharge` to always cap requested percentages by configured `max_charge`.
- pkg/cmd/schedule_runner_test.go: added tests for below-cap pass-through, `max_charge=0`, storage failure handling, and 100%->cap behavior.
- docs/mqtt.md and home-assistant/addons/sbam/DOCS.md: document capped behavior and `max_charge` semantics.

Testing

- Unit tests for `pkg/cmd` and targeted `pkg/mqtt` discovery tests were run locally; all relevant tests passed.

Reviewer notes

- The HA discovery payload still advertises the default press payload `target_pct: 100`; enforcement happens at runtime. Consider changing discovery to compute and publish a pre-capped value if you want the UI to reflect the capped result.
- Behavior is backward-compatible; this change only enforces a cap and adjusts ForceCharge to use correct units.

Commit

- Implement force_charge capping and tests; update docs.


