### PR TITLE
feat: Home Assistant slider controls for force_charge and pause

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,7 @@ jobs:
             ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'dev' }}
           version: ${{ env.VERSION }}
           context: home-assistant/addons/sbam
+          cosign: "false"
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           push: "true"
           build-args: |

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
@@ -1,4 +1,4 @@
-# Plan: Home Assistant Slider Controls for Force Charge and Pause
+# Plan: Home Assistant Controls for Force Charge and Pause
 
 > Date: 2026-05-19
 > Task: [128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md](128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md)
@@ -7,14 +7,14 @@
 
 ## Task Analysis
 
-Issue #128 asks sbam to improve the Home Assistant MQTT discovery UX for manual `force_charge` and `pause` commands. Users should be able to choose a force-charge target percentage with a slider and a pause duration via a numeric input (box) with steppers, then press explicit send buttons that publish to the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` topics.
+Issue #128 asks sbam to improve the Home Assistant MQTT discovery UX for manual `force_charge` and `pause` commands. Users should be able to choose a force-charge target percentage with a numeric box and a pause duration via a numeric input (box) with steppers, then press explicit send buttons that publish to the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` topics.
 
 Goals:
 
-- Add Home Assistant MQTT `number` entities: a slider for force-charge target percent and a numeric box (mode: box) for pause duration seconds.
+- Add Home Assistant MQTT `number` entities: a numeric box for force-charge target percent and a numeric box (mode: box) for pause duration seconds.
 - Keep explicit button presses as the only way to publish to sbam command topics.
 - Keep ordinary force-charge requests subject to the existing `max_charge` cap.
-- Add an explicit full-charge override path for the slider's `>100` value.
+- Add an explicit full-charge override path for the selector's `>100` value.
 - Preserve direct MQTT command compatibility and existing command topics.
 - Document and test the new discovery payloads, parser behavior, runner behavior, and edge cases.
 
@@ -25,7 +25,7 @@ Non-goals:
 - Do not change Fronius Modbus register addresses or unrelated charging algorithm behavior.
 - Do not modify Solcast or Fronius Solar API integrations.
 
-Acceptance criteria from the TASK are covered by adding two number selector entities (force-charge slider and pause numeric box), templated send buttons, strict command parsing for ordinary and override requests, runner tests for capped and uncapped paths, docs updates, and validation with `go test ./...`, `make test`, and `make build`.
+Acceptance criteria from the TASK are covered by adding two number selector entities (force-charge numeric box and pause numeric box), templated send buttons, strict command parsing for ordinary and override requests, runner tests for capped and uncapped paths, docs updates, and validation with `go test ./...`, `make test`, and `make build`.
 
 ## Current State
 
@@ -64,7 +64,7 @@ flowchart LR
 
 Discovery design:
 
-- Add `number` entity `force_charge_target_pct` with default entity ID `number.sbam_force_charge_target_pct`, `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, and command/state topic `<prefix>/control/force_charge_target_pct`.
+- Add `number` entity `force_charge_target_pct` with default entity ID `number.sbam_force_charge_target_pct`, `min=0`, `max=101`, `step=1`, `mode=box`, `unit_of_measurement="%"`, and command/state topic `<prefix>/control/force_charge_target_pct`.
    - Add `number` entity `pause_duration_s` with default entity ID `number.sbam_pause_duration_s`, `min=0`, `max=86400`, `step=60`, `mode=box`, `unit_of_measurement="s"`, and command/state topic `<prefix>/control/pause_duration_s`.
 - Use the same topic for each selector's `command_topic` and `state_topic`, with `retain=true`, so the selected value is harmlessly retained by the broker and can be restored. sbam must not subscribe to these selector topics.
 - Update the existing Home Assistant `force_charge` button discovery payload to use `command_template` instead of a fixed payload. The button keeps `command_topic=<prefix>/cmd/force_charge` and defaults unknown selector state to `100` for backward-compatible behavior.
@@ -72,10 +72,10 @@ Discovery design:
 
 Command contract:
 
-- `{"target_pct":0}` becomes valid and means stop forced charging / restore defaults through `ForceCharge(..., 0)`. This matches the issue's `0..100` slider range and the existing Fronius helper behavior.
+-- `{"target_pct":0}` becomes valid and means stop forced charging / restore defaults through `ForceCharge(..., 0)`. This matches the issue's `0..100` selector range and the existing Fronius helper behavior.
 - `{"target_pct":1}` through `{"target_pct":100}` remain valid ordinary requests. They continue to be capped by `max_charge` through `resolveForceChargeTargetPct`.
 - `{"target_pct":100,"ignore_max_charge":true}` is the explicit uncapped full-charge request. It writes `ForceCharge(..., 100)` without reading storage or applying `max_charge`.
-- Raw `{"target_pct":101}` remains invalid. The Home Assistant slider value `101` is mapped by the button `command_template` to the explicit `ignore_max_charge` payload, avoiding accidental uncapped charge from loosely validated direct MQTT payloads.
+-- Raw `{"target_pct":101}` remains invalid. The Home Assistant selector value `101` is mapped by the button `command_template` to the explicit `ignore_max_charge` payload, avoiding accidental uncapped charge from loosely validated direct MQTT payloads.
 - `{"ignore_max_charge":true}` is invalid unless `target_pct` is exactly `100`.
 - Pause stays backward compatible: empty payload and `{}` mean indefinite pause; `{"until":"3600s"}` means pause until `now + 3600s`.
 
@@ -115,14 +115,14 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
    - Add small pointer helpers such as `floatPtr(value float64) *float64` and `boolPtr(value bool) *bool`.
    - Add `numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, commandTopic string, min, max, step float64, unit, icon string) discoveryPayload`.
    - Add `templatedButtonPayload(base discoveryPayload, deviceID, objectID, name, commandTopic, commandTemplate string) discoveryPayload` or extend `buttonPayload` with an optional command-template argument.
-   - For number payloads, clear inherited `ValueTemplate` unless intentionally used, set `StateTopic` to the selector topic, set `CommandTopic` to the same selector topic, set `Retain=true`, set `Mode` to the requested value (e.g., `slider` for force target, `box` for pause), and set `QoS=1` through the existing base value.
+   - For number payloads, clear inherited `ValueTemplate` unless intentionally used, set `StateTopic` to the selector topic, set `CommandTopic` to the same selector topic, set `Retain=true`, set `Mode` to `box` for both force target and pause, and set `QoS=1` through the existing base value.
 
 3. Add selector discovery entities in `BuildDiscovery` in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
    - Increase the entity slice capacity from `18` to `20`.
    - Append `number/force_charge_target_pct` and `number/pause_duration_s` before the command buttons.
    - Use `default_entity_id` values `number.sbam_force_charge_target_pct` and `number.sbam_pause_duration_s` so button templates have stable entity IDs on first discovery.
    - Use `max=101` for the force-charge selector; `101` is the explicit UI override sentinel.
-   - Use `max=86400` for the pause selector and `step=60` unless tests or manual review show Home Assistant needs `step=1` for exact seconds. The command parser accepts any positive Go duration string, so either step is safe; `60` makes the slider usable.
+   - Use `max=86400` for the pause selector and `step=60` unless tests or manual review show Home Assistant needs `step=1` for exact seconds. The command parser accepts any positive Go duration string, so either step is safe; `60` makes the selector usable.
 
 4. Convert existing `force_charge` and `pause` buttons to templated send buttons in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
    - Keep object IDs `force_charge` and `pause` for stable Home Assistant entities and backward-compatible button service calls.
@@ -165,7 +165,7 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
 8. Update MQTT discovery tests in [pkg/mqtt/discovery_test.go](../../../pkg/mqtt/discovery_test.go).
    - Extend `discoveryPayloadView` with `DefaultEntityID`, `CommandTemplate`, `Min`, `Max`, `Step`, `Mode`, `Retain`, `Unit`, and `Icon` fields. Use pointer types for `Min`, `Max`, `Step`, and `Retain` where zero or false must be asserted.
    - Update expected entity count to at least `20`.
-   - Assert the new `number/force_charge_target_pct` payload has `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, `default_entity_id="number.sbam_force_charge_target_pct"`, retained selector topic, QoS 1, and shared device identifier.
+   - Assert the new `number/force_charge_target_pct` payload has `min=0`, `max=101`, `step=1`, `mode=box`, `unit_of_measurement="%"`, `default_entity_id="number.sbam_force_charge_target_pct"`, retained selector topic, QoS 1, and shared device identifier.
    - Assert the new `number/pause_duration_s` payload has `min=0`, `max=86400`, `mode=box`, `unit_of_measurement="s"`, `default_entity_id="number.sbam_pause_duration_s"`, retained selector topic, QoS 1, and shared device identifier.
    - Replace the fixed force-charge button payload assertion with assertions for `CommandTopic`, `CommandTemplate`, `retain=false`, and template substrings `number.sbam_force_charge_target_pct` and `ignore_max_charge`.
    - Assert the pause button template references `number.sbam_pause_duration_s`, emits `{}` for zero/unknown values, and emits an `until` seconds duration for positive values.
@@ -186,7 +186,7 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
     - Keep paused rejection tests first in behavior order; paused commands should not write even for `0` or override requests.
 
 11. Update documentation in [docs/mqtt.md](../../../docs/mqtt.md).
-    - Revise Home Assistant discovery entity counts to include 2 number sliders and 5 buttons.
+   - Revise Home Assistant discovery entity counts to include 2 number selectors (box mode) and 5 buttons.
     - Document selector topics `<prefix>/control/force_charge_target_pct` and `<prefix>/control/pause_duration_s` as Home Assistant selector state topics, not sbam command topics.
     - Update discovery button action descriptions: `force_charge` reads the force target selector, maps `101` to `ignore_max_charge`, and publishes to `cmd/force_charge`; `pause` reads the pause duration selector and publishes `{}` or `{"until":"Ns"}`.
     - Update command constraints: `target_pct` is `0..100`; `0` stops forced charge/restores defaults; `1..100` is capped by `max_charge`; `ignore_max_charge=true` is accepted only with `target_pct=100`; raw `101` is invalid.
@@ -194,9 +194,9 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
     - Update rejected ack example text from `1 and 100` to `0 and 100` where appropriate.
 
 12. Update Home Assistant add-on docs in [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md) and [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md).
-    - In `DOCS.md`, mention that enabling MQTT discovery now creates force-charge and pause sliders plus send buttons.
+   - In `DOCS.md`, mention that enabling MQTT discovery now creates force-charge and pause box selectors plus send buttons.
     - Explain the `101` force-charge selector value as an explicit full-charge override that ignores `max_charge`; keep this concise and avoid dashboard redesign instructions.
-    - In `CHANGELOG.md`, add a bullet under `Changes 2.0.0` for the new Home Assistant MQTT slider controls and explicit uncapped full-charge command semantics.
+   - In `CHANGELOG.md`, add a bullet under `Changes 2.0.0` for the new Home Assistant MQTT box selectors and explicit uncapped full-charge command semantics.
     - No add-on schema or runtime script changes should be made.
 
 13. Review README impact in [README.md](../../../README.md).
@@ -311,9 +311,9 @@ docker build -t sbam:test .
 
 Manual Home Assistant validation after unit tests:
 
-- Enable `mqtt_enabled=true` and `mqtt_ha_discovery=true`.
-- Confirm Home Assistant discovers the two number sliders and the `force_charge` / `pause` buttons under the same sbam device.
-- Move each slider and verify only `<prefix>/control/...` selector topics are published, not `<prefix>/cmd/...`.
+-- Enable `mqtt_enabled=true` and `mqtt_ha_discovery=true`.
+-- Confirm Home Assistant discovers the two number selectors and the `force_charge` / `pause` buttons under the same sbam device.
+-- Move each selector and verify only `<prefix>/control/...` selector topics are published, not `<prefix>/cmd/...`.
 - Press `force_charge` with selector `80` and confirm `cmd/force_charge` receives `{"target_pct":80}` and sbam publishes an accepted ack.
 - Press `force_charge` with selector `101` and confirm `cmd/force_charge` receives `{"target_pct":100,"ignore_max_charge":true}` and sbam writes target `100`.
 - Press `pause` with selector `0` and confirm `{}` is published.
@@ -335,14 +335,14 @@ Manual Home Assistant validation after unit tests:
 - Keep strict JSON decoding and `MaxPayloadBytes` enforcement to avoid broadening MQTT command input unnecessarily.
 - The uncapped full-charge path must require `ignore_max_charge=true` with `target_pct=100`; do not infer it from any ordinary `1..100` request.
 - `ignore_max_charge=true` bypasses `max_charge`, so it must be documented as a manual override and covered by tests.
-- Slider selector retained MQTT payloads contain only numeric control values, no secrets.
+-- Selector retained MQTT payloads contain only numeric control values, no secrets.
 - Do not log MQTT usernames, passwords, broker secrets, or Home Assistant service credentials while testing.
 - Modbus writes remain serialized through `Runner`; do not introduce direct writes from MQTT subscription callbacks.
 - Keep paused-state rejection ahead of force-charge writes so remote commands cannot bypass an intentional pause.
 
 ## Gotchas
 
-- Home Assistant MQTT `number` entities publish when their value changes. To satisfy “slider changes do not execute commands,” their command topics must be harmless selector topics, not sbam `cmd/*` topics.
+-- Home Assistant MQTT `number` entities publish when their value changes. To satisfy “selector changes do not execute commands,” their command topics must be harmless selector topics, not sbam `cmd/*` topics.
 - Button `command_template` relies on Home Assistant entity IDs. Set `default_entity_id` for the new number entities and document that renaming those entities can break the generated button templates until discovery is reset or the template is updated.
 - `min=0` requires pointer fields in Go discovery payload structs; plain numeric fields with `omitempty` will silently omit zero.
 - Existing `discoveryPayload` inherits `StateTopic` from `base`. Clear or intentionally override it for buttons and numbers so Home Assistant does not try to parse the sbam JSON state payload as a number selector.
@@ -353,7 +353,7 @@ Manual Home Assistant validation after unit tests:
 
 ## Open Questions / Risks
 
-- RESOLVED: Home Assistant MQTT supports `number` slider mode and MQTT button `command_template`, so the preferred slider plus explicit send-button UX is viable.
+- RESOLVED: Home Assistant MQTT supports `number` modes (including `box`) and MQTT button `command_template`, so the preferred selector-plus-explicit send-button UX is viable.
 - RESOLVED: Pause selector value `0` maps to `{}` for existing indefinite pause behavior.
 - RESOLVED: Pause selector maximum is `86400` seconds.
 - RESOLVED: Force selector value `101` maps to `target_pct=100` with `ignore_max_charge=true`, an explicit payload convention for uncapped full charge.

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
@@ -1,0 +1,368 @@
+# Plan: Home Assistant Slider Controls for Force Charge and Pause
+
+> Date: 2026-05-19
+> Task: [128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md](128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md)
+> Source issue: [#128](https://github.com/atbore-phx/sbam/issues/128)
+> Related PR: [#127](https://github.com/atbore-phx/sbam/pull/127)
+
+## Task Analysis
+
+Issue #128 asks sbam to improve the Home Assistant MQTT discovery UX for manual `force_charge` and `pause` commands. Users should be able to choose a force-charge target percentage and pause duration with sliders, then press explicit send buttons that publish to the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` topics.
+
+Goals:
+
+- Add Home Assistant MQTT `number` entities rendered as sliders for force-charge target percent and pause duration seconds.
+- Keep explicit button presses as the only way to publish to sbam command topics.
+- Keep ordinary force-charge requests subject to the existing `max_charge` cap.
+- Add an explicit full-charge override path for the slider's `>100` value.
+- Preserve direct MQTT command compatibility and existing command topics.
+- Document and test the new discovery payloads, parser behavior, runner behavior, and edge cases.
+
+Non-goals:
+
+- Do not redesign Home Assistant dashboards beyond MQTT discovery entities.
+- Do not add new configuration keys unless implementation discovers a hard compatibility blocker.
+- Do not change Fronius Modbus register addresses or unrelated charging algorithm behavior.
+- Do not modify Solcast or Fronius Solar API integrations.
+
+Acceptance criteria from the TASK are covered by adding two slider entities, templated send buttons, strict command parsing for ordinary and override requests, runner tests for capped and uncapped paths, docs updates, and validation with `go test ./...`, `make test`, and `make build`.
+
+## Current State
+
+- [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go) builds retained single-component Home Assistant discovery payloads for 10 sensors, 3 binary sensors, and 5 buttons. The existing `force_charge` button publishes `{"target_pct":100,"duration_s":3600}` directly to `sbam/cmd/force_charge`; the existing `pause` button publishes `{}` directly to `sbam/cmd/pause`.
+- [pkg/mqtt/discovery_test.go](../../../pkg/mqtt/discovery_test.go) verifies the discovery shape, topics, version, unique IDs, retained publication behavior, and current fixed force-charge button payload.
+- [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go) parses MQTT command payloads with strict JSON decoding. `force_charge.target_pct` is currently required and must be `1..100`; `pause.until` may be omitted for indefinite pause, a future RFC3339 timestamp, or a positive Go duration.
+- [pkg/mqtt/commands_test.go](../../../pkg/mqtt/commands_test.go) already covers canonical commands, strict JSON validation, payload size limits, pause duration parsing, and rejected `target_pct` values `0` and `101`.
+- [pkg/mqtt/types.go](../../../pkg/mqtt/types.go) defines `Intent` with `TargetPct`, `DurationS`, `PauseUntil`, and `CommandTopic`, but no flag to bypass `max_charge`.
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go) serializes all schedule ticks and MQTT commands. `handleForceCharge` rejects target percentages outside `1..100`, then calls `resolveForceChargeTargetPct`, which caps requests using live battery capacity and `MaxCharge` before writing through `batteryWriter.ForceCharge`.
+- [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go) covers queued command handling, capped force charge, `max_charge=0`, paused rejection, parse-error acks, and storage failure while resolving capped targets.
+- [pkg/fronius/configure.go](../../../pkg/fronius/configure.go) already treats `fronius.ForceCharge(ip, 0)` as a safe defaults reset by delegating to `Setdefaults`; negative values are rejected.
+- [docs/mqtt.md](../../../docs/mqtt.md) documents current MQTT discovery buttons, command topics, payload constraints, examples, and the current `force_charge.target_pct` `1..100` rule.
+- [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md) and [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md) document add-on MQTT behavior and v2.0.0 changes.
+
+External Home Assistant facts checked on 2026-05-19:
+
+- MQTT button supports `command_template`, which generates the payload sent to `command_topic`: https://www.home-assistant.io/integrations/button.mqtt/
+- MQTT number supports `min`, `max`, `step`, `mode: slider`, `command_topic`, `state_topic`, `retain`, `qos`, and `command_template`: https://www.home-assistant.io/integrations/number.mqtt/
+- MQTT discovery accepts retained single-component discovery payloads and ignores unknown keys for compatibility: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
+
+## Target Architecture
+
+Use Home Assistant MQTT `number` entities as harmless selectors and keep sbam commands behind buttons:
+
+```mermaid
+flowchart LR
+  HAForceNumber[HA number: force target] -->|publishes selected value only| ForceSelectTopic[<prefix>/control/force_charge_target_pct]
+  HAPauseNumber[HA number: pause seconds] -->|publishes selected value only| PauseSelectTopic[<prefix>/control/pause_duration_s]
+  HAForceButton[HA button: force_charge] -->|command_template reads number state| ForceCmd[<prefix>/cmd/force_charge]
+  HAPauseButton[HA button: pause] -->|command_template reads number state| PauseCmd[<prefix>/cmd/pause]
+  ForceCmd --> Parser[pkg/mqtt.ParseIntent]
+  PauseCmd --> Parser
+  Parser --> Runner[pkg/cmd.Runner]
+  Runner --> Writer[fronius.ForceCharge / pause state]
+```
+
+Discovery design:
+
+- Add `number` entity `force_charge_target_pct` with default entity ID `number.sbam_force_charge_target_pct`, `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, and command/state topic `<prefix>/control/force_charge_target_pct`.
+- Add `number` entity `pause_duration_s` with default entity ID `number.sbam_pause_duration_s`, `min=0`, `max=86400`, `step=60`, `mode=slider`, `unit_of_measurement="s"`, and command/state topic `<prefix>/control/pause_duration_s`.
+- Use the same topic for each selector's `command_topic` and `state_topic`, with `retain=true`, so the selected value is harmlessly retained by the broker and can be restored. sbam must not subscribe to these selector topics.
+- Update the existing Home Assistant `force_charge` button discovery payload to use `command_template` instead of a fixed payload. The button keeps `command_topic=<prefix>/cmd/force_charge` and defaults unknown selector state to `100` for backward-compatible behavior.
+- Update the existing Home Assistant `pause` button discovery payload to use `command_template`. It keeps `command_topic=<prefix>/cmd/pause` and defaults unknown selector state to `0`, which publishes `{}` for existing indefinite pause behavior.
+
+Command contract:
+
+- `{"target_pct":0}` becomes valid and means stop forced charging / restore defaults through `ForceCharge(..., 0)`. This matches the issue's `0..100` slider range and the existing Fronius helper behavior.
+- `{"target_pct":1}` through `{"target_pct":100}` remain valid ordinary requests. They continue to be capped by `max_charge` through `resolveForceChargeTargetPct`.
+- `{"target_pct":100,"ignore_max_charge":true}` is the explicit uncapped full-charge request. It writes `ForceCharge(..., 100)` without reading storage or applying `max_charge`.
+- Raw `{"target_pct":101}` remains invalid. The Home Assistant slider value `101` is mapped by the button `command_template` to the explicit `ignore_max_charge` payload, avoiding accidental uncapped charge from loosely validated direct MQTT payloads.
+- `{"ignore_max_charge":true}` is invalid unless `target_pct` is exactly `100`.
+- Pause stays backward compatible: empty payload and `{}` mean indefinite pause; `{"until":"3600s"}` means pause until `now + 3600s`.
+
+## Dependency Choices
+
+No new Go modules are required.
+
+Use existing dependencies and patterns:
+
+- `encoding/json` with strict decoding in [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go).
+- Existing MQTT client abstractions in [pkg/mqtt/client.go](../../../pkg/mqtt/client.go) and [pkg/mqtt/publisher.go](../../../pkg/mqtt/publisher.go).
+- Existing `testify` assertions in package tests.
+- Existing runner factory overrides for storage and battery writer tests in [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go).
+
+## Configuration Changes
+
+No new sbam configuration keys are required.
+
+- CLI flags: none.
+- `config.yaml`: none.
+- Environment variables: none.
+- Home Assistant add-on [home-assistant/addons/sbam/config.json](../../../home-assistant/addons/sbam/config.json): no schema changes.
+- [home-assistant/addons/sbam/run.sh](../../../home-assistant/addons/sbam/run.sh): no new exports.
+- Precedence remains unchanged: CLI flags > environment variables > `config.yaml` > built-in defaults.
+
+MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, `mqtt_ha_discovery`, `mqtt_topic_prefix`, and `mqtt_ha_discovery_prefix` settings.
+
+## Implementation Blueprint
+
+1. Update discovery payload fields in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+   - Add JSON fields to `discoveryPayload`: `CommandTemplate string`, `DefaultEntityID string`, `Min *float64`, `Max *float64`, `Step *float64`, `Mode string`, and `Optimistic *bool` if needed.
+   - Keep pointer fields for numeric values because `min=0` must be emitted and `omitempty` would drop a plain `float64` zero.
+   - Keep the existing `Retain *bool` field and use it for selector retained state and button non-retained commands.
+
+2. Add discovery helpers in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+   - Add `controlTopic(prefix, name string) string`, returning `normalizePrefix(prefix) + "/control/" + cleanedName`.
+   - Add small pointer helpers such as `floatPtr(value float64) *float64` and `boolPtr(value bool) *bool`.
+   - Add `numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, commandTopic string, min, max, step float64, unit, icon string) discoveryPayload`.
+   - Add `templatedButtonPayload(base discoveryPayload, deviceID, objectID, name, commandTopic, commandTemplate string) discoveryPayload` or extend `buttonPayload` with an optional command-template argument.
+   - For number payloads, clear inherited `ValueTemplate` unless intentionally used, set `StateTopic` to the selector topic, set `CommandTopic` to the same selector topic, set `Retain=true`, set `Mode="slider"`, and set `QoS=1` through the existing base value.
+
+3. Add selector discovery entities in `BuildDiscovery` in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+   - Increase the entity slice capacity from `18` to `20`.
+   - Append `number/force_charge_target_pct` and `number/pause_duration_s` before the command buttons.
+   - Use `default_entity_id` values `number.sbam_force_charge_target_pct` and `number.sbam_pause_duration_s` so button templates have stable entity IDs on first discovery.
+   - Use `max=101` for the force-charge selector; `101` is the explicit UI override sentinel.
+   - Use `max=86400` for the pause selector and `step=60` unless tests or manual review show Home Assistant needs `step=1` for exact seconds. The command parser accepts any positive Go duration string, so either step is safe; `60` makes the slider usable.
+
+4. Convert existing `force_charge` and `pause` buttons to templated send buttons in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
+   - Keep object IDs `force_charge` and `pause` for stable Home Assistant entities and backward-compatible button service calls.
+   - Keep command topics `commandTopic(prefix, "force_charge")` and `commandTopic(prefix, "pause")`.
+   - Use `retain=false` for button command messages.
+   - Force-charge `command_template`:
+
+     ```jinja
+     {% set target = states('number.sbam_force_charge_target_pct') | int(100) %}{% if target > 100 %}{"target_pct":100,"ignore_max_charge":true}{% elif target < 0 %}{"target_pct":0}{% else %}{"target_pct":{{ target }}}{% endif %}
+     ```
+
+   - Pause `command_template`:
+
+     ```jinja
+     {% set seconds = states('number.sbam_pause_duration_s') | int(0) %}{% if seconds <= 0 %}{}{% else %}{"until":"{{ seconds }}s"}{% endif %}
+     ```
+
+   - Do not add visible in-app instructional text. Use names and icons only; detailed semantics belong in docs.
+
+5. Extend command parsing in [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go).
+   - Add `IgnoreMaxCharge *bool `json:"ignore_max_charge,omitempty"`` to `forceChargePayload`.
+   - Change `parseForceChargePayload` validation from `1..100` to `0..100`.
+   - Reject `ignore_max_charge=true` unless `target_pct == 100`.
+   - Keep `duration_s` validation unchanged (`0..86400`) even though the runner currently ignores duration.
+   - Keep strict JSON decoding so unknown fields still fail.
+   - Update error strings to mention `target_pct must be between 0 and 100` and `ignore_max_charge requires target_pct 100`.
+
+6. Add intent propagation in [pkg/mqtt/types.go](../../../pkg/mqtt/types.go).
+   - Add `IgnoreMaxCharge bool `json:"ignore_max_charge,omitempty"`` to `Intent`.
+   - In `parseIntentAt`, set `intent.IgnoreMaxCharge = forcePayload.IgnoreMaxCharge != nil && *forcePayload.IgnoreMaxCharge`.
+
+7. Update runner force-charge handling in [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go).
+   - Change `handleForceCharge` validation to allow `0..100`.
+   - If `intent.IgnoreMaxCharge` is true, require `TargetPct == 100` defensively and set `targetPct = 100` without calling `resolveForceChargeTargetPct`.
+   - If `TargetPct == 0`, set `targetPct = 0` and call `writer.ForceCharge` directly without storage lookup. This uses existing `fronius.ForceCharge(..., 0)` defaults behavior.
+   - For `1..100` with no override, keep the existing capped `resolveForceChargeTargetPct` flow unchanged.
+   - Publish `ChargePct` as the actual written target for all accepted paths.
+   - Keep paused-state rejection before any write.
+
+8. Update MQTT discovery tests in [pkg/mqtt/discovery_test.go](../../../pkg/mqtt/discovery_test.go).
+   - Extend `discoveryPayloadView` with `DefaultEntityID`, `CommandTemplate`, `Min`, `Max`, `Step`, `Mode`, `Retain`, `Unit`, and `Icon` fields. Use pointer types for `Min`, `Max`, `Step`, and `Retain` where zero or false must be asserted.
+   - Update expected entity count to at least `20`.
+   - Assert the new `number/force_charge_target_pct` payload has `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, `default_entity_id="number.sbam_force_charge_target_pct"`, retained selector topic, QoS 1, and shared device identifier.
+   - Assert the new `number/pause_duration_s` payload has `min=0`, `max=86400`, `mode=slider`, `unit_of_measurement="s"`, `default_entity_id="number.sbam_pause_duration_s"`, retained selector topic, QoS 1, and shared device identifier.
+   - Replace the fixed force-charge button payload assertion with assertions for `CommandTopic`, `CommandTemplate`, `retain=false`, and template substrings `number.sbam_force_charge_target_pct` and `ignore_max_charge`.
+   - Assert the pause button template references `number.sbam_pause_duration_s`, emits `{}` for zero/unknown values, and emits an `until` seconds duration for positive values.
+   - Add selector `controlTopic` normalization tests if the helper is exported only inside the package tests.
+
+9. Update MQTT command parser tests in [pkg/mqtt/commands_test.go](../../../pkg/mqtt/commands_test.go).
+   - Add valid cases for `{"target_pct":0}`, `{"target_pct":100,"ignore_max_charge":true}`, and ordinary `1`, `100`, and duration variants.
+   - Assert parsed `Intent.IgnoreMaxCharge` is true only for the explicit override payload.
+   - Keep `{"target_pct":101}` invalid.
+   - Add invalid cases for `{"target_pct":-1}`, `{"target_pct":50,"ignore_max_charge":true}`, `{"target_pct":100,"ignore_max_charge":"true"}`, and unknown fields.
+   - Keep pause tests for `{}`, `{"until":"1s"}`, `{"until":"86400s"}`, negative durations, zero duration, malformed strings, and past RFC3339 timestamps.
+
+10. Update runner tests in [pkg/cmd/schedule_runner_test.go](../../../pkg/cmd/schedule_runner_test.go).
+    - Add `TestRunner_ForceChargeCommandZeroSetsDefaults` or equivalent: send `{"target_pct":0}`, verify writer called once with target `0`, storage not called, accepted ack published, and state `charge_pct` is `0`.
+    - Add `TestRunner_ForceChargeCommandIgnoreMaxChargeBypassesCap`: send `{"target_pct":100,"ignore_max_charge":true}`, verify writer target `100`, storage not called, accepted ack, and state `charge_pct` is `100`.
+    - Keep and adjust existing `target_pct:100` capped test so ordinary full target still resolves to `35` with the current fake `MaxCharge` and capacity.
+    - Add a rejected-path test for a manually constructed `mqtt.Intent{Kind: IntentForceCharge, TargetPct: 50, IgnoreMaxCharge: true}` to verify runner defense in depth, even though the parser should reject it.
+    - Keep paused rejection tests first in behavior order; paused commands should not write even for `0` or override requests.
+
+11. Update documentation in [docs/mqtt.md](../../../docs/mqtt.md).
+    - Revise Home Assistant discovery entity counts to include 2 number sliders and 5 buttons.
+    - Document selector topics `<prefix>/control/force_charge_target_pct` and `<prefix>/control/pause_duration_s` as Home Assistant selector state topics, not sbam command topics.
+    - Update discovery button action descriptions: `force_charge` reads the force target selector, maps `101` to `ignore_max_charge`, and publishes to `cmd/force_charge`; `pause` reads the pause duration selector and publishes `{}` or `{"until":"Ns"}`.
+    - Update command constraints: `target_pct` is `0..100`; `0` stops forced charge/restores defaults; `1..100` is capped by `max_charge`; `ignore_max_charge=true` is accepted only with `target_pct=100`; raw `101` is invalid.
+    - Add `mosquitto_pub` examples for ordinary capped force charge, uncapped full-charge override, `target_pct:0`, pause indefinite, and pause duration.
+    - Update rejected ack example text from `1 and 100` to `0 and 100` where appropriate.
+
+12. Update Home Assistant add-on docs in [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md) and [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md).
+    - In `DOCS.md`, mention that enabling MQTT discovery now creates force-charge and pause sliders plus send buttons.
+    - Explain the `101` force-charge selector value as an explicit full-charge override that ignores `max_charge`; keep this concise and avoid dashboard redesign instructions.
+    - In `CHANGELOG.md`, add a bullet under `Changes 2.0.0` for the new Home Assistant MQTT slider controls and explicit uncapped full-charge command semantics.
+    - No add-on schema or runtime script changes should be made.
+
+13. Review README impact in [README.md](../../../README.md).
+    - The README mostly delegates MQTT details to [docs/mqtt.md](../../../docs/mqtt.md). Only update it if existing text becomes inaccurate after the docs changes; otherwise leave it untouched to avoid duplicate MQTT reference content.
+
+## Test Plan
+
+### `pkg/mqtt`
+
+Expected cases:
+
+- Discovery includes `number/force_charge_target_pct` and `number/pause_duration_s` with min/max/step/mode, selector topics, default entity IDs, shared device metadata, availability topic, QoS 1, and retained selector publication.
+- Existing `button/force_charge` and `button/pause` remain present, keep existing command topics, and include `command_template` values that reference the selector entity IDs.
+- `ParseIntent` accepts `{"target_pct":0}`, ordinary capped values `1..100`, `duration_s` values `0..86400`, explicit override `{"target_pct":100,"ignore_max_charge":true}`, pause `{}`, and pause durations like `{"until":"3600s"}`.
+
+Edge cases:
+
+- Force target `0`, `1`, `100`, and raw `101`.
+- Pause duration `0`, `1`, `86400`, and future RFC3339 timestamps.
+- Empty payloads for commands that still accept them.
+- Discovery prefix and topic prefix normalization for selector topics.
+
+Failure cases:
+
+- `force_charge` missing `target_pct`, negative target, raw target over `100`, string target, malformed JSON, unknown fields, invalid `ignore_max_charge` type, and `ignore_max_charge=true` with target less than `100`.
+- `pause.until` empty string, `0s`, negative duration, malformed duration, non-string value, and past RFC3339 timestamp.
+- Payload size above `MaxPayloadBytes` remains rejected.
+
+Mocks:
+
+- Use existing fake MQTT client helpers for retained discovery publication checks.
+- No network broker is needed for unit tests.
+
+### `pkg/cmd`
+
+Expected cases:
+
+- Ordinary `force_charge` values `1..100` keep using storage-backed capping via `resolveForceChargeTargetPct`.
+- `{"target_pct":100,"ignore_max_charge":true}` writes target `100` directly and publishes an accepted ack and state payload.
+- `{"target_pct":0}` writes target `0` directly and publishes an accepted ack and state payload.
+- Pause duration payloads still set finite pause deadlines and publish state/ack payloads.
+
+Edge cases:
+
+- `max_charge=0` still resolves ordinary capped requests to `0`.
+- Storage unavailable still rejects ordinary capped `target_pct:100`, but must not affect explicit override or `target_pct:0` because those paths do not need capacity lookup.
+- Paused runner rejects force-charge commands before any write.
+
+Failure cases:
+
+- Parser-rejected payloads publish rejected acks from `HandleCommand`.
+- Defense-in-depth runner rejection for impossible `Intent{TargetPct:50, IgnoreMaxCharge:true}`.
+- Battery writer error publishes rejected ack/error and does not publish successful state.
+
+Mocks:
+
+- Use existing `fakeBatteryWriter`, `fakeStorageClient`, and `newStorage` / `newBatteryWriter` overrides.
+- Defer restoration of package-level factories after each test.
+
+### `pkg/fronius`
+
+Expected cases:
+
+- Existing `ForceCharge(0)` tests already verify the helper delegates to defaults against the mock Modbus server.
+
+Edge cases:
+
+- No new Fronius register tests are required unless implementation changes `fronius.ForceCharge` itself.
+
+Failure cases:
+
+- Existing negative force-charge and unavailable mock server tests remain sufficient.
+
+Mocks:
+
+- Continue using `github.com/tbrandon/mbserver` with `defer` or existing teardown cleanup if tests are touched.
+
+### Documentation
+
+Expected cases:
+
+- [docs/mqtt.md](../../../docs/mqtt.md) command examples and constraints match parser behavior exactly.
+- [home-assistant/addons/sbam/DOCS.md](../../../home-assistant/addons/sbam/DOCS.md) describes the Home Assistant add-on user-facing discovery controls.
+- [home-assistant/addons/sbam/CHANGELOG.md](../../../home-assistant/addons/sbam/CHANGELOG.md) includes the feature in v2.0.0 changes.
+
+Failure cases:
+
+- Avoid documenting new config keys or add-on schema changes, because none are planned.
+
+## Validation Gates
+
+Run these before marking implementation complete:
+
+```bash
+go test ./pkg/mqtt ./pkg/cmd
+go test ./...
+make test
+make build
+```
+
+Run formatting if any Go files change:
+
+```bash
+go fmt ./pkg/mqtt ./pkg/cmd
+```
+
+No `docker build` gate is required because the Dockerfiles and add-on runtime image should not change. If implementation unexpectedly changes Docker or add-on build files, add:
+
+```bash
+docker build -t sbam:test .
+```
+
+Manual Home Assistant validation after unit tests:
+
+- Enable `mqtt_enabled=true` and `mqtt_ha_discovery=true`.
+- Confirm Home Assistant discovers the two number sliders and the `force_charge` / `pause` buttons under the same sbam device.
+- Move each slider and verify only `<prefix>/control/...` selector topics are published, not `<prefix>/cmd/...`.
+- Press `force_charge` with selector `80` and confirm `cmd/force_charge` receives `{"target_pct":80}` and sbam publishes an accepted ack.
+- Press `force_charge` with selector `101` and confirm `cmd/force_charge` receives `{"target_pct":100,"ignore_max_charge":true}` and sbam writes target `100`.
+- Press `pause` with selector `0` and confirm `{}` is published.
+- Press `pause` with selector `3600` and confirm `{"until":"3600s"}` is published.
+
+## Rollout / Backward Compatibility
+
+- Existing MQTT command topics stay unchanged: `<prefix>/cmd/force_charge` and `<prefix>/cmd/pause`.
+- Existing direct MQTT publishers using `{"target_pct":1..100}` continue to work, but now `target_pct:0` is also accepted as an explicit stop/defaults request.
+- Existing ordinary `target_pct:100` remains capped by `max_charge` unless `ignore_max_charge=true` is explicitly present.
+- Raw `target_pct:101` remains rejected so direct publishers do not accidentally bypass `max_charge` by sending out-of-range values.
+- Existing Home Assistant button object IDs `force_charge` and `pause` remain present. Their payloads become template-driven, defaulting to legacy-like behavior when selectors are unknown: capped `target_pct:100` for force charge and `{}` for pause.
+- The selector topics are new retained MQTT topics under `<prefix>/control/...`; they are not command topics and sbam should not subscribe to them.
+- Discovery payload changes are retained; Home Assistant may need MQTT discovery refresh or an sbam restart to pick up changed entity configs.
+- Update docs and add-on changelog as part of the implementation PR.
+
+## Security Considerations
+
+- Keep strict JSON decoding and `MaxPayloadBytes` enforcement to avoid broadening MQTT command input unnecessarily.
+- The uncapped full-charge path must require `ignore_max_charge=true` with `target_pct=100`; do not infer it from any ordinary `1..100` request.
+- `ignore_max_charge=true` bypasses `max_charge`, so it must be documented as a manual override and covered by tests.
+- Slider selector retained MQTT payloads contain only numeric control values, no secrets.
+- Do not log MQTT usernames, passwords, broker secrets, or Home Assistant service credentials while testing.
+- Modbus writes remain serialized through `Runner`; do not introduce direct writes from MQTT subscription callbacks.
+- Keep paused-state rejection ahead of force-charge writes so remote commands cannot bypass an intentional pause.
+
+## Gotchas
+
+- Home Assistant MQTT `number` entities publish when their value changes. To satisfy “slider changes do not execute commands,” their command topics must be harmless selector topics, not sbam `cmd/*` topics.
+- Button `command_template` relies on Home Assistant entity IDs. Set `default_entity_id` for the new number entities and document that renaming those entities can break the generated button templates until discovery is reset or the template is updated.
+- `min=0` requires pointer fields in Go discovery payload structs; plain numeric fields with `omitempty` will silently omit zero.
+- Existing `discoveryPayload` inherits `StateTopic` from `base`. Clear or intentionally override it for buttons and numbers so Home Assistant does not try to parse the sbam JSON state payload as a number selector.
+- `fronius.ForceCharge(..., 0)` currently calls `Setdefaults`; do not duplicate Modbus default-writing logic in the runner.
+- `duration_s` is parsed for `force_charge` but currently unused by the runner. Do not expand duration semantics in this feature unless separately requested.
+- `make test` runs with `-race`; keep tests deterministic and restore package-level factories with `defer`.
+- Home Assistant discovery accepts unknown keys, so unit tests must assert the exact fields we rely on rather than assuming Home Assistant will reject bad config.
+
+## Open Questions / Risks
+
+- RESOLVED: Home Assistant MQTT supports `number` slider mode and MQTT button `command_template`, so the preferred slider plus explicit send-button UX is viable.
+- RESOLVED: Pause slider value `0` maps to `{}` for existing indefinite pause behavior.
+- RESOLVED: Pause slider maximum is `86400` seconds.
+- RESOLVED: Force selector value `101` maps to `target_pct=100` with `ignore_max_charge=true`, an explicit payload convention for uncapped full charge.
+- RESOLVED: Force selector value `0` maps to `target_pct=0`, using existing Fronius defaults behavior.
+- DEFERRED: Manual Home Assistant validation is still required because discovery payloads can be syntactically valid while entity IDs, templates, or retained selector behavior are awkward in the UI.
+- DEFERRED: If users have already renamed Home Assistant entities, the default entity IDs used by templates may not match. The implementation should document this and prefer manual validation before release.
+
+## Confidence Score
+
+9/10.
+
+The implementation path is concrete, uses existing packages and tests, and Home Assistant supports the needed MQTT fields. The remaining risk is Home Assistant runtime behavior around `command_template` references to newly discovered `number` entity IDs; manual validation in a Home Assistant instance is the best way to raise confidence further.

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-PLAN.md
@@ -7,11 +7,11 @@
 
 ## Task Analysis
 
-Issue #128 asks sbam to improve the Home Assistant MQTT discovery UX for manual `force_charge` and `pause` commands. Users should be able to choose a force-charge target percentage and pause duration with sliders, then press explicit send buttons that publish to the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` topics.
+Issue #128 asks sbam to improve the Home Assistant MQTT discovery UX for manual `force_charge` and `pause` commands. Users should be able to choose a force-charge target percentage with a slider and a pause duration via a numeric input (box) with steppers, then press explicit send buttons that publish to the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` topics.
 
 Goals:
 
-- Add Home Assistant MQTT `number` entities rendered as sliders for force-charge target percent and pause duration seconds.
+- Add Home Assistant MQTT `number` entities: a slider for force-charge target percent and a numeric box (mode: box) for pause duration seconds.
 - Keep explicit button presses as the only way to publish to sbam command topics.
 - Keep ordinary force-charge requests subject to the existing `max_charge` cap.
 - Add an explicit full-charge override path for the slider's `>100` value.
@@ -25,7 +25,7 @@ Non-goals:
 - Do not change Fronius Modbus register addresses or unrelated charging algorithm behavior.
 - Do not modify Solcast or Fronius Solar API integrations.
 
-Acceptance criteria from the TASK are covered by adding two slider entities, templated send buttons, strict command parsing for ordinary and override requests, runner tests for capped and uncapped paths, docs updates, and validation with `go test ./...`, `make test`, and `make build`.
+Acceptance criteria from the TASK are covered by adding two number selector entities (force-charge slider and pause numeric box), templated send buttons, strict command parsing for ordinary and override requests, runner tests for capped and uncapped paths, docs updates, and validation with `go test ./...`, `make test`, and `make build`.
 
 ## Current State
 
@@ -43,7 +43,7 @@ Acceptance criteria from the TASK are covered by adding two slider entities, tem
 External Home Assistant facts checked on 2026-05-19:
 
 - MQTT button supports `command_template`, which generates the payload sent to `command_topic`: https://www.home-assistant.io/integrations/button.mqtt/
-- MQTT number supports `min`, `max`, `step`, `mode: slider`, `command_topic`, `state_topic`, `retain`, `qos`, and `command_template`: https://www.home-assistant.io/integrations/number.mqtt/
+- MQTT number supports `min`, `max`, `step`, `mode` (for example `slider` or `box`), `command_topic`, `state_topic`, `retain`, `qos`, and `command_template`: https://www.home-assistant.io/integrations/number.mqtt/
 - MQTT discovery accepts retained single-component discovery payloads and ignores unknown keys for compatibility: https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery
 
 ## Target Architecture
@@ -65,7 +65,7 @@ flowchart LR
 Discovery design:
 
 - Add `number` entity `force_charge_target_pct` with default entity ID `number.sbam_force_charge_target_pct`, `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, and command/state topic `<prefix>/control/force_charge_target_pct`.
-- Add `number` entity `pause_duration_s` with default entity ID `number.sbam_pause_duration_s`, `min=0`, `max=86400`, `step=60`, `mode=slider`, `unit_of_measurement="s"`, and command/state topic `<prefix>/control/pause_duration_s`.
+   - Add `number` entity `pause_duration_s` with default entity ID `number.sbam_pause_duration_s`, `min=0`, `max=86400`, `step=60`, `mode=box`, `unit_of_measurement="s"`, and command/state topic `<prefix>/control/pause_duration_s`.
 - Use the same topic for each selector's `command_topic` and `state_topic`, with `retain=true`, so the selected value is harmlessly retained by the broker and can be restored. sbam must not subscribe to these selector topics.
 - Update the existing Home Assistant `force_charge` button discovery payload to use `command_template` instead of a fixed payload. The button keeps `command_topic=<prefix>/cmd/force_charge` and defaults unknown selector state to `100` for backward-compatible behavior.
 - Update the existing Home Assistant `pause` button discovery payload to use `command_template`. It keeps `command_topic=<prefix>/cmd/pause` and defaults unknown selector state to `0`, which publishes `{}` for existing indefinite pause behavior.
@@ -115,7 +115,7 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
    - Add small pointer helpers such as `floatPtr(value float64) *float64` and `boolPtr(value bool) *bool`.
    - Add `numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, commandTopic string, min, max, step float64, unit, icon string) discoveryPayload`.
    - Add `templatedButtonPayload(base discoveryPayload, deviceID, objectID, name, commandTopic, commandTemplate string) discoveryPayload` or extend `buttonPayload` with an optional command-template argument.
-   - For number payloads, clear inherited `ValueTemplate` unless intentionally used, set `StateTopic` to the selector topic, set `CommandTopic` to the same selector topic, set `Retain=true`, set `Mode="slider"`, and set `QoS=1` through the existing base value.
+   - For number payloads, clear inherited `ValueTemplate` unless intentionally used, set `StateTopic` to the selector topic, set `CommandTopic` to the same selector topic, set `Retain=true`, set `Mode` to the requested value (e.g., `slider` for force target, `box` for pause), and set `QoS=1` through the existing base value.
 
 3. Add selector discovery entities in `BuildDiscovery` in [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go).
    - Increase the entity slice capacity from `18` to `20`.
@@ -166,7 +166,7 @@ MQTT discovery changes are data-only and controlled by existing `mqtt_enabled`, 
    - Extend `discoveryPayloadView` with `DefaultEntityID`, `CommandTemplate`, `Min`, `Max`, `Step`, `Mode`, `Retain`, `Unit`, and `Icon` fields. Use pointer types for `Min`, `Max`, `Step`, and `Retain` where zero or false must be asserted.
    - Update expected entity count to at least `20`.
    - Assert the new `number/force_charge_target_pct` payload has `min=0`, `max=101`, `step=1`, `mode=slider`, `unit_of_measurement="%"`, `default_entity_id="number.sbam_force_charge_target_pct"`, retained selector topic, QoS 1, and shared device identifier.
-   - Assert the new `number/pause_duration_s` payload has `min=0`, `max=86400`, `mode=slider`, `unit_of_measurement="s"`, `default_entity_id="number.sbam_pause_duration_s"`, retained selector topic, QoS 1, and shared device identifier.
+   - Assert the new `number/pause_duration_s` payload has `min=0`, `max=86400`, `mode=box`, `unit_of_measurement="s"`, `default_entity_id="number.sbam_pause_duration_s"`, retained selector topic, QoS 1, and shared device identifier.
    - Replace the fixed force-charge button payload assertion with assertions for `CommandTopic`, `CommandTemplate`, `retain=false`, and template substrings `number.sbam_force_charge_target_pct` and `ignore_max_charge`.
    - Assert the pause button template references `number.sbam_pause_duration_s`, emits `{}` for zero/unknown values, and emits an `until` seconds duration for positive values.
    - Add selector `controlTopic` normalization tests if the helper is exported only inside the package tests.
@@ -354,8 +354,8 @@ Manual Home Assistant validation after unit tests:
 ## Open Questions / Risks
 
 - RESOLVED: Home Assistant MQTT supports `number` slider mode and MQTT button `command_template`, so the preferred slider plus explicit send-button UX is viable.
-- RESOLVED: Pause slider value `0` maps to `{}` for existing indefinite pause behavior.
-- RESOLVED: Pause slider maximum is `86400` seconds.
+- RESOLVED: Pause selector value `0` maps to `{}` for existing indefinite pause behavior.
+- RESOLVED: Pause selector maximum is `86400` seconds.
 - RESOLVED: Force selector value `101` maps to `target_pct=100` with `ignore_max_charge=true`, an explicit payload convention for uncapped full charge.
 - RESOLVED: Force selector value `0` maps to `target_pct=0`, using existing Fronius defaults behavior.
 - DEFERRED: Manual Home Assistant validation is still required because discovery payloads can be syntactically valid while entity IDs, templates, or retained selector behavior are awkward in the UI.

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
@@ -1,4 +1,4 @@
-# Feature: Home Assistant Slider Controls for Force Charge and Pause
+# Feature: Home Assistant Controls for Force Charge and Pause
 
 > Source issue: [#128](https://github.com/atbore-phx/sbam/issues/128)
 > Fetched: 2026-05-19
@@ -6,14 +6,14 @@
 > Slug: `128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause` · Created: 2026-05-19
 
 ## Summary
-Home Assistant MQTT discovery should expose a slider control for `force_charge` and a numeric `box` input for `pause`, paired with explicit send buttons so users can choose a target charge percent or pause duration before publishing the command. The feature replaces the awkward fixed 100% force-charge button behavior with precise values that still respect server-side safety limits unless the user intentionally requests an uncapped full charge.
+Home Assistant MQTT discovery should expose numeric `box` controls for `force_charge` and `pause`, paired with explicit send buttons so users can choose a target charge percent or pause duration before publishing the command. The feature replaces the awkward fixed 100% force-charge button behavior with precise values that still respect server-side safety limits unless the user intentionally requests an uncapped full charge.
 
 ## Motivation / User Story
-As a Home Assistant user, I want to pick a charge target and pause duration with sliders and then press a button to send the command, so I can set precise values quickly without repeatedly pressing buttons or accidentally sending incorrect 100% force-charge commands that ignore `max_charge`.
+As a Home Assistant user, I want to pick a charge target and pause duration with numeric boxes and then press a button to send the command, so I can set precise values quickly without repeatedly pressing buttons or accidentally sending incorrect 100% force-charge commands that ignore `max_charge`.
 
 ## Scope
-- In scope: add or update Home Assistant MQTT discovery payloads for a slider control for `force_charge` target percent and a numeric box control for `pause` duration.
-- In scope: keep an explicit send action so changing a slider does not itself execute the command when the Home Assistant MQTT platform can support that behavior.
+- In scope: add or update Home Assistant MQTT discovery payloads for a numeric box control for `force_charge` target percent and a numeric box control for `pause` duration.
+- In scope: keep an explicit send action so changing a selector value does not itself execute the command when the Home Assistant MQTT platform can support that behavior.
 - In scope: publish or cause publication of payloads compatible with the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` command behavior.
 - In scope: preserve existing command topics and existing button-based integrations for backward compatibility.
 - In scope: enforce existing runtime `max_charge` caps for ordinary `force_charge` requests.
@@ -23,7 +23,7 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - Out of scope: introducing new configuration keys unless implementation research shows opt-in/opt-out behavior is required for backward compatibility.
 
 ## Functional Requirements
-- Home Assistant discovery must include a slider-like control for selecting a force-charge target percent.
+-- Home Assistant discovery must include a numeric box control (mode: box) for selecting a force-charge target percent.
 - The force-charge control must represent values from `0` through at least `100`, where values `1..100` map to `target_pct` percentages.
 - When a selected force-charge value is between `1` and `100`, the command payload must request `{"target_pct": <n>}` and the server must continue applying the configured `max_charge` cap as it does today.
 - When a selected force-charge value is greater than `100`, the value must be treated as a generic `max`/override request meaning `charge_pct=100` without applying the `max_charge` cap.
@@ -32,15 +32,15 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - The pause duration control must use `0..86400` seconds by default.
 - A pause duration value of `0` must publish `{}` to request the existing indefinite pause behavior.
 - Pause duration values from `1` through `86400` must publish a payload compatible with `parsePauseUntil`, such as `{"until":"3600s"}`.
-- The implementation must prefer a slider plus explicit send-button UX using Home Assistant MQTT `command_template` if viable.
-- If Home Assistant MQTT discovery cannot safely implement a separate send button with slider state using `command_template`, the PLAN must identify the limitation and propose the smallest compatible fallback.
+- The implementation must prefer a selector (box mode) plus explicit send-button UX using Home Assistant MQTT `command_template` if viable.
+- If Home Assistant MQTT discovery cannot safely implement a separate send button with selector state using `command_template`, the PLAN must identify the limitation and propose the smallest compatible fallback.
 - Existing consumers that publish directly to `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` must continue to work.
 
 ## Non-functional Requirements
 - Backward compatibility: existing MQTT command topics and existing button-based integrations must remain functional.
 - Safety / defaults: server-side `max_charge` caps remain enforced for ordinary force-charge values `1..100`.
 - Safety / defaults: uncapped full charge requires an explicit value greater than `100` and must not be triggered by the default send button payload.
-- Usability: slider changes should not execute commands when the selected Home Assistant MQTT approach can provide a separate explicit send action.
+- Usability: selector value changes (box mode) should not execute commands when the selected Home Assistant MQTT approach can provide a separate explicit send action.
 - Performance: discovery payload generation must remain local and deterministic with no additional runtime network calls.
 - Maintainability: payload builders and command parsing changes must follow existing `pkg/mqtt` patterns and be covered by focused unit tests.
 
@@ -62,13 +62,13 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - Fronius Modbus registers: no new registers expected; existing force-charge write behavior may be reused.
 
 ## Acceptance Criteria
-- [ ] Home Assistant discovers a slider for force-charge target percent and a numeric box for pause duration.
+- [ ] Home Assistant discovers a numeric box for force-charge target percent and a numeric box for pause duration.
 - [ ] Home Assistant discovers explicit send actions for force charge and pause, or the PLAN documents why pure MQTT discovery cannot provide that UX and selects the smallest compatible fallback.
-- [ ] Moving a slider alone does not execute the command when the selected Home Assistant MQTT approach supports a separate send action.
+- [ ] Changing a selector value alone does not execute the command when the selected Home Assistant MQTT approach supports a separate send action.
 - [ ] Pressing the force-charge send action publishes or causes handling of a valid payload compatible with existing `force_charge` command behavior.
 - [ ] Force-charge values `1..100` remain subject to the configured `max_charge` cap.
 - [ ] Force-charge values greater than `100` request full charge at `100%` without applying the `max_charge` cap.
-- [ ] Pressing the pause send action with slider value `0` requests the existing indefinite pause behavior using `{}`.
+- [ ] Pressing the pause send action with selector value `0` requests the existing indefinite pause behavior using `{}`.
 - [ ] Pressing the pause send action with values `1..86400` publishes an `until` duration string accepted by `parsePauseUntil`, for example `{"until":"3600s"}`.
 - [ ] Existing button-based clients and direct MQTT publishers for `cmd/force_charge` and `cmd/pause` continue to function.
 - [ ] Unit tests cover discovery payload JSON, command parsing, capped force-charge handling, uncapped full-charge handling, pause duration handling, and invalid payloads.
@@ -83,9 +83,9 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - Validation should include `go test ./...`, `make test`, and focused package tests for any modified packages.
 
 ## Risks / Open Questions
-- Home Assistant MQTT discovery may not support the desired slider plus separate send-button UX entirely through static discovery payloads. The preferred path is to use `command_template` if viable; if not viable, the PLAN must document the limitation and propose the smallest compatible fallback.
+- Home Assistant MQTT discovery may not support the desired selector-plus-separate-send-button UX entirely through static discovery payloads. The preferred path is to use `command_template` if viable; if not viable, the PLAN must document the limitation and propose the smallest compatible fallback.
 - The exact payload convention for uncapped full charge is not yet chosen. It should be explicit, testable, and backward-compatible with existing `target_pct` payloads.
-- The issue references slider values greater than `100`; Home Assistant `number` entity metadata must make that intentional without making ordinary users likely to select it accidentally.
+- The issue references selector values greater than `100`; Home Assistant `number` entity metadata must make that intentional without making ordinary users likely to select it accidentally.
 - Manual Home Assistant validation is still required after implementation because discovery payloads can be syntactically valid but awkward in the UI.
 
 ## References
@@ -100,4 +100,4 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 -- 2026-05-19: Pause selector value `0` should publish `{}` for the existing indefinite pause behavior.
 -- 2026-05-19: Pause selector maximum should be `86400` seconds.
 - 2026-05-19: Force-charge values greater than `100` should be treated as a generic `max` value meaning `charge_pct=100` without applying the configured cap.
-- 2026-05-19: Prefer Home Assistant MQTT `command_template` for the slider plus explicit send-button UX if viable.
+- 2026-05-19: Prefer Home Assistant MQTT `command_template` for the selector (box mode) plus explicit send-button UX if viable.

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
@@ -6,13 +6,13 @@
 > Slug: `128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause` · Created: 2026-05-19
 
 ## Summary
-Home Assistant MQTT discovery should expose slider-style controls for `force_charge` and `pause`, paired with explicit send buttons so users can choose a target charge percent or pause duration before publishing the command. The feature replaces the awkward fixed 100% force-charge button behavior with precise values that still respect server-side safety limits unless the user intentionally requests an uncapped full charge.
+Home Assistant MQTT discovery should expose a slider control for `force_charge` and a numeric `box` input for `pause`, paired with explicit send buttons so users can choose a target charge percent or pause duration before publishing the command. The feature replaces the awkward fixed 100% force-charge button behavior with precise values that still respect server-side safety limits unless the user intentionally requests an uncapped full charge.
 
 ## Motivation / User Story
 As a Home Assistant user, I want to pick a charge target and pause duration with sliders and then press a button to send the command, so I can set precise values quickly without repeatedly pressing buttons or accidentally sending incorrect 100% force-charge commands that ignore `max_charge`.
 
 ## Scope
-- In scope: add or update Home Assistant MQTT discovery payloads for slider controls related to `force_charge` target percent and `pause` duration.
+- In scope: add or update Home Assistant MQTT discovery payloads for a slider control for `force_charge` target percent and a numeric box control for `pause` duration.
 - In scope: keep an explicit send action so changing a slider does not itself execute the command when the Home Assistant MQTT platform can support that behavior.
 - In scope: publish or cause publication of payloads compatible with the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` command behavior.
 - In scope: preserve existing command topics and existing button-based integrations for backward compatibility.
@@ -28,7 +28,7 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - When a selected force-charge value is between `1` and `100`, the command payload must request `{"target_pct": <n>}` and the server must continue applying the configured `max_charge` cap as it does today.
 - When a selected force-charge value is greater than `100`, the value must be treated as a generic `max`/override request meaning `charge_pct=100` without applying the `max_charge` cap.
 - The override request must be explicit in the payload contract, using either a special field or a clearly documented convention chosen during implementation.
-- Home Assistant discovery must include a slider-like control for selecting pause duration in seconds.
+- Home Assistant discovery must include a numeric box control (`mode: box`) for selecting pause duration in seconds.
 - The pause duration control must use `0..86400` seconds by default.
 - A pause duration value of `0` must publish `{}` to request the existing indefinite pause behavior.
 - Pause duration values from `1` through `86400` must publish a payload compatible with `parsePauseUntil`, such as `{"until":"3600s"}`.
@@ -62,7 +62,7 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 - Fronius Modbus registers: no new registers expected; existing force-charge write behavior may be reused.
 
 ## Acceptance Criteria
-- [ ] Home Assistant discovers slider-style controls for force-charge target percent and pause duration.
+- [ ] Home Assistant discovers a slider for force-charge target percent and a numeric box for pause duration.
 - [ ] Home Assistant discovers explicit send actions for force charge and pause, or the PLAN documents why pure MQTT discovery cannot provide that UX and selects the smallest compatible fallback.
 - [ ] Moving a slider alone does not execute the command when the selected Home Assistant MQTT approach supports a separate send action.
 - [ ] Pressing the force-charge send action publishes or causes handling of a valid payload compatible with existing `force_charge` command behavior.
@@ -97,7 +97,7 @@ As a Home Assistant user, I want to pick a charge target and pause duration with
 
 ## Clarifications
 - 2026-05-19: Use slug `128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause`.
-- 2026-05-19: Pause slider value `0` should publish `{}` for the existing indefinite pause behavior.
-- 2026-05-19: Pause slider maximum should be `86400` seconds.
+-- 2026-05-19: Pause selector value `0` should publish `{}` for the existing indefinite pause behavior.
+-- 2026-05-19: Pause selector maximum should be `86400` seconds.
 - 2026-05-19: Force-charge values greater than `100` should be treated as a generic `max` value meaning `charge_pct=100` without applying the configured cap.
 - 2026-05-19: Prefer Home Assistant MQTT `command_template` for the slider plus explicit send-button UX if viable.

--- a/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
+++ b/docs/implementations/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause/128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause-TASK.md
@@ -1,0 +1,103 @@
+# Feature: Home Assistant Slider Controls for Force Charge and Pause
+
+> Source issue: [#128](https://github.com/atbore-phx/sbam/issues/128)
+> Fetched: 2026-05-19
+
+> Slug: `128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause` · Created: 2026-05-19
+
+## Summary
+Home Assistant MQTT discovery should expose slider-style controls for `force_charge` and `pause`, paired with explicit send buttons so users can choose a target charge percent or pause duration before publishing the command. The feature replaces the awkward fixed 100% force-charge button behavior with precise values that still respect server-side safety limits unless the user intentionally requests an uncapped full charge.
+
+## Motivation / User Story
+As a Home Assistant user, I want to pick a charge target and pause duration with sliders and then press a button to send the command, so I can set precise values quickly without repeatedly pressing buttons or accidentally sending incorrect 100% force-charge commands that ignore `max_charge`.
+
+## Scope
+- In scope: add or update Home Assistant MQTT discovery payloads for slider controls related to `force_charge` target percent and `pause` duration.
+- In scope: keep an explicit send action so changing a slider does not itself execute the command when the Home Assistant MQTT platform can support that behavior.
+- In scope: publish or cause publication of payloads compatible with the existing `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` command behavior.
+- In scope: preserve existing command topics and existing button-based integrations for backward compatibility.
+- In scope: enforce existing runtime `max_charge` caps for ordinary `force_charge` requests.
+- In scope: support an intentional uncapped full-charge request when the selected force-charge control value is greater than `100`.
+- Out of scope: a full Home Assistant UI redesign outside MQTT discovery payloads and documented UX behavior.
+- Out of scope: changing unrelated Fronius Modbus safety limits or charge scheduling logic.
+- Out of scope: introducing new configuration keys unless implementation research shows opt-in/opt-out behavior is required for backward compatibility.
+
+## Functional Requirements
+- Home Assistant discovery must include a slider-like control for selecting a force-charge target percent.
+- The force-charge control must represent values from `0` through at least `100`, where values `1..100` map to `target_pct` percentages.
+- When a selected force-charge value is between `1` and `100`, the command payload must request `{"target_pct": <n>}` and the server must continue applying the configured `max_charge` cap as it does today.
+- When a selected force-charge value is greater than `100`, the value must be treated as a generic `max`/override request meaning `charge_pct=100` without applying the `max_charge` cap.
+- The override request must be explicit in the payload contract, using either a special field or a clearly documented convention chosen during implementation.
+- Home Assistant discovery must include a slider-like control for selecting pause duration in seconds.
+- The pause duration control must use `0..86400` seconds by default.
+- A pause duration value of `0` must publish `{}` to request the existing indefinite pause behavior.
+- Pause duration values from `1` through `86400` must publish a payload compatible with `parsePauseUntil`, such as `{"until":"3600s"}`.
+- The implementation must prefer a slider plus explicit send-button UX using Home Assistant MQTT `command_template` if viable.
+- If Home Assistant MQTT discovery cannot safely implement a separate send button with slider state using `command_template`, the PLAN must identify the limitation and propose the smallest compatible fallback.
+- Existing consumers that publish directly to `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause` must continue to work.
+
+## Non-functional Requirements
+- Backward compatibility: existing MQTT command topics and existing button-based integrations must remain functional.
+- Safety / defaults: server-side `max_charge` caps remain enforced for ordinary force-charge values `1..100`.
+- Safety / defaults: uncapped full charge requires an explicit value greater than `100` and must not be triggered by the default send button payload.
+- Usability: slider changes should not execute commands when the selected Home Assistant MQTT approach can provide a separate explicit send action.
+- Performance: discovery payload generation must remain local and deterministic with no additional runtime network calls.
+- Maintainability: payload builders and command parsing changes must follow existing `pkg/mqtt` patterns and be covered by focused unit tests.
+
+## Configuration Impact
+- New CLI flags: none expected.
+- New config keys (`config.yaml`): none expected unless the PLAN justifies an opt-in/out switch for the new discovery controls.
+- New env vars: none expected.
+- Home Assistant add-on schema changes (`home-assistant/addons/sbam/config.json`): none expected unless a new config key is introduced.
+- MQTT discovery: add or change Home Assistant discovery entities in `pkg/mqtt/discovery.go`, likely including `number` entities and send buttons for force charge and pause.
+
+## External Integrations Touched
+- MQTT discovery: Home Assistant MQTT discovery payloads under the configured discovery prefix.
+- MQTT command topics: `PREFIX/cmd/force_charge` and `PREFIX/cmd/pause`.
+- MQTT command parsing: `pkg/mqtt/commands.go` if an explicit override field or additional payload convention is introduced.
+- Schedule command handling: `pkg/cmd/schedule_runner.go` if force-charge intent needs an uncapped/full-charge flag propagated to runner logic.
+- Fronius charge handling: `pkg/fronius` only if uncapped full charge requires a new target-resolution path separate from existing capped behavior.
+- Solcast: not touched.
+- Fronius Solar API: not touched directly.
+- Fronius Modbus registers: no new registers expected; existing force-charge write behavior may be reused.
+
+## Acceptance Criteria
+- [ ] Home Assistant discovers slider-style controls for force-charge target percent and pause duration.
+- [ ] Home Assistant discovers explicit send actions for force charge and pause, or the PLAN documents why pure MQTT discovery cannot provide that UX and selects the smallest compatible fallback.
+- [ ] Moving a slider alone does not execute the command when the selected Home Assistant MQTT approach supports a separate send action.
+- [ ] Pressing the force-charge send action publishes or causes handling of a valid payload compatible with existing `force_charge` command behavior.
+- [ ] Force-charge values `1..100` remain subject to the configured `max_charge` cap.
+- [ ] Force-charge values greater than `100` request full charge at `100%` without applying the `max_charge` cap.
+- [ ] Pressing the pause send action with slider value `0` requests the existing indefinite pause behavior using `{}`.
+- [ ] Pressing the pause send action with values `1..86400` publishes an `until` duration string accepted by `parsePauseUntil`, for example `{"until":"3600s"}`.
+- [ ] Existing button-based clients and direct MQTT publishers for `cmd/force_charge` and `cmd/pause` continue to function.
+- [ ] Unit tests cover discovery payload JSON, command parsing, capped force-charge handling, uncapped full-charge handling, pause duration handling, and invalid payloads.
+
+## Test Strategy
+- Unit tests in `pkg/mqtt` should verify discovery payloads for new `number` entities, send buttons, command topics, templates, min/max/step values, and retained/QoS behavior.
+- Unit tests in `pkg/mqtt` should verify parsing for ordinary `force_charge` payloads, the explicit full-charge override convention, ordinary pause durations, indefinite pause `{}`, and invalid inputs.
+- Unit tests in `pkg/cmd` should verify runner command handling preserves capped behavior for `1..100` and allows explicit uncapped full charge only through the agreed override convention.
+- Unit tests in `pkg/fronius` should cover target resolution if force-charge capping logic changes there.
+- Edge cases: force-charge `0`, `1`, `100`, `101`, malformed values, pause `0`, `1`, `86400`, negative pause values, non-duration strings, and RFC3339 values if still supported by existing parsing.
+- Failure cases: invalid JSON payloads, invalid number values, and command payloads that request override without the explicit convention.
+- Validation should include `go test ./...`, `make test`, and focused package tests for any modified packages.
+
+## Risks / Open Questions
+- Home Assistant MQTT discovery may not support the desired slider plus separate send-button UX entirely through static discovery payloads. The preferred path is to use `command_template` if viable; if not viable, the PLAN must document the limitation and propose the smallest compatible fallback.
+- The exact payload convention for uncapped full charge is not yet chosen. It should be explicit, testable, and backward-compatible with existing `target_pct` payloads.
+- The issue references slider values greater than `100`; Home Assistant `number` entity metadata must make that intentional without making ordinary users likely to select it accidentally.
+- Manual Home Assistant validation is still required after implementation because discovery payloads can be syntactically valid but awkward in the UI.
+
+## References
+- [Issue #128](https://github.com/atbore-phx/sbam/issues/128)
+- [Related PR #127](https://github.com/atbore-phx/sbam/pull/127)
+- [pkg/mqtt/discovery.go](../../../pkg/mqtt/discovery.go)
+- [pkg/mqtt/commands.go](../../../pkg/mqtt/commands.go)
+- [pkg/cmd/schedule_runner.go](../../../pkg/cmd/schedule_runner.go)
+
+## Clarifications
+- 2026-05-19: Use slug `128-issue-feature-home-assistant-slider-controls-for-force-charge-and-pause`.
+- 2026-05-19: Pause slider value `0` should publish `{}` for the existing indefinite pause behavior.
+- 2026-05-19: Pause slider maximum should be `86400` seconds.
+- 2026-05-19: Force-charge values greater than `100` should be treated as a generic `max` value meaning `charge_pct=100` without applying the configured cap.
+- 2026-05-19: Prefer Home Assistant MQTT `command_template` for the slider plus explicit send-button UX if viable.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -46,7 +46,17 @@ Current discovery set includes:
 
 - 10 sensors
 - 3 binary sensors
+- 2 numbers (`force_charge_target_pct`, `pause_duration_s`)
 - 5 buttons (`trigger_now`, `pause`, `resume`, `force_charge`, `set_defaults`)
+
+### Discovery selector entities
+
+When discovery is enabled, Home Assistant receives two slider-backed MQTT number entities:
+
+- `force_charge_target_pct`: retained selector on `<prefix>/control/force_charge_target_pct` with range `0..101`.
+- `pause_duration_s`: retained selector on `<prefix>/control/pause_duration_s` with range `0..86400` seconds.
+
+These selector topics store user selection state only. sbam command execution still happens only through the command buttons.
 
 ### Discovery button actions
 
@@ -54,9 +64,14 @@ Each Home Assistant button publishes to `<prefix>/cmd/<name>`, and sbam publishe
 an acknowledgement on `<prefix>/cmd/<name>/ack`.
 
 - `trigger_now`: requests one immediate schedule evaluation run.
-- `pause`: pauses indefinitely the automatic schedule processing.
+- `pause`: reads the `pause_duration_s` selector and sends:
+  - `{}` when selector value is `0` (existing indefinite pause behavior)
+  - `{"until":"<seconds>s"}` when selector value is `1..86400`
 - `resume`: clears pause state and resumes automatic schedule processing.
-- `force_charge`: requests a manual force charge. The button sends `{"target_pct":100}` which is the maximum load percentage. NB: sbam caps the effective target by `max_charge` (see configuration) and battery capacity at runtime.
+- `force_charge`: reads the `force_charge_target_pct` selector and sends:
+  - `{"target_pct":0}` when selector value is `0` (stop force charge / restore defaults)
+  - `{"target_pct":<n>}` when selector value is `1..100` (still capped by `max_charge` and battery capacity)
+  - `{"target_pct":100,"ignore_max_charge":true}` when selector value is `101` (explicit uncapped full-charge override)
 - `set_defaults`: restores inverter defaults via the configured Modbus write path.
 
 ### Command sequencing note (schedule active)
@@ -113,6 +128,7 @@ Use `mqtt_topic_prefix` to change the default `sbam` prefix.
 | `<prefix>/error` (default `sbam/error`) | sbam publishes | not retained, qos 1 | `ErrorPayload` JSON |
 | `<prefix>/cmd/+` (default `sbam/cmd/+`) | sbam subscribes | qos 1 | command payload JSON |
 | `<prefix>/cmd/<name>/ack` | sbam publishes | not retained, qos 1 | `AckPayload` JSON |
+| `<prefix>/control/+` | Home Assistant publishes selector values | retained, qos 1 | slider state used by discovery button templates |
 | `<mqtt_ha_discovery_prefix>/<component>/sbam/<object_id>/config` | sbam publishes | retained, qos 1 | Home Assistant discovery config |
 
 Defaults:
@@ -145,7 +161,7 @@ Error payload (`<prefix>/error`):
 
 ```json
 {
-  "error": "invalid payload: target_pct must be between 1 and 100",
+  "error": "invalid payload: target_pct must be between 0 and 100",
   "source": "force_charge",
   "ts": "2026-05-18T21:01:00Z"
 }
@@ -168,7 +184,7 @@ Rejected ack payload (`<prefix>/cmd/force_charge/ack`):
   "ts": "2026-05-18T21:01:10Z",
   "command": "force_charge",
   "accepted": false,
-  "error": "invalid payload: target_pct must be between 1 and 100"
+  "error": "invalid payload: target_pct must be between 0 and 100"
 }
 ```
 
@@ -194,6 +210,12 @@ mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/resume" -
 # force_charge
 mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/force_charge" -m '{"target_pct":80}'
 
+# force_charge explicit uncapped full-charge override
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/force_charge" -m '{"target_pct":100,"ignore_max_charge":true}'
+
+# force_charge stop/reset (restores defaults)
+mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/force_charge" -m '{"target_pct":0}'
+
 # set_defaults
 mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/set_defaults" -m '{}'
 ```
@@ -201,6 +223,9 @@ mosquitto_pub -h "$BROKER_HOST" -p "$BROKER_PORT" -q 1 -t "$PREFIX/cmd/set_defau
 Command payload constraints:
 
 - Maximum payload size is 4096 bytes.
-- `force_charge.target_pct` is required and must be between 1 and 100.
-- sbam always caps `force_charge.target_pct` by `max_charge` using live battery max capacity.
+- `force_charge.target_pct` is required and must be between 0 and 100.
+- `force_charge.target_pct=0` stops forced charge and restores defaults through the existing Fronius defaults path.
+- `force_charge.target_pct=1..100` remains capped by `max_charge` using live battery max capacity.
+- `force_charge.ignore_max_charge=true` is accepted only when `target_pct=100`; it requests an explicit uncapped full-charge write.
+- Raw `target_pct=101` is invalid for direct command payloads.
 - `pause.until` is optional; when set, it must be a future RFC3339 timestamp or a positive Go duration.

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -51,10 +51,10 @@ Current discovery set includes:
 
 ### Discovery selector entities
 
-When discovery is enabled, Home Assistant receives two slider-backed MQTT number entities:
+When discovery is enabled, Home Assistant receives two numeric selector MQTT `number` entities (mode: box):
 
-- `force_charge_target_pct`: retained selector on `<prefix>/control/force_charge_target_pct` with range `0..101`.
-- `pause_duration_s`: retained selector on `<prefix>/control/pause_duration_s` with range `0..86400` seconds.
+- `force_charge_target_pct`: retained selector on `<prefix>/control/force_charge_target_pct` with range `0..101`, mode `box`, step `1`, unit `%`.
+- `pause_duration_s`: retained selector on `<prefix>/control/pause_duration_s` with range `0..86400` seconds, mode `box`, step `60`.
 
 These selector topics store user selection state only. sbam command execution still happens only through the command buttons.
 

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,27 +1,22 @@
-## Release Changelog
-[sbam](https://github.com/atbore-phx/sbam/releases/latest)
-
-### Doc v2.0.0
+## What's New in v2.0.0
 [docs](https://github.com/atbore-phx/sbam/blob/main/home-assistant/addons/sbam/DOCS.md#new-features-in-v200)
 
-### Changes 2.0.0
+## Changes 2.0.0
 
+- Added support for cross-midnight charge (`start_hr`, `end_hr`) and reserve (`batt_reserve_start_hr`, `batt_reserve_end_hr`) windows, for example 23:00-05:00. Equal start and end values remain invalid.
 - Added opt-in MQTT support to the add-on with configuration keys for broker, credentials, topic prefix, and Home Assistant discovery controls.
 - Added MQTT runtime topics for availability, state snapshots, error reports, command intake, and per-command acknowledgement payloads.
 - Added Home Assistant MQTT Discovery publication so sbam entities are created automatically when MQTT discovery is enabled.
+- Added MQTT command handling for `trigger_now`, `pause`, `resume`, `force_charge`, and `set_defaults`.
 - Added Home Assistant MQTT slider selectors for force-charge target and pause duration with explicit send-button actions, including an explicit uncapped full-charge override payload (`{"target_pct":100,"ignore_max_charge":true}`).
 - Added serialized schedule execution through a single runner queue so cron ticks and MQTT command intents do not race each other.
-- Added MQTT command handling for trigger_now, pause, resume, force_charge, and set_defaults.
 - Added extensive tests across MQTT client behavior, command parsing, discovery payloads, schedule runner lifecycle, cron wiring, and config precedence.
-- Changed add-on manifest version to 2.0.0.
-- Changed add-on manifest to declare optional Home Assistant MQTT service availability.
-- Changed add-on runtime script to export MQTT environment variables used by the schedule command.
 - Changed add-on startup behavior to auto-fill MQTT broker host/port and optional credentials from Home Assistant service data only when MQTT is enabled and broker is not manually set.
 - Changed precedence behavior so manually configured broker, username, and password are preserved over auto-filled Home Assistant service values.
 - Changed documentation coverage with expanded add-on setup guidance, MQTT usage notes, topic and payload references, command examples, and migration notes.
+- Enhanced non-blocking `schedule` execution in case of errors or long-running operations, with serialized command and cron execution through a single runner queue. 
 - Improved Fronius decision/classification error handling and related test coverage for safer failure behavior.
 - Clarified release scope: set_reserve remains intentionally unsupported in v2.0.0.
-- Added support for cross-midnight reserve windows, for example 23:00-05:00.
-- Fixed schedule charge and reserve window evaluation so local-time cron ticks are not compared as UTC.
-- Fixed early-morning tick handling in non-UTC timezones so configured local windows are honored.
-- Kept malformed time strings and equal start/end values invalid with explicit validation errors.
+
+## Full Release Changelog
+[sbam](https://github.com/atbore-phx/sbam/releases/latest)

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## What's New in v2.0.0
-[docs](https://github.com/atbore-phx/sbam/blob/main/home-assistant/addons/sbam/DOCS.md#new-features-in-v200)
+[link to news for v2.0.0](https://github.com/atbore-phx/sbam/blob/main/home-assistant/addons/sbam/DOCS.md#new-features-in-v200)
 
 ## Changes 2.0.0
 
@@ -19,4 +19,4 @@
 - Clarified release scope: set_reserve remains intentionally unsupported in v2.0.0.
 
 ## Full Release Changelog
-[sbam](https://github.com/atbore-phx/sbam/releases/latest)
+[link to sbam latest release](https://github.com/atbore-phx/sbam/releases/latest)

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added opt-in MQTT support to the add-on with configuration keys for broker, credentials, topic prefix, and Home Assistant discovery controls.
 - Added MQTT runtime topics for availability, state snapshots, error reports, command intake, and per-command acknowledgement payloads.
 - Added Home Assistant MQTT Discovery publication so sbam entities are created automatically when MQTT discovery is enabled.
+- Added Home Assistant MQTT slider selectors for force-charge target and pause duration with explicit send-button actions, including an explicit uncapped full-charge override payload (`{"target_pct":100,"ignore_max_charge":true}`).
 - Added serialized schedule execution through a single runner queue so cron ticks and MQTT command intents do not race each other.
 - Added MQTT command handling for trigger_now, pause, resume, force_charge, and set_defaults.
 - Added extensive tests across MQTT client behavior, command parsing, discovery payloads, schedule runner lifecycle, cron wiring, and config precedence.

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -126,6 +126,8 @@ Add-on specific behavior:
 - Auto-fill applies only to empty values and does not overwrite manual broker, username, or password.
 - `mqtt_topic_prefix` controls state, error, availability, and command topics (default `sbam`).
 - `mqtt_ha_discovery_prefix` controls Home Assistant discovery topics (default `homeassistant`).
+- Home Assistant discovery includes slider selectors for `force_charge_target_pct` and `pause_duration_s`, plus explicit send buttons for force charge and pause.
+- Force-charge selector value `101` is treated as an explicit full-charge override and sends `{"target_pct":100,"ignore_max_charge":true}`.
 
 #### Cross-midnight time window configuration
 

--- a/home-assistant/addons/sbam/DOCS.md
+++ b/home-assistant/addons/sbam/DOCS.md
@@ -126,7 +126,7 @@ Add-on specific behavior:
 - Auto-fill applies only to empty values and does not overwrite manual broker, username, or password.
 - `mqtt_topic_prefix` controls state, error, availability, and command topics (default `sbam`).
 - `mqtt_ha_discovery_prefix` controls Home Assistant discovery topics (default `homeassistant`).
-- Home Assistant discovery includes slider selectors for `force_charge_target_pct` and `pause_duration_s`, plus explicit send buttons for force charge and pause.
+- Home Assistant discovery includes numeric box selectors for `force_charge_target_pct` and `pause_duration_s` (box mode), plus explicit send buttons for force charge and pause.
 - Force-charge selector value `101` is treated as an explicit full-charge override and sends `{"target_pct":100,"ignore_max_charge":true}`.
 
 #### Cross-midnight time window configuration

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -486,10 +486,10 @@ func (r *Runner) setPause(pauseUntil *time.Time) {
 		u.Log.Info("schedule paused indefinitely")
 		return
 	}
-
-	until := pauseUntil.UTC()
-	r.paused.Store(&until)
-	u.Log.Infof("schedule paused until %s", until.Format(time.RFC3339))
+	untilUTC := pauseUntil.UTC()
+	r.paused.Store(&untilUTC)
+	localUntil := pauseUntil.In(r.now().Location())
+	u.Log.Infof("schedule paused until %s", localUntil.Format(time.RFC3339))
 }
 
 // clearPause removes any pause deadline.
@@ -512,7 +512,8 @@ func (r *Runner) pauseStateAt(now time.Time) (bool, *time.Time) {
 
 	until := deadline.UTC()
 	if !until.After(now) {
-		u.Log.Infof("pause expired at %s; resuming", until.Format(time.RFC3339))
+		localUntil := until.In(r.now().Location())
+		u.Log.Infof("pause expired at %s; resuming", localUntil.Format(time.RFC3339))
 		r.clearPause()
 		return false, nil
 	}

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -323,16 +323,33 @@ func (r *Runner) handleForceCharge(ctx context.Context, intent mqtt.Intent) erro
 		r.publishError(ctx, "force_charge", err)
 		return err
 	}
-	if intent.TargetPct < 1 || intent.TargetPct > 100 {
-		err := fmt.Errorf("%w: target_pct must be between 1 and 100", mqtt.ErrInvalidPayload)
+	if intent.TargetPct < 0 || intent.TargetPct > 100 {
+		err := fmt.Errorf("%w: target_pct must be between 0 and 100", mqtt.ErrInvalidPayload)
 		r.publishError(ctx, "force_charge", err)
 		return err
 	}
 
-	targetPct, err := r.resolveForceChargeTargetPct(intent.TargetPct)
-	if err != nil {
-		r.publishError(ctx, "force_charge", err)
-		return err
+	var (
+		targetPct int16
+		err       error
+	)
+
+	switch {
+	case intent.IgnoreMaxCharge:
+		if intent.TargetPct != 100 {
+			err = fmt.Errorf("%w: ignore_max_charge requires target_pct 100", mqtt.ErrInvalidPayload)
+			r.publishError(ctx, "force_charge", err)
+			return err
+		}
+		targetPct = 100
+	case intent.TargetPct == 0:
+		targetPct = 0
+	default:
+		targetPct, err = r.resolveForceChargeTargetPct(intent.TargetPct)
+		if err != nil {
+			r.publishError(ctx, "force_charge", err)
+			return err
+		}
 	}
 
 	if err := r.writer.ForceCharge(r.cfg.FroniusIP, targetPct); err != nil {

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -269,6 +269,115 @@ func TestRunner_ForceChargeCommandAt100UsesMaxChargeCap(t *testing.T) {
 	assert.Equal(t, "force_charge", ack.Command)
 }
 
+func TestRunner_ForceChargeCommandZeroSetsDefaults(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":0}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 0, fakeStorage.calls)
+	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
+	assert.Equal(t, int16(0), fakeWriter.lastTargetPct)
+
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	require.NotNil(t, state.ChargePct)
+	assert.Equal(t, int16(0), *state.ChargePct)
+
+	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
+	require.True(t, ok, "expected ack publish")
+	ack := decodeAckPayload(t, ackMsg.payload)
+	assert.True(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+}
+
+func TestRunner_ForceChargeCommandIgnoreMaxChargeBypassesCap(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	accepted := runner.HandleCommand(context.Background(), "sbam/cmd/force_charge", []byte(`{"target_pct":100,"ignore_max_charge":true}`))
+	require.True(t, accepted)
+
+	intent := <-runner.intents
+	runner.handleIntent(context.Background(), intent)
+
+	assert.Equal(t, 0, fakeStorage.calls)
+	assert.Equal(t, 1, fakeWriter.forceChargeCalls)
+	assert.Equal(t, int16(100), fakeWriter.lastTargetPct)
+
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	require.NotNil(t, state.ChargePct)
+	assert.Equal(t, int16(100), *state.ChargePct)
+
+	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
+	require.True(t, ok, "expected ack publish")
+	ack := decodeAckPayload(t, ackMsg.payload)
+	assert.True(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+}
+
+func TestRunner_ForceChargeRejectsInvalidOverrideIntent(t *testing.T) {
+	client := newFakeClient()
+	fakeWriter := &fakeBatteryWriter{}
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+
+	oldFactory := newBatteryWriter
+	newBatteryWriter = func() batteryWriter { return fakeWriter }
+	defer func() { newBatteryWriter = oldFactory }()
+
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.handleIntent(context.Background(), mqtt.Intent{
+		Kind:            mqtt.IntentForceCharge,
+		TargetPct:       50,
+		IgnoreMaxCharge: true,
+		CommandTopic:    "sbam/cmd/force_charge",
+	})
+
+	assert.Equal(t, 0, fakeStorage.calls)
+	assert.Equal(t, 0, fakeWriter.forceChargeCalls)
+
+	msgs := drainPublishes(client)
+	ackMsg, ok := findPublishedBySuffix(msgs, "/ack")
+	require.True(t, ok, "expected ack publish")
+	ack := decodeAckPayload(t, ackMsg.payload)
+	assert.False(t, ack.Accepted)
+	assert.Equal(t, "force_charge", ack.Command)
+	assert.Contains(t, ack.Error, "ignore_max_charge requires target_pct 100")
+}
+
 func TestRunner_ForceChargeCommandAt100RejectedWhenCapacityUnavailable(t *testing.T) {
 	client := newFakeClient()
 	fakeWriter := &fakeBatteryWriter{}

--- a/pkg/mqtt/commands.go
+++ b/pkg/mqtt/commands.go
@@ -28,8 +28,9 @@ type commandTopicInfo struct {
 }
 
 type forceChargePayload struct {
-	TargetPct *int `json:"target_pct"`
-	DurationS *int `json:"duration_s,omitempty"`
+	TargetPct       *int  `json:"target_pct"`
+	DurationS       *int  `json:"duration_s,omitempty"`
+	IgnoreMaxCharge *bool `json:"ignore_max_charge,omitempty"`
 }
 
 type pausePayload struct {
@@ -38,6 +39,11 @@ type pausePayload struct {
 
 var jsonMarshal = json.Marshal
 
+// ParseIntent parses an MQTT command topic and payload into a validated Intent.
+//
+// ParseIntent enforces payload size limits and strict JSON decoding rules,
+// normalizes supported command names, and returns ErrInvalidPayload or
+// ErrUnknownCommand when the request cannot be accepted.
 func ParseIntent(topic string, payload []byte) (Intent, error) {
 	return parseIntentAt(topic, payload, time.Now().UTC())
 }
@@ -66,6 +72,7 @@ func parseIntentAt(topic string, payload []byte, now time.Time) (Intent, error) 
 			TargetPct:    int16(*forcePayload.TargetPct),
 			CommandTopic: topic,
 		}
+		intent.IgnoreMaxCharge = forcePayload.IgnoreMaxCharge != nil && *forcePayload.IgnoreMaxCharge
 		if forcePayload.DurationS != nil {
 			intent.DurationS = *forcePayload.DurationS
 		}
@@ -180,8 +187,12 @@ func parseForceChargePayload(payload []byte) (forceChargePayload, error) {
 	if parsed.TargetPct == nil {
 		return forceChargePayload{}, fmt.Errorf("%w: target_pct is required", ErrInvalidPayload)
 	}
-	if *parsed.TargetPct < 1 || *parsed.TargetPct > 100 {
-		return forceChargePayload{}, fmt.Errorf("%w: target_pct must be between 1 and 100", ErrInvalidPayload)
+	if *parsed.TargetPct < 0 || *parsed.TargetPct > 100 {
+		return forceChargePayload{}, fmt.Errorf("%w: target_pct must be between 0 and 100", ErrInvalidPayload)
+	}
+
+	if parsed.IgnoreMaxCharge != nil && *parsed.IgnoreMaxCharge && *parsed.TargetPct != 100 {
+		return forceChargePayload{}, fmt.Errorf("%w: ignore_max_charge requires target_pct 100", ErrInvalidPayload)
 	}
 
 	if parsed.DurationS != nil {

--- a/pkg/mqtt/commands_test.go
+++ b/pkg/mqtt/commands_test.go
@@ -24,6 +24,7 @@ func TestParseIntentCanonicalCommands(t *testing.T) {
 		expectedKind     IntentKind
 		expectedTarget   int16
 		expectedDuration int
+		expectedIgnore   bool
 		checkPause       bool
 		expectPauseNil   bool
 	}{
@@ -32,6 +33,7 @@ func TestParseIntentCanonicalCommands(t *testing.T) {
 		{name: "set_defaults empty", topic: "sbam/cmd/set_defaults", payload: nil, expectedKind: IntentSetDefaults},
 		{name: "resume empty object", topic: "sbam/cmd/resume", payload: []byte("{}"), expectedKind: IntentResume},
 		{name: "force_charge full payload", topic: "sbam/cmd/force_charge", payload: []byte(`{"target_pct":50,"duration_s":3600}`), expectedKind: IntentForceCharge, expectedTarget: 50, expectedDuration: 3600},
+		{name: "force_charge explicit override", topic: "sbam/cmd/force_charge", payload: []byte(`{"target_pct":100,"ignore_max_charge":true}`), expectedKind: IntentForceCharge, expectedTarget: 100, expectedIgnore: true},
 		{name: "pause empty payload is indefinite", topic: "sbam/cmd/pause", payload: nil, expectedKind: IntentPause, expectPauseNil: true},
 		{name: "pause empty object is indefinite", topic: "sbam/cmd/pause", payload: []byte("{}"), expectedKind: IntentPause, expectPauseNil: true},
 		{name: "pause rfc3339 future", topic: "sbam/cmd/pause", payload: []byte(fmt.Sprintf(`{"until":%q}`, future)), expectedKind: IntentPause, checkPause: true},
@@ -49,6 +51,7 @@ func TestParseIntentCanonicalCommands(t *testing.T) {
 			if tc.expectedKind == IntentForceCharge {
 				assert.Equal(t, tc.expectedTarget, intent.TargetPct)
 				assert.Equal(t, tc.expectedDuration, intent.DurationS)
+				assert.Equal(t, tc.expectedIgnore, intent.IgnoreMaxCharge)
 			}
 
 			if tc.expectPauseNil {
@@ -92,8 +95,10 @@ func TestParseIntentForceChargeValidation(t *testing.T) {
 	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
 
 	valid := []string{
+		`{"target_pct":0}`,
 		`{"target_pct":1}`,
 		`{"target_pct":100}`,
+		`{"target_pct":100,"ignore_max_charge":true}`,
 		`{"target_pct":50,"duration_s":0}`,
 		`{"target_pct":50,"duration_s":86400}`,
 	}
@@ -102,12 +107,19 @@ func TestParseIntentForceChargeValidation(t *testing.T) {
 		intent, err := parseIntentAt("sbam/cmd/force_charge", []byte(payload), now)
 		require.NoError(t, err)
 		assert.Equal(t, IntentForceCharge, intent.Kind)
+		if strings.Contains(payload, "ignore_max_charge") {
+			assert.True(t, intent.IgnoreMaxCharge)
+		} else {
+			assert.False(t, intent.IgnoreMaxCharge)
+		}
 	}
 
 	invalid := []string{
 		`{}`,
-		`{"target_pct":0}`,
+		`{"target_pct":-1}`,
 		`{"target_pct":101}`,
+		`{"target_pct":50,"ignore_max_charge":true}`,
+		`{"target_pct":100,"ignore_max_charge":"true"}`,
 		`{"target_pct":50,"duration_s":-1}`,
 		`{"target_pct":50,"duration_s":86401}`,
 		`{"target_pct":"50"}`,

--- a/pkg/mqtt/discovery.go
+++ b/pkg/mqtt/discovery.go
@@ -32,11 +32,22 @@ type discoveryPayload struct {
 	PayloadOn         string          `json:"payload_on,omitempty"`
 	PayloadOff        string          `json:"payload_off,omitempty"`
 	CommandTopic      string          `json:"command_topic,omitempty"`
+	CommandTemplate   string          `json:"command_template,omitempty"`
 	PayloadPress      string          `json:"payload_press,omitempty"`
+	DefaultEntityID   string          `json:"default_entity_id,omitempty"`
+	Min               *float64        `json:"min,omitempty"`
+	Max               *float64        `json:"max,omitempty"`
+	Step              *float64        `json:"step,omitempty"`
+	Mode              string          `json:"mode,omitempty"`
 	Retain            *bool           `json:"retain,omitempty"`
 	QoS               int             `json:"qos,omitempty"`
 }
 
+// BuildDiscovery returns Home Assistant MQTT discovery entities for sbam.
+//
+// BuildDiscovery publishes sensor state entities plus command controls and
+// selector entities used by templated buttons. It normalizes prefixes and
+// falls back to "dev" when the version string is empty.
 func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	if strings.TrimSpace(version) == "" {
 		version = "dev"
@@ -63,7 +74,12 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 		QoS:               int(qosAtLeastOnce),
 	}
 
-	entities := make([]DiscoveryEntity, 0, 18)
+	forceChargeControlTopic := controlTopic(prefix, "force_charge_target_pct")
+	pauseDurationControlTopic := controlTopic(prefix, "pause_duration_s")
+	forceChargeCommandTemplate := `{% set target = states('number.sbam_force_charge_target_pct') | int(100) %}{% if target > 100 %}{"target_pct":100,"ignore_max_charge":true}{% elif target < 0 %}{"target_pct":0}{% else %}{"target_pct":{{ target }}}{% endif %}`
+	pauseCommandTemplate := `{% set seconds = states('number.sbam_pause_duration_s') | int(0) %}{% if seconds <= 0 %}{}{% else %}{"until":"{{ seconds }}s"}{% endif %}`
+
+	entities := make([]DiscoveryEntity, 0, 20)
 
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "battery_soc_pct", sensorPayload(base, deviceID, "battery_soc_pct", "Battery SoC", "{{ value_json.battery_soc_pct }}", "%", "battery", "measurement", ""))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "battery_capacity_wh", sensorPayload(base, deviceID, "battery_capacity_wh", "Battery Capacity", "{{ value_json.battery_capacity_wh }}", "Wh", "", "measurement", ""))
@@ -91,10 +107,13 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	reserveWindowBinary.PayloadOff = "false"
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "binary_sensor", "batt_reserve_window_active", reserveWindowBinary)
 
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "force_charge_target_pct", numberPayload(base, deviceID, "force_charge_target_pct", "Force Charge Target", "number.sbam_force_charge_target_pct", forceChargeControlTopic, 0, 101, 1, "%", "mdi:battery-charging-60"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "pause_duration_s", numberPayload(base, deviceID, "pause_duration_s", "Pause Duration", "number.sbam_pause_duration_s", pauseDurationControlTopic, 0, 86400, 60, "s", "mdi:timer-outline"))
+
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "trigger_now", buttonPayload(base, deviceID, "trigger_now", "Trigger Now", commandTopic(prefix, "trigger_now"), "{}"))
-	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "pause", buttonPayload(base, deviceID, "pause", "Pause", commandTopic(prefix, "pause"), "{}"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "pause", templatedButtonPayload(base, deviceID, "pause", "Pause", commandTopic(prefix, "pause"), pauseCommandTemplate))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "resume", buttonPayload(base, deviceID, "resume", "Resume", commandTopic(prefix, "resume"), "{}"))
-	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "force_charge", buttonPayload(base, deviceID, "force_charge", "Force Charge", commandTopic(prefix, "force_charge"), `{"target_pct":100,"duration_s":3600}`))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "force_charge", templatedButtonPayload(base, deviceID, "force_charge", "Force Charge", commandTopic(prefix, "force_charge"), forceChargeCommandTemplate))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "set_defaults", buttonPayload(base, deviceID, "set_defaults", "Set Defaults", commandTopic(prefix, "set_defaults"), "{}"))
 
 	return entities
@@ -113,19 +132,58 @@ func sensorPayload(base discoveryPayload, deviceID, objectID, name, valueTemplat
 }
 
 func buttonPayload(base discoveryPayload, deviceID, objectID, name, commandTopic, payloadPress string) discoveryPayload {
-	retained := false
-
 	payload := base
 	payload.Name = name
 	payload.UniqueID = uniqueEntityID(deviceID, objectID)
 	payload.CommandTopic = commandTopic
+	payload.CommandTemplate = ""
 	payload.PayloadPress = payloadPress
-	payload.Retain = &retained
+	payload.DefaultEntityID = ""
+	payload.Min = nil
+	payload.Max = nil
+	payload.Step = nil
+	payload.Mode = ""
+	payload.Retain = boolPtr(false)
 	payload.StateTopic = ""
 	payload.ValueTemplate = ""
 	payload.Unit = ""
 	payload.DeviceClass = ""
 	payload.StateClass = ""
+	payload.EntityCategory = ""
+	payload.Icon = ""
+	payload.PayloadOn = ""
+	payload.PayloadOff = ""
+	return payload
+}
+
+func templatedButtonPayload(base discoveryPayload, deviceID, objectID, name, commandTopic, commandTemplate string) discoveryPayload {
+	payload := buttonPayload(base, deviceID, objectID, name, commandTopic, "")
+	payload.CommandTemplate = commandTemplate
+	return payload
+}
+
+func numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, selectorTopic string, min, max, step float64, unit, icon string) discoveryPayload {
+	payload := base
+	payload.Name = name
+	payload.UniqueID = uniqueEntityID(deviceID, objectID)
+	payload.DefaultEntityID = defaultEntityID
+	payload.CommandTopic = selectorTopic
+	payload.CommandTemplate = ""
+	payload.PayloadPress = ""
+	payload.StateTopic = selectorTopic
+	payload.ValueTemplate = ""
+	payload.Unit = unit
+	payload.DeviceClass = ""
+	payload.StateClass = ""
+	payload.EntityCategory = "config"
+	payload.Icon = icon
+	payload.PayloadOn = ""
+	payload.PayloadOff = ""
+	payload.Min = floatPtr(min)
+	payload.Max = floatPtr(max)
+	payload.Step = floatPtr(step)
+	payload.Mode = "slider"
+	payload.Retain = boolPtr(true)
 	return payload
 }
 
@@ -145,6 +203,18 @@ func appendDiscoveryEntity(current []DiscoveryEntity, discoveryPrefix, component
 
 func commandTopic(prefix, name string) string {
 	return normalizePrefix(prefix) + "/cmd/" + strings.Trim(strings.TrimSpace(name), "/")
+}
+
+func controlTopic(prefix, name string) string {
+	return normalizePrefix(prefix) + "/control/" + strings.Trim(strings.TrimSpace(name), "/")
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
 }
 
 func uniqueEntityID(baseID, objectID string) string {

--- a/pkg/mqtt/discovery.go
+++ b/pkg/mqtt/discovery.go
@@ -107,8 +107,8 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	reserveWindowBinary.PayloadOff = "false"
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "binary_sensor", "batt_reserve_window_active", reserveWindowBinary)
 
-	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "force_charge_target_pct", numberPayload(base, deviceID, "force_charge_target_pct", "Force Charge Target", "number.sbam_force_charge_target_pct", forceChargeControlTopic, 0, 101, 1, "%", "mdi:battery-charging-60"))
-	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "pause_duration_s", numberPayload(base, deviceID, "pause_duration_s", "Pause Duration", "number.sbam_pause_duration_s", pauseDurationControlTopic, 0, 86400, 60, "s", "mdi:timer-outline"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "force_charge_target_pct", numberPayload(base, deviceID, "force_charge_target_pct", "Force Charge Target", "number.sbam_force_charge_target_pct", forceChargeControlTopic, 0, 101, 1, "%", "mdi:battery-charging-60", "slider"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "pause_duration_s", numberPayload(base, deviceID, "pause_duration_s", "Pause Duration", "number.sbam_pause_duration_s", pauseDurationControlTopic, 0, 86400, 60, "s", "mdi:timer-outline", "box"))
 
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "trigger_now", buttonPayload(base, deviceID, "trigger_now", "Trigger Now", commandTopic(prefix, "trigger_now"), "{}"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "pause", templatedButtonPayload(base, deviceID, "pause", "Pause", commandTopic(prefix, "pause"), pauseCommandTemplate))
@@ -162,7 +162,7 @@ func templatedButtonPayload(base discoveryPayload, deviceID, objectID, name, com
 	return payload
 }
 
-func numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, selectorTopic string, min, max, step float64, unit, icon string) discoveryPayload {
+func numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntityID, selectorTopic string, min, max, step float64, unit, icon, mode string) discoveryPayload {
 	payload := base
 	payload.Name = name
 	payload.UniqueID = uniqueEntityID(deviceID, objectID)
@@ -182,7 +182,7 @@ func numberPayload(base discoveryPayload, deviceID, objectID, name, defaultEntit
 	payload.Min = floatPtr(min)
 	payload.Max = floatPtr(max)
 	payload.Step = floatPtr(step)
-	payload.Mode = "slider"
+	payload.Mode = mode
 	payload.Retain = boolPtr(true)
 	return payload
 }

--- a/pkg/mqtt/discovery.go
+++ b/pkg/mqtt/discovery.go
@@ -107,7 +107,7 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	reserveWindowBinary.PayloadOff = "false"
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "binary_sensor", "batt_reserve_window_active", reserveWindowBinary)
 
-	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "force_charge_target_pct", numberPayload(base, deviceID, "force_charge_target_pct", "Force Charge Target", "number.sbam_force_charge_target_pct", forceChargeControlTopic, 0, 101, 1, "%", "mdi:battery-charging-60", "slider"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "force_charge_target_pct", numberPayload(base, deviceID, "force_charge_target_pct", "Force Charge Target", "number.sbam_force_charge_target_pct", forceChargeControlTopic, 0, 101, 1, "%", "mdi:battery-charging-60", "box"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "number", "pause_duration_s", numberPayload(base, deviceID, "pause_duration_s", "Pause Duration", "number.sbam_pause_duration_s", pauseDurationControlTopic, 0, 86400, 60, "s", "mdi:timer-outline", "box"))
 
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "button", "trigger_now", buttonPayload(base, deviceID, "trigger_now", "Trigger Now", commandTopic(prefix, "trigger_now"), "{}"))

--- a/pkg/mqtt/discovery_test.go
+++ b/pkg/mqtt/discovery_test.go
@@ -90,7 +90,7 @@ func TestBuildDiscoveryExpectedShape(t *testing.T) {
 	assert.Equal(t, "sbam/control/force_charge_target_pct", forceSelectorPayload.CommandTopic)
 	assert.Equal(t, "sbam/control/force_charge_target_pct", forceSelectorPayload.StateTopic)
 	assert.Equal(t, "%", forceSelectorPayload.Unit)
-	assert.Equal(t, "slider", forceSelectorPayload.Mode)
+	assert.Equal(t, "box", forceSelectorPayload.Mode)
 	assert.Equal(t, "config", forceSelectorPayload.EntityCategory)
 	assert.Equal(t, "mdi:battery-charging-60", forceSelectorPayload.Icon)
 	assert.Equal(t, int(qosAtLeastOnce), forceSelectorPayload.QoS)

--- a/pkg/mqtt/discovery_test.go
+++ b/pkg/mqtt/discovery_test.go
@@ -109,7 +109,7 @@ func TestBuildDiscoveryExpectedShape(t *testing.T) {
 	assert.Equal(t, "sbam/control/pause_duration_s", pauseSelectorPayload.CommandTopic)
 	assert.Equal(t, "sbam/control/pause_duration_s", pauseSelectorPayload.StateTopic)
 	assert.Equal(t, "s", pauseSelectorPayload.Unit)
-	assert.Equal(t, "slider", pauseSelectorPayload.Mode)
+	assert.Equal(t, "box", pauseSelectorPayload.Mode)
 	assert.Equal(t, "config", pauseSelectorPayload.EntityCategory)
 	assert.Equal(t, "mdi:timer-outline", pauseSelectorPayload.Icon)
 	assert.Equal(t, int(qosAtLeastOnce), pauseSelectorPayload.QoS)

--- a/pkg/mqtt/discovery_test.go
+++ b/pkg/mqtt/discovery_test.go
@@ -11,15 +11,26 @@ import (
 )
 
 type discoveryPayloadView struct {
-	UniqueID          string `json:"unique_id"`
-	AvailabilityTopic string `json:"availability_topic"`
-	StateTopic        string `json:"state_topic"`
-	ValueTemplate     string `json:"value_template"`
-	CommandTopic      string `json:"command_topic"`
-	PayloadPress      string `json:"payload_press"`
-	PayloadOn         string `json:"payload_on"`
-	PayloadOff        string `json:"payload_off"`
-	SWVersion         string `json:"sw_version"`
+	UniqueID          string   `json:"unique_id"`
+	AvailabilityTopic string   `json:"availability_topic"`
+	StateTopic        string   `json:"state_topic"`
+	ValueTemplate     string   `json:"value_template"`
+	CommandTopic      string   `json:"command_topic"`
+	CommandTemplate   string   `json:"command_template"`
+	PayloadPress      string   `json:"payload_press"`
+	DefaultEntityID   string   `json:"default_entity_id"`
+	Min               *float64 `json:"min"`
+	Max               *float64 `json:"max"`
+	Step              *float64 `json:"step"`
+	Mode              string   `json:"mode"`
+	Retain            *bool    `json:"retain"`
+	Unit              string   `json:"unit_of_measurement"`
+	Icon              string   `json:"icon"`
+	EntityCategory    string   `json:"entity_category"`
+	QoS               int      `json:"qos"`
+	PayloadOn         string   `json:"payload_on"`
+	PayloadOff        string   `json:"payload_off"`
+	SWVersion         string   `json:"sw_version"`
 	Device            struct {
 		Identifiers  []string `json:"identifiers"`
 		Manufacturer string   `json:"manufacturer"`
@@ -40,7 +51,7 @@ func TestBuildDiscoveryExpectedShape(t *testing.T) {
 
 	entities := BuildDiscovery(cfg, "2.0.0")
 	require.NotEmpty(t, entities)
-	assert.GreaterOrEqual(t, len(entities), 18)
+	assert.GreaterOrEqual(t, len(entities), 20)
 
 	battery := requireEntity(t, entities, "sensor", "battery_soc_pct")
 	assert.Equal(t, "homeassistant/sensor/sbam/battery_soc_pct/config", battery.Topic)
@@ -58,7 +69,58 @@ func TestBuildDiscoveryExpectedShape(t *testing.T) {
 	button := requireEntity(t, entities, "button", "force_charge")
 	buttonPayload := decodeDiscoveryPayload(t, button.Payload)
 	assert.Equal(t, "sbam/cmd/force_charge", buttonPayload.CommandTopic)
-	assert.Equal(t, `{"target_pct":100,"duration_s":3600}`, buttonPayload.PayloadPress)
+	assert.Empty(t, buttonPayload.PayloadPress)
+	assert.Contains(t, buttonPayload.CommandTemplate, "number.sbam_force_charge_target_pct")
+	assert.Contains(t, buttonPayload.CommandTemplate, "ignore_max_charge")
+	require.NotNil(t, buttonPayload.Retain)
+	assert.False(t, *buttonPayload.Retain)
+
+	pauseButton := requireEntity(t, entities, "button", "pause")
+	pauseButtonPayload := decodeDiscoveryPayload(t, pauseButton.Payload)
+	assert.Equal(t, "sbam/cmd/pause", pauseButtonPayload.CommandTopic)
+	assert.Empty(t, pauseButtonPayload.PayloadPress)
+	assert.Contains(t, pauseButtonPayload.CommandTemplate, "number.sbam_pause_duration_s")
+	assert.Contains(t, pauseButtonPayload.CommandTemplate, `{"until":"{{ seconds }}s"}`)
+	require.NotNil(t, pauseButtonPayload.Retain)
+	assert.False(t, *pauseButtonPayload.Retain)
+
+	forceSelector := requireEntity(t, entities, "number", "force_charge_target_pct")
+	forceSelectorPayload := decodeDiscoveryPayload(t, forceSelector.Payload)
+	assert.Equal(t, "number.sbam_force_charge_target_pct", forceSelectorPayload.DefaultEntityID)
+	assert.Equal(t, "sbam/control/force_charge_target_pct", forceSelectorPayload.CommandTopic)
+	assert.Equal(t, "sbam/control/force_charge_target_pct", forceSelectorPayload.StateTopic)
+	assert.Equal(t, "%", forceSelectorPayload.Unit)
+	assert.Equal(t, "slider", forceSelectorPayload.Mode)
+	assert.Equal(t, "config", forceSelectorPayload.EntityCategory)
+	assert.Equal(t, "mdi:battery-charging-60", forceSelectorPayload.Icon)
+	assert.Equal(t, int(qosAtLeastOnce), forceSelectorPayload.QoS)
+	require.NotNil(t, forceSelectorPayload.Min)
+	require.NotNil(t, forceSelectorPayload.Max)
+	require.NotNil(t, forceSelectorPayload.Step)
+	require.NotNil(t, forceSelectorPayload.Retain)
+	assert.Equal(t, 0.0, *forceSelectorPayload.Min)
+	assert.Equal(t, 101.0, *forceSelectorPayload.Max)
+	assert.Equal(t, 1.0, *forceSelectorPayload.Step)
+	assert.True(t, *forceSelectorPayload.Retain)
+
+	pauseSelector := requireEntity(t, entities, "number", "pause_duration_s")
+	pauseSelectorPayload := decodeDiscoveryPayload(t, pauseSelector.Payload)
+	assert.Equal(t, "number.sbam_pause_duration_s", pauseSelectorPayload.DefaultEntityID)
+	assert.Equal(t, "sbam/control/pause_duration_s", pauseSelectorPayload.CommandTopic)
+	assert.Equal(t, "sbam/control/pause_duration_s", pauseSelectorPayload.StateTopic)
+	assert.Equal(t, "s", pauseSelectorPayload.Unit)
+	assert.Equal(t, "slider", pauseSelectorPayload.Mode)
+	assert.Equal(t, "config", pauseSelectorPayload.EntityCategory)
+	assert.Equal(t, "mdi:timer-outline", pauseSelectorPayload.Icon)
+	assert.Equal(t, int(qosAtLeastOnce), pauseSelectorPayload.QoS)
+	require.NotNil(t, pauseSelectorPayload.Min)
+	require.NotNil(t, pauseSelectorPayload.Max)
+	require.NotNil(t, pauseSelectorPayload.Step)
+	require.NotNil(t, pauseSelectorPayload.Retain)
+	assert.Equal(t, 0.0, *pauseSelectorPayload.Min)
+	assert.Equal(t, 86400.0, *pauseSelectorPayload.Max)
+	assert.Equal(t, 60.0, *pauseSelectorPayload.Step)
+	assert.True(t, *pauseSelectorPayload.Retain)
 
 	paused := requireEntity(t, entities, "binary_sensor", "paused")
 	pausedPayload := decodeDiscoveryPayload(t, paused.Payload)
@@ -197,5 +259,17 @@ func TestDiscoveryConfigTopicDefaults(t *testing.T) {
 		t,
 		"ha/button/sbam/trigger_now/config",
 		discoveryConfigTopic(" /ha/ ", " /button/ ", " /trigger_now/ "),
+	)
+
+	assert.Equal(
+		t,
+		"sbam/control/force_charge_target_pct",
+		controlTopic(" /sbam/ ", " /force_charge_target_pct/ "),
+	)
+
+	assert.Equal(
+		t,
+		"sbam/control/pause_duration_s",
+		controlTopic(" ", "pause_duration_s"),
 	)
 }

--- a/pkg/mqtt/types.go
+++ b/pkg/mqtt/types.go
@@ -69,13 +69,19 @@ const (
 	IntentTriggerNow  IntentKind = "trigger_now"
 )
 
+// Intent describes a validated command request routed through the schedule runner.
+//
+// Intent carries normalized command kind and optional command-specific fields
+// (for example force-charge target and pause deadline) plus the originating
+// MQTT command topic used for acknowledgement publication.
 type Intent struct {
-	Kind          IntentKind `json:"kind"`
-	TargetPct     int16      `json:"target_pct,omitempty"`
-	DurationS     int        `json:"duration_s,omitempty"`
-	PauseUntil    *time.Time `json:"pause_until,omitempty"`
-	PwBattReserve float64    `json:"pw_batt_reserve,omitempty"`
-	CommandTopic  string     `json:"-"`
+	Kind            IntentKind `json:"kind"`
+	TargetPct       int16      `json:"target_pct,omitempty"`
+	IgnoreMaxCharge bool       `json:"ignore_max_charge,omitempty"`
+	DurationS       int        `json:"duration_s,omitempty"`
+	PauseUntil      *time.Time `json:"pause_until,omitempty"`
+	PwBattReserve   float64    `json:"pw_batt_reserve,omitempty"`
+	CommandTopic    string     `json:"-"`
 }
 
 type DiscoveryEntity struct {


### PR DESCRIPTION
Ref #128.

Summary:
- Discovery adds number sliders and templated send buttons.
- force_charge parser supports 0..100 plus ignore_max_charge override.
- Runner handles capped/uncapped/zero paths.
- Tests and docs updated.
- Validations passed (go vet, go test, make test, make build).