### PR TITLE
feat(fronius): remove numeric value from decision reason MQTT payload; log net power separately

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,3 +234,4 @@ some prompts are available in `.github/prompts/` for reference and iteration. Th
 - Avoid hyperbole and excitement, stick to the task at hand and complete it pragmatically.
 - Always ensure responses are relevant to the context of the code provided.
 - Avoid unnecessary detail not related to the task.
+- when you use gh tool --repo flag, use "atbore-phx/sbam".

--- a/docs/implementations/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-PLAN.md
+++ b/docs/implementations/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-PLAN.md
@@ -1,0 +1,168 @@
+# PLAN: Remove numeric value from Decision Reason MQTT payload; log Net Power separately
+
+> Issue: [#131](https://github.com/atbore-phx/sbam/issues/131) · TASK: [131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-TASK.md](131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-TASK.md) · Created: 2026-05-24
+
+## Task Analysis
+
+**Goal:** Make `last_decision_reason` MQTT payload strings static (no embedded numeric values) so Home Assistant can group them as single history items.
+
+**Non-goals:** Do NOT change `DecisionReserveCharge` reason string, do NOT change MQTT discovery, do NOT change decision logic, do NOT change `pw_net_wh`.
+
+**Acceptance Criteria:** Clean reason strings for `DecisionForecastCharge` and `DecisionIdle`, separate log line for `pw.Net`, all tests updated, `make test` and `make build` pass.
+
+## Current State
+
+Three reason strings in `ClassifyDecision` (`pkg/fronius/classify.go:48,50,52`) embed numeric values via `fmt.Sprintf`:
+
+| Line | Decision | Current String |
+|------|----------|---------------|
+| 48 | `DecisionForecastCharge` | `"Net Power (actual battery power + Net solar power) is not enough: %2f Wh"` |
+| 50 | `DecisionReserveCharge` | `"battery %2f Wh < reserve %2f Wh"` (out of scope) |
+| 52 | `DecisionIdle` | `"Net Power (actual battery power + Net solar power) is enough: %2f Wh"` |
+
+All three are returned as the `reason` string, eventually published as `last_decision_reason` in the MQTT state payload (`pkg/mqtt/types.go:38`).
+
+Tests in `pkg/fronius/classify_test.go:48,61,74` assert the old numeric-containing strings exactly.
+
+The Net Power value is already available separately as `pw_net_wh` in the MQTT state payload (`pkg/mqtt/types.go:35`) and as a "Net Energy" HA discovery entity (`pkg/mqtt/discovery.go:87`).
+
+## Target Architecture
+
+No architectural changes. Only string formatting in `classify.go`, one added log line in `schedule.go`, and test updates in `classify_test.go`.
+
+```
+ClassifyDecision (classify.go)
+  DecisionForecastCharge → static string (no %2f Wh)
+  DecisionIdle           → static string (no %2f Wh)
+  DecisionReserveCharge  → unchanged (still has %2f Wh)
+  DecisionBatteryFull    → unchanged
+  DecisionSkip           → unchanged
+
+SetFroniusChargeBatteryMode (schedule.go)
+  Existing log: "Decision: %s - %s" (now cleaner reason strings)
+  New log:      "Net Power: %.2f Wh" (pw.Net value)
+```
+
+## Dependency Choices
+
+No new dependencies. Uses existing `fmt` (classify.go) and `zap` via `src/utils` (schedule.go).
+
+## Configuration Changes
+
+None. No new CLI flags, config keys, env vars, or HA add-on schema changes.
+
+## Implementation Blueprint
+
+### Step 1 — Clean up reason strings in `pkg/fronius/classify.go`
+
+**File:** `pkg/fronius/classify.go`
+
+**Line 48:** Change the `DecisionForecastCharge` reason from a `fmt.Sprintf` with numeric value to a static string:
+```go
+// Before:
+return DecisionForecastCharge, fmt.Sprintf("Net Power (actual battery power + Net solar power) is not enough: %2f Wh", pw.Net), pw, nil
+// After:
+return DecisionForecastCharge, "Net Power (actual battery power + Net solar power) is not enough", pw, nil
+```
+
+**Line 52:** Change the `DecisionIdle` reason from a `fmt.Sprintf` with numeric value to a static string:
+```go
+// Before:
+return DecisionIdle, fmt.Sprintf("Net Power (actual battery power + Net solar power) is enough: %2f Wh", pw.Net), pw, nil
+// After:
+return DecisionIdle, "Net Power (actual battery power + Net solar power) is enough", pw, nil
+```
+
+**Line 50:** Leave `DecisionReserveCharge` reason string **unchanged** (out of scope).
+
+**Rationale:** The numeric value is redundant with `pw_netWh` in the MQTT payload. Removing it makes the reason string static per decision type, fixing HA history grouping.
+
+### Step 2 — Clean up unused import in `pkg/fronius/classify.go`
+
+After Step 1, check if `fmt` is still used in `classify.go`. `DecisionReserveCharge` (line 50) still uses `fmt.Sprintf`, and `DecisionSkip` (line 54) also uses `fmt.Sprintf`. The `fmt` package is still needed — no import change required.
+
+### Step 3 — Add Net Power log line in `pkg/fronius/schedule.go`
+
+**File:** `pkg/fronius/schedule.go`
+
+**After line 17** (the existing `u.Log.Infof("Decision: %s - %s", ...)` line), add a new log line:
+```go
+u.Log.Infof("Net Power: %.2f Wh", pw.Net)
+```
+
+This preserves the Net Power information in sbam application logs for debugging, using `Infof` (not `Errorf`) to avoid spurious alerts.
+
+The `pw` variable is already available in scope from the `ClassifyDecision` call at line 12-16.
+
+### Step 4 — Update test expectations in `pkg/fronius/classify_test.go`
+
+**File:** `pkg/fronius/classify_test.go`
+
+**Line 48:** Update expected reason string:
+```go
+// Before:
+expectedReason: "Net Power (actual battery power + Net solar power) is not enough: -1900.000000 Wh",
+// After:
+expectedReason: "Net Power (actual battery power + Net solar power) is not enough",
+```
+
+**Line 74:** Update expected reason string:
+```go
+// Before:
+expectedReason: "Net Power (actual battery power + Net solar power) is enough: 9400.000000 Wh",
+// After:
+expectedReason: "Net Power (actual battery power + Net solar power) is enough",
+```
+
+**Line 61:** Leave `DecisionReserveCharge` expectation **unchanged** (still `"battery 1000.000000 Wh < reserve 3000.000000 Wh"`).
+
+## Test Plan
+
+### `pkg/fronius` package
+
+**Expected case (updated existing tests):**
+- `TestClassifyDecision` table-driven cases for `DecisionForecastCharge` and `DecisionIdle` assert cleaned static reason strings
+- `TestClassifyDecision` case for `DecisionBatteryFull` continues to assert `"Battery is full charged"`
+
+**Edge case (already covered by existing tests):**
+- `DecisionReserveCharge` reason string still contains numeric values (unchanged, verified by existing test at line 61)
+- `DecisionSkip` default case unchanged (verified by existing test at line 93)
+
+**Failure case:**
+- `DecisionSkip` with `forecastChargeEnabled=false, battReserveChargeEnabled=false` still returns error and `"unexpected power state"` prefix
+
+### Log output verification
+
+The new log line `"Net Power: %.2f Wh"` will appear in zap logs. No dedicated log-capture test is required for this simple change — the existing	test structure doesn't capture logs, and the value (`pw.Net`) is already validated by the `"returns power state snapshot"` test case.
+
+## Validation Gates
+
+```bash
+make test        # all unit tests pass
+make build       # binary compiles
+make all         # full validation suite
+```
+
+## Rollout / Backward Compatibility
+
+- **Breaking change:** Any HA automation or template that parses `last_decision_reason` expecting the embedded numeric value will break. The numeric data is available via `pw_net_wh` or the "Net Energy" sensor.
+- **No migration needed:** No config changes, no schema changes.
+- **No HA add-on config update needed.**
+
+## Security Considerations
+
+No security impact. Log output uses `Infof` and only emits already-computed internal state.
+
+## Gotchas
+
+- The `fmt` import in `classify.go` must remain — `DecisionReserveCharge` and `DecisionSkip` still use `fmt.Sprintf`.
+- `pw` in `schedule.go` is the full `PowerState` struct returned by `ClassifyDecision`; `pw.Net` is already computed before the log line.
+
+## Open Questions / Risks
+
+- **RESOLVED:** `DecisionReserveCharge` reason string left unchanged (out of scope per issue).
+- **ACCEPTED RISK:** Downstream consumers parsing `last_decision_reason` with regex will break. Acceptable because data is redundant.
+
+## Confidence Score
+
+**10/10** — Minimal, surgical changes to string formatting in 3 files with no architectural impact. The issue is exceptionally well-specified with clear acceptance criteria and scope boundaries.

--- a/docs/implementations/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-TASK.md
+++ b/docs/implementations/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately/131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately-TASK.md
@@ -1,0 +1,104 @@
+# Feature: Remove numeric value from Decision Reason MQTT payload; log Net Power separately
+
+> Source issue: [#131](https://github.com/atbore-phx/sbam/issues/131)
+> Fetched: 2026-05-24
+> Slug: `131-issue-remove-numeric-value-from-decision-reason-mqtt-payload-log-net-power-separately` · Created: 2026-05-24
+
+## Summary
+
+Remove the numeric Net Power value from the MQTT `last_decision_reason` payload so the string is static per decision type, and instead log the Net Power value separately in the sbam application log. This allows Home Assistant to group and graph decision reasons as a single item in the History tab.
+
+## Motivation / User Story
+
+As a Home Assistant user,
+I want the `last_decision_reason` MQTT payload to be a static string without embedded numeric values,
+So that HA treats each decision reason as a single item in the History tab and graph instead of creating a new item every time the numeric value changes.
+
+Currently, the MQTT state payload publishes `"last_decision_reason": "Net Power (actual battery power + Net solar power) is enough: 35420.173000 Wh"`. Because the Wh value changes every tick, HA sees each unique string as a new entry. The Net Power value is already available as a separate numeric sensor via `pw_net_wh` in the same state payload and as a dedicated "Net Energy" HA discovery entity.
+
+## Scope
+
+**In scope:**
+- Remove the numeric `%2f Wh` value from the `ClassifyDecision` reason strings in `pkg/fronius/classify.go` for the two Net Power decisions (`DecisionForecastCharge` and `DecisionIdle`)
+- Add a separate log line (zap `Infof`) that logs the Net Power value (`pw.Net`) so the information is still available in sbam logs for debugging
+- Update all tests referencing the old reason string format
+
+**Out of scope:**
+- Removing or changing the `pw_net_wh` MQTT state field (numeric Net Energy sensor remains unchanged)
+- Changing the MQTT discovery configuration for the "Net Energy" entity
+- Changing any other MQTT payload fields
+- Changing the decision logic itself
+- The `DecisionReserveCharge` reason string (`"battery %2f Wh < reserve %2f Wh"`) — this also contains numeric values but is explicitly out of scope for this issue (may be a follow-up)
+
+## Functional Requirements
+
+- [ ] `ClassifyDecision` reason strings for `DecisionForecastCharge` and `DecisionIdle` must no longer include the numeric Net Power value (e.g., `"Net Power (actual battery power + Net solar power) is enough"` instead of `"Net Power (actual battery power + Net solar power) is enough: 35420.173000 Wh"`)
+- [ ] A zap log line must be added (in `SetFroniusChargeBatteryMode` in `pkg/fronius/schedule.go`) that prints the Net Power value (`pw.Net`) in Wh
+- [ ] The `last_decision_reason` field in the MQTT state payload must contain the cleaned string without any numeric value
+- [ ] The `pw_net_wh` numeric field in the MQTT state payload must remain unchanged and continue to be published
+
+## Non-functional Requirements
+
+**Backward compatibility:**
+- This is a **breaking change** for any automation or template that parses the old reason string expecting the numeric value. Users who need the value should reference the `pw_net_wh` state attribute or the "Net Energy" HA sensor instead.
+- No config key changes, no CLI flag changes, no env var changes, no add-on config schema impact.
+
+**Safety / defaults:**
+- Logging must use `Infof` (not `Errorf` or higher) for the Net Power value to avoid spurious alerts.
+- The decision logic itself is unchanged; only the human-readable reason string and log output are affected.
+
+**Performance / reliability:**
+- No additional external calls. The Net Power value is already computed in `ClassifyDecision`; we only log it.
+
+## Configuration Impact
+
+- New CLI flags: none
+- New config.yaml keys: none
+- New env vars: none
+- Home Assistant add-on config schema impact: none
+
+## External Integrations Touched
+
+- Solcast: none
+- Fronius Solar API: none
+- Fronius Modbus registers: none
+- MQTT topics: `last_decision_reason` field value format change (no topic name change)
+
+## Acceptance Criteria
+
+- [ ] `ClassifyDecision` returns `"Net Power (actual battery power + Net solar power) is not enough"` (no numeric value) for `DecisionForecastCharge`
+- [ ] `ClassifyDecision` returns `"Net Power (actual battery power + Net solar power) is enough"` (no numeric value) for `DecisionIdle`
+- [ ] A log line containing the Net Power value (e.g., `"Net Power: %.2f Wh"`) is emitted on every classification
+- [ ] `pw_net_wh` continues to be published in the MQTT state payload
+- [ ] `go test ./...` passes with updated test expectations
+- [ ] `make build` succeeds
+- [ ] `make all` passes
+
+## Test Strategy
+
+**Unit tests (expected case):**
+- Existing tests in `pkg/fronius/classify_test.go` that assert the old reason string format (containing `%2f Wh`) must be updated to match the new static strings.
+- A new test or assertion must verify that the cleaned reason string matches exactly (e.g., `assert.Equal(t, "Net Power (actual battery power + Net solar power) is enough", reason)`).
+
+**Edge case:**
+- Test that the reason string for `DecisionBatteryFull` (`"Battery is full charged"`) and `DecisionReserveCharge` (`"battery %2f Wh < reserve %2f Wh"`) are **not** changed.
+
+**Failure case:**
+- The `DecisionSkip` default case reason string (debug struct dump) is unchanged.
+
+**Integration/validation commands:**
+- `make test`
+- `make build`
+
+## Risks / Open Questions
+
+- The `DecisionReserveCharge` reason string (`"battery %2f Wh < reserve %2f Wh"`) also contains numeric values and would cause the same HA history fragmentation. This is **out of scope** for this issue but may be a follow-up.
+- Downstream consumers (e.g., automations parsing `last_decision_reason` with regex) will break. This is acceptable because the numeric data was redundant with `pw_net_wh`.
+
+## References
+
+- `pkg/fronius/classify.go` — `ClassifyDecision` function (lines 30–57)
+- `pkg/fronius/schedule.go` — `SetFroniusChargeBatteryMode` (lines 5–44), current log at line 17
+- `pkg/fronius/classify_test.go` — unit tests for ClassifyDecision
+- `pkg/mqtt/types.go` — `StatePayload.LastDecisionReason` field (line 38)
+- `pkg/mqtt/discovery.go` — "Net Energy" HA discovery entity (line 87, reads `pw_net_wh`)

--- a/pkg/fronius/classify.go
+++ b/pkg/fronius/classify.go
@@ -45,11 +45,11 @@ func ClassifyDecision(
 	case pwBatt2charge == 0:
 		return DecisionBatteryFull, "Battery is full charged", pw, nil
 	case pw.Net < -1*pwLwt && forecastChargeEnabled:
-		return DecisionForecastCharge, fmt.Sprintf("Net Power (actual battery power + Net solar power) is not enough: %2f Wh", pw.Net), pw, nil
+		return DecisionForecastCharge, "Net Power (actual battery power + Net solar power) is not enough", pw, nil
 	case pw.BattReserveNet < -1*pwLwt && battReserveChargeEnabled:
 		return DecisionReserveCharge, fmt.Sprintf("battery %2f Wh < reserve %2f Wh", pw.Batt, pwBattReserve), pw, nil
 	case pw.Net >= -1*pwLwt:
-		return DecisionIdle, fmt.Sprintf("Net Power (actual battery power + Net solar power) is enough: %2f Wh", pw.Net), pw, nil
+		return DecisionIdle, "Net Power (actual battery power + Net solar power) is enough", pw, nil
 	default:
 		reason := fmt.Sprintf("unexpected power state: %+v", pw)
 		return DecisionSkip, reason, pw, fmt.Errorf("%s", reason)

--- a/pkg/fronius/classify_test.go
+++ b/pkg/fronius/classify_test.go
@@ -45,7 +45,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    true,
 			battReserveChargeEnabled: false,
 			expectedDecision:         fronius.DecisionForecastCharge,
-			expectedReason:           "Net Power (actual battery power + Net solar power) is not enough: -1900.000000 Wh",
+			expectedReason:           "Net Power (actual battery power + Net solar power) is not enough",
 		},
 		{
 			name:                     "reserve charge fires when battery is below reserve and reserve charge enabled",
@@ -71,7 +71,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    true,
 			battReserveChargeEnabled: true,
 			expectedDecision:         fronius.DecisionIdle,
-			expectedReason:           "Net Power (actual battery power + Net solar power) is enough: 9400.000000 Wh",
+			expectedReason:           "Net Power (actual battery power + Net solar power) is enough",
 		},
 	}
 

--- a/pkg/fronius/schedule.go
+++ b/pkg/fronius/schedule.go
@@ -15,6 +15,7 @@ func SetFroniusChargeBatteryMode(pw_forecast float64, pw_batt2charge float64, pw
 		forecast_charge_enabled, batt_reserve_charge_enabled,
 	)
 	u.Log.Infof("Decision: %s - %s", decision.String(), reason)
+	u.Log.Infof("Net Power: %.2f Wh", pw.Net)
 
 	if cerr != nil {
 		u.Log.Errorf("Classifier error: %s - resetting Fronius to defaults (stop forced charge)", cerr)


### PR DESCRIPTION
## Summary

Closes #131.

Removes the embedded numeric Net Power value from the `last_decision_reason` MQTT payload strings for `DecisionForecastCharge` and `DecisionIdle`, making them static per decision type. Adds a separate `Infof` log line for the Net Power value so it remains available in sbam logs for debugging.

This allows Home Assistant to group and graph decision reasons as single items in the History tab instead of creating a new entry every time the numeric value changes.

## Changes

| File | Change |
|------|--------|
| `pkg/fronius/classify.go` | Removed `%2f Wh` suffix from `DecisionForecastCharge` and `DecisionIdle` reason strings |
| `pkg/fronius/schedule.go` | Added `u.Log.Infof("Net Power: %.2f Wh", pw.Net)` after the existing decision log line |
| `pkg/fronius/classify_test.go` | Updated 2 expected reason strings to match new static format |

## What's NOT changed

- `DecisionReserveCharge` reason string still contains numeric values (out of scope for this issue; may be a follow-up)
- `pw_net_wh` MQTT field unchanged — Net Power is still available as a separate numeric sensor
- MQTT discovery configuration unchanged
- Decision logic unchanged

## Backward Compatibility

This is a **breaking change** for any automation or template that parses `last_decision_reason` expecting the embedded numeric value. Users who need the value should reference the `pw_net_wh` state attribute or the "Net Energy" HA sensor instead.

## Validation

- `make test` — all packages pass ✅
- `make build` — binary compiles cleanly ✅