### PR TITLE
feat(claude): add CLAUDE.md and adapt workflow prompts for Claude Code

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,2 @@
+# Copilot-only instructions — not needed for Claude Code
+.github/copilot-instructions.md

--- a/.github/prompts/generate-plan-from-issue.prompt.md
+++ b/.github/prompts/generate-plan-from-issue.prompt.md
@@ -107,7 +107,7 @@ Follow Phases 3–4 of [generate-plan-local.prompt.md](generate-plan-local.promp
 - Print a summary with workspace-relative links to the TASK and PLAN, plus the issue URL.
 - Remind the user the next step is `/implement-plan <feature-slug>`.
 - **Do not** comment on or close the GitHub issue. **Do not** push branches. Surface those as suggestions only.
-- If you added or removed files anywhere in the repo, update the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md).
+- If you added or removed files anywhere in the repo, update the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md) **and** [CLAUDE.md](../../CLAUDE.md).
 
 ## Operating Rules
 

--- a/.github/prompts/generate-plan-local.prompt.md
+++ b/.github/prompts/generate-plan-local.prompt.md
@@ -5,7 +5,7 @@ description: "Interactively author a TASK and produce a comprehensive PLAN for a
 
 # Generate Plan (Local)
 
-You are generating an implementation plan for the **sbam** project (Smart Battery Advanced Manager — see [.github/copilot-instructions.md](../copilot-instructions.md)). The user invokes this prompt as:
+You are generating an implementation plan for the **sbam** project (Smart Battery Advanced Manager — see [.github/copilot-instructions.md](../copilot-instructions.md) or [CLAUDE.md](../../CLAUDE.md)). The user invokes this prompt as:
 
 ```
 /generate-plan-local <feature-name>
@@ -36,7 +36,7 @@ Follow these phases **in order**. Use the todo list tool to track progress and k
    - Read also any sibling files (existing PLAN, notes, diagrams).
    - Summarize back to the user what the TASK currently says (3–6 bullets).
    - Identify gaps, ambiguities, missing acceptance criteria, missing non-goals, missing config/env impacts, missing test strategy.
-   - Ask **only the necessary clarifying questions** (use the questions tool; batch them; prefer fixed-choice options when possible). Do not ask questions whose answers are already in the TASK or in `copilot-instructions.md`.
+   - Ask **only the necessary clarifying questions** (use the questions tool; batch them; prefer fixed-choice options when possible). Do not ask questions whose answers are already in the TASK or in `copilot-instructions.md` / `CLAUDE.md`.
    - Always include a final open question for the user to add any additional information or context that they think is relevant to the feature being implemented.
    - Apply the answers by editing the TASK file in place. Preserve any human-written sections; add a "Clarifications" section at the bottom if useful.
 3. **If it does not exist:**
@@ -46,7 +46,7 @@ Follow these phases **in order**. Use the todo list tool to track progress and k
      - **User story / motivation** (who benefits and why).
      - **Scope / non-scope** (what is explicitly out).
      - **Inputs/outputs**: new CLI flags, config keys, env vars, Modbus registers, Solcast/Fronius endpoints touched.
-     - **Affected packages** (`pkg/cmd`, `pkg/fronius`, `pkg/power`, `pkg/storage`, `src/utils`, Home Assistant add-on, Dockerfile, Makefile, CI workflows).
+     - **Affected packages** (`pkg/*`, `src/utils`, Home Assistant add-on, Dockerfile, Makefile, CI workflows).
      - **Acceptance criteria** (observable, testable).
      - **Constraints**: backward compatibility, default behavior, safety (e.g. must never write Modbus registers in dry-run).
      - **Risks / unknowns** worth flagging.
@@ -121,14 +121,7 @@ Why this matters and for whom.
 
 Now perform the research needed to write a high-confidence PLAN. Reuse `runSubagent` (Explore agent) for read-only sweeps when helpful.
 
-1. **Codebase analysis** — find and cite existing patterns to mirror:
-   - CLI command shape: see [pkg/cmd/root.go](../../pkg/cmd/root.go), [pkg/cmd/schedule.go](../../pkg/cmd/schedule.go).
-   - Modbus access: see [pkg/fronius/modbus.go](../../pkg/fronius/modbus.go), [pkg/fronius/configure.go](../../pkg/fronius/configure.go).
-   - HTTP client + caching: see [pkg/power/estimate.go](../../pkg/power/estimate.go).
-   - Test patterns (httptest, mbserver): see [pkg/fronius/fronius_test.go](../../pkg/fronius/fronius_test.go), [pkg/power/power_test.go](../../pkg/power/power_test.go), [pkg/storage/storage_test.go](../../pkg/storage/storage_test.go).
-   - Logging: see [src/utils/log.go](../../src/utils/log.go).
-   - Build / CI: see [Makefile](../../Makefile), [.github/workflows/test.yml](../workflows/test.yml), [.github/workflows/release.yml](../workflows/release.yml).
-   - Home Assistant add-on: see [home-assistant/addons/sbam/](../../home-assistant/addons/sbam/).
+1. **Codebase analysis** — find and cite existing patterns to mirror. Consult [.github/copilot-instructions.md](../copilot-instructions.md) and [CLAUDE.md](../../CLAUDE.md) (Project Structure sections) for file locations, and read the specific files relevant to the feature.
 2. **External research** — capture concrete URLs (vendor docs, library godoc, register maps, RFCs). Note any Fronius firmware quirks, Modbus register addresses, Solcast quotas, or `simonvetter/modbus` API specifics.
 3. **Conventions** — confirm naming, error handling (`handleError` / `handleErrorPanic`), constructor pattern (`New() *T`), config hierarchy (flag > env > yaml).
 
@@ -167,7 +160,7 @@ Create `docs/implementations/<feature-name>/<feature-name>-PLAN.md` using the st
 - Print a short summary with workspace-relative links to the TASK and PLAN.
 - Remind the user the next step is `/implement-plan <feature-name>`.
 - **Do not** modify any files outside `docs/implementations/<feature-name>/` during this prompt.
-- Files added or removed under `docs/implementations/<feature-name>/` do **not** require updates to the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md). If you notice unrelated non-`docs/implementations/**` file additions/removals that would require a `Project Structure` update, mention that as a follow-up only; do **not** edit `.github/copilot-instructions.md` in this prompt.
+- Files added or removed under `docs/implementations/<feature-name>/` do **not** require updates to the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md) or [CLAUDE.md](../../CLAUDE.md). If you notice unrelated non-`docs/implementations/**` file additions/removals that would require a `Project Structure` update, mention that as a follow-up only; do **not** edit `.github/copilot-instructions.md` or `CLAUDE.md` in this prompt.
 
 ## Operating Rules
 

--- a/.github/prompts/implement-plan.prompt.md
+++ b/.github/prompts/implement-plan.prompt.md
@@ -5,7 +5,7 @@ description: "Implement an sbam feature from its PLAN file under docs/implementa
 
 # Implement Plan
 
-Implement a feature for the **sbam** project (see [.github/copilot-instructions.md](../copilot-instructions.md)) using a previously generated PLAN file. The user invokes this prompt as:
+Implement a feature for the **sbam** project (see [.github/copilot-instructions.md](../copilot-instructions.md) or [CLAUDE.md](../../CLAUDE.md)) using a previously generated PLAN file. The user invokes this prompt as:
 
 ```
 /implement-plan <feature-name>
@@ -27,7 +27,7 @@ Where `<feature-name>` matches the directory under `docs/implementations/` (e.g.
 Before changing any code:
 
 - ask the user an open question to add any additional information or context that they think is relevant to the feature being implemented. Do not proceed until the user confirms they have provided all relevant information.
-- Read the PLAN end-to-end. Read the TASK. Re-read [.github/copilot-instructions.md](../copilot-instructions.md).
+- Read the PLAN end-to-end. Read the TASK. Re-read [.github/copilot-instructions.md](../copilot-instructions.md) and/or [CLAUDE.md](../../CLAUDE.md).
 - Build a todo list mirroring the PLAN's "Implementation Blueprint" — one todo per blueprint step. Mark exactly one as `in-progress` at a time.
 - Confirm the working tree is clean enough to proceed (warn the user if there are unrelated modified files; do not stash without permission).
 
@@ -69,15 +69,13 @@ Use:
 - `github.com/tbrandon/mbserver` for Modbus mocks
 - always `defer server.Close()` (or `defer s.Stop()` for mbserver)
 
-Mirror the existing test files: [pkg/fronius/fronius_test.go](../../pkg/fronius/fronius_test.go), [pkg/power/power_test.go](../../pkg/power/power_test.go), [pkg/storage/storage_test.go](../../pkg/storage/storage_test.go).
-
 ### 4. Validate
 
 Run, in order, and fix until each passes:
 
 ```bash
-go mod tidy
-go vet ./...
+make tidy
+make vet
 make test
 make build
 ```
@@ -95,7 +93,7 @@ If the PLAN defines additional validation gates, run those too. Do not declare s
 ### 5. Documentation and surface updates
 
 - For every type, function, or method added or modified in a public package (pkg/) or sources (src/), ensure the code is properly documented with GoDoc comments. The comments are inserted before the declaration and start with the name of the item and a description of its purpose, behavior, and any important details.
-- If you added/removed/renamed/moved any files, update the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md), while respecting the existing structure, formatting, important sections, and conventions.
+- If you added/removed/renamed/moved any files, update the `Project Structure` section in [.github/copilot-instructions.md](../copilot-instructions.md) **and** [CLAUDE.md](../../CLAUDE.md), while respecting the existing structure, formatting, important sections, and conventions.
 - Update [README.md](../../README.md) only if the PLAN says so or if user-visible behavior changed.
 - If the Home Assistant add-on schema or behavior changed, append an entry to [home-assistant/addons/sbam/CHANGELOG.md](../../home-assistant/addons/sbam/CHANGELOG.md) and update [home-assistant/addons/sbam/DOCS.md](../../home-assistant/addons/sbam/DOCS.md).
 - If new config keys, env vars, or flags were added, update [config.yaml](../../config.yaml) (commented example) and [home-assistant/addons/sbam/config.json](../../home-assistant/addons/sbam/config.json) schema.
@@ -112,7 +110,7 @@ Produce a final message containing:
 
 ## Operating Rules
 
-- **Stop and ask** if the PLAN is internally inconsistent, contradicts `copilot-instructions.md`, or requires destructive operations.
+- **Stop and ask** if the PLAN is internally inconsistent, contradicts `copilot-instructions.md` or `CLAUDE.md`, or requires destructive operations.
 - Never bypass safety: do not push, force-push, amend pushed commits, delete branches, or run `--no-verify`.
 - Never commit secrets. Never write real Solcast API keys or Fronius IPs into committed files; use placeholders that match the existing examples.
 - Never edit Modbus write logic to skip safety checks (e.g. removing reserve thresholds) unless the PLAN explicitly requires it.
@@ -126,7 +124,7 @@ Implementation is complete when:
 - Every acceptance criterion in the TASK is satisfied.
 - Every blueprint step in the PLAN is checked off or explicitly marked deferred with rationale.
 - `make tidy`, `make vet`, `make test` and `make build` all pass.
-- All sbam conventions in `copilot-instructions.md` are upheld.
+- All sbam conventions in `copilot-instructions.md` and `CLAUDE.md` are upheld.
 - Documentation surfaces are in sync with the change.
 
 ## Final steps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,9 @@ This project uses a prompt-driven workflow for feature development. Features are
 - `<feature-name>-TASK.md` — human-facing feature request and requirements
 - `<feature-name>-PLAN.md` — agent-facing implementation plan
 
-### Available Commands
+### Available Prompts
+
+some prompts are available in `.github/prompts/` for reference and iteration. The main ones are:
 
 - `/generate-plan-local <feature-name>` — interactive authoring of TASK + PLAN from scratch (or refinement of an existing TASK)
 - `/generate-plan-from-issue <issue-ref>` — same as above but seeded from a GitHub issue
@@ -211,7 +213,7 @@ This project uses a prompt-driven workflow for feature development. Features are
 3. Answer clarifications added by the agent, update the TASK if needed
 4. Implement changes locally on a feature branch
 5. Add or update unit and integration tests as appropriate
-6. Run validation: `make test`, `make build`
+6. Run validation: `make test`, `make build`, `make all` to ensure everything works locally.
 7. Open a **draft PR** referencing the issue and the generated PLAN
 8. Request at least one human reviewer and ensure CI passes before converting from draft
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,234 @@
+# Claude Code Instructions – sbam (Smart Battery Advanced Manager)
+
+## Project Overview
+
+This project is a **Go (Golang) application** that intelligently manages Fronius Gen24+ solar battery charging using weather forecasts.
+
+The system:
+
+- Retrieves daily solar production forecasts from the Solcast API
+- Monitors battery state of charge via the Fronius local Solar API (REST)
+- Controls battery charging via Fronius Modbus TCP protocol (register writes)
+- Dynamically decides when and how much to charge the battery from the grid based on:
+  - Weather forecasts (solar production estimates)
+  - Daily household consumption
+  - Current battery charge level
+  - Configurable battery reserve thresholds
+  - Time windows for grid charging
+  - Net power calculations (solar production − consumption)
+
+Deployment targets:
+
+- Standalone CLI application
+- Home Assistant add-on
+- Docker container
+
+The application must be:
+
+- Modular
+- Testable
+- Secure
+- Idiomatic Go
+- Deployable as a Home Assistant add-on and Docker container
+
+---
+
+## Tech Stack
+
+- Go 1.26+
+- net/http (default HTTP client for Solcast and Fronius Solar API)
+- github.com/simonvetter/modbus (Modbus TCP client for Fronius inverter control)
+- github.com/spf13/cobra (CLI framework)
+- github.com/spf13/viper (configuration: YAML, env vars, CLI flags)
+- go.uber.org/zap (structured logging)
+- github.com/robfig/cron/v3 (cron scheduling for recurring charge cycles)
+- github.com/stretchr/testify (testing assertions)
+- github.com/tbrandon/mbserver (mock Modbus server for testing)
+- Docker support (standalone + Home Assistant add-on)
+
+---
+
+## Project Structure
+
+```
+.github/
+  ISSUE_TEMPLATE/
+    bug_report.yml            - GitHub issue form for bug reports
+    feature_request.yml       - GitHub issue form for feature requests
+    config.yml                - Issue template chooser policy (blank issues disabled)
+  dependabot.yml              - Dependabot updates for Go modules, GitHub Actions, and Dockerfiles
+  prompts/                    - Workflow prompts (generate-plan-*, implement-plan)
+  workflows/                  - CI/CD workflow definitions
+
+docs/
+  prereq.md                   - Prerequisites required to run sbam
+  mqtt.md                     - Detailed MQTT feed and Home Assistant discovery documentation
+  vibe/                       - Contributor workflow docs for TASK/PLAN prompt usage
+
+main.go                      # Entry point, version vars, delegates to pkg/cmd
+main_test.go                 # CLI-level tests
+
+pkg/
+  cmd/
+    root.go                   - Cobra root command, Viper config loading
+    configure.go              - `configure` command: battery defaults & force charge
+    estimate.go               - `estimate` command: display forecast & battery state
+    schedule.go               - `schedule` command: main intelligent charging workflow
+    schedule_runner.go        - Single-goroutine runner that serializes schedule ticks and command intents
+    schedule_runner_test.go   - Unit tests for runner command handling and queue behavior
+    schedule_mqtt_wiring_test.go - Unit tests for MQTT command subscription wiring and latest-state re-publish behavior
+    schedule_lifecycle_test.go - Unit tests for runner lifecycle behavior in no-cron MQTT/no-MQTT modes
+    precedence_test.go        - Unit tests for flag > env > yaml viper precedence
+  fronius/
+    types.go                  - Fronius struct definitions
+    handler.go                - Main battery control dispatcher
+    modbus.go                 - Modbus TCP client (open, read, write, close)
+    configure.go              - Modbus register writing (SetDefaults, ForceCharge)
+    schedule.go               - Battery charging algorithm
+    error.go                  - Error handling utilities
+    fronius_test.go           - Unit tests with mock Modbus server
+    error_test.go             - Error handling tests
+  mqtt/
+    types.go                  - MQTT config and payload carrier types
+    client.go                 - MQTT client interface, factory, and topic helpers
+    commands.go               - MQTT command topic parser, payload validation, and ack publisher
+    discovery.go              - Home Assistant MQTT discovery payload builder
+    noop.go                   - Disabled MQTT client implementation
+    paho.go                   - Paho-backed MQTT client with reconnect and TLS
+    reconnect.go              - Reconnect strategy normalization and manager selection
+    reconnect_custom.go       - Custom jittered reconnect manager
+    reconnect_paho.go         - Paho auto-reconnect manager
+    publisher.go              - Typed state, error, and availability publishers
+    mqtt_test.go              - In-process MQTT broker tests
+    commands_test.go          - Unit tests for command parsing and ack publishing
+    discovery_test.go         - Unit tests for Home Assistant discovery generation
+  power/
+    types.go                  - Solcast forecast struct definitions
+    handler.go                - Get daily solar production estimate
+    estimate.go               - Forecast retrieval, caching, power calculations
+    power_test.go             - HTTP mock tests for Solcast API
+  storage/
+    types.go                  - Fronius battery JSON response structs
+    handler.go                - Main handler fetching battery data
+    charge.go                 - Parse battery capacity & charge state
+    storage_test.go           - Unit tests
+
+src/
+  utils/
+    log.go                    - Centralized zap logger initialization
+    error.go                  - Error handling helpers (HandleError, HandleErrorPanic)
+    startup.go                - Startup parameters dump (DumpStartupParams, SecretKeys)
+    startup_test.go           - Unit tests for the startup dump helper
+
+config.yaml                  - Configuration file
+Makefile                     - Build targets (test, build, test-build)
+Dockerfile                   - Standalone container image
+home-assistant/addons/sbam/  - Home Assistant add-on files
+```
+
+Important:
+
+If you add, remove, rename, or move files or directories in this repository, update the "Project Structure" list above to reflect those changes.
+
+Do not track:
+- docs/implementations/ in the project structure as these are generated and managed by the implementation workflow.
+
+Rules:
+
+- Business logic lives in pkg/ packages (fronius, power, storage)
+- CLI command definitions live in pkg/cmd/
+- Reusable utilities live in src/utils/
+- No circular dependencies
+- Charging logic must not depend directly on HTTP or Modbus implementation details
+
+---
+
+## Coding Standards
+
+### Idiomatic Go
+
+- Always return (value, error)
+- Never panic in business logic
+- Use context.Context in all external calls
+- Use interfaces for abstractions
+- Keep functions small and focused
+- Avoid global state where possible
+
+### Constructor Pattern
+
+- Use `New()` factory functions returning `*TypeName` for package types
+
+### Error Handling
+
+- Always check and handle errors
+- Use `handleError()` for non-fatal errors (log + return)
+- Reserve panics strictly for unrecoverable initialization failures
+
+### Testing
+
+- Always create unit tests for components you introduce into the application
+- After changing or introducing new logic make sure that the tests are updated to match the new situation
+- Use `testify` for assertions (`assert.NoError`, `assert.Equal`, `assert.Contains`, `assert.Error`)
+- Use `httptest.NewServer` for mocking HTTP APIs (Solcast, Fronius Solar API)
+- Use `tbrandon/mbserver` for mocking Modbus TCP servers (Fronius Modbus)
+- Include at least the following types of test cases:
+  - 1 test case for the expected use
+  - 1 edge case
+  - 1 failure case
+- Always `defer server.Close()` for mock servers
+
+### Configuration
+
+- Configuration hierarchy: CLI flags > environment variables > config.yaml
+- All config is managed via Viper with `AutomaticEnv()` and cobra flag binding
+- Key parameters: `url`, `apikey`, `fronius_ip`, `pw_consumption`, `start_hr`, `end_hr`, `crontab`, `pw_batt_reserve`, `max_charge`, `pw_lwt`, `pw_upt`, `mqtt_enabled`, `mqtt_broker`, `mqtt_client_id`, `mqtt_username`, `mqtt_password`, `mqtt_topic_prefix`, `mqtt_ha_discovery`, `mqtt_ha_discovery_prefix`
+
+### Build
+
+- Binary built with `CGO_ENABLED=0` for portability
+- Version injected via `-ldflags` from git tags at build time
+- Build output: `bin/sbam`
+
+---
+
+## Claude Code Workflow
+
+This project uses a prompt-driven workflow for feature development. Features are designed and shipped in three repeatable steps. Each feature lives in its own directory under `docs/implementations/<feature-name>/` and contains exactly two managed files:
+
+- `<feature-name>-TASK.md` — human-facing feature request and requirements
+- `<feature-name>-PLAN.md` — agent-facing implementation plan
+
+### Available Commands
+
+- `/generate-plan-local <feature-name>` — interactive authoring of TASK + PLAN from scratch (or refinement of an existing TASK)
+- `/generate-plan-from-issue <issue-ref>` — same as above but seeded from a GitHub issue
+- `/implement-plan <feature-name>` — executes the PLAN, runs validation gates, and updates documentation surfaces
+
+### Workflow
+
+1. Generate a PLAN using `/generate-plan-from-issue <N>` or `/generate-plan-local <slug>`
+2. Review the generated `TASK.md` and `PLAN.md` under `docs/implementations/<feature>/`
+3. Answer clarifications added by the agent, update the TASK if needed
+4. Implement changes locally on a feature branch
+5. Add or update unit and integration tests as appropriate
+6. Run validation: `make test`, `make build`
+7. Open a **draft PR** referencing the issue and the generated PLAN
+8. Request at least one human reviewer and ensure CI passes before converting from draft
+
+### Guardrails
+
+- Tests: run `make test` locally; the PR must pass CI tests
+- Review: at least one reviewer must sign off on generated code
+- Secrets: never commit real API keys or credentials; use placeholders
+- Scope: keep each generated PR small and focused
+
+---
+
+## Additional Instructions
+
+- If I tell you that you are wrong, please check and think about whether or not you think that's true and respond with facts.
+- Avoid apologizing or making conciliatory statements.
+- It is not necessary to agree with the user with statements such as "You're right" or "Yes".
+- Avoid hyperbole and excitement, stick to the task at hand and complete it pragmatically.
+- Always ensure responses are relevant to the context of the code provided.
+- Avoid unnecessary detail not related to the task.


### PR DESCRIPTION
## Summary

Adds native Claude Code support to the sbam project by introducing a `CLAUDE.md` file and adapting existing workflow prompts to work with both Claude Code and GitHub Copilot.

## Changes

### New files

- **`CLAUDE.md`** — Project instructions for Claude Code, covering the project overview, tech stack, project structure, coding standards, and the prompt-driven workflow. Mirrors the structure of `.github/copilot-instructions.md` so both AI tools have equivalent context.

- **`.claudeignore`** — Excludes `.github/copilot-instructions.md` from Claude Code's context, avoiding redundant instructions.

### Modified files

- **`.github/prompts/generate-plan-from-issue.prompt.md`**
  - References `CLAUDE.md` alongside `.github/copilot-instructions.md` for project structure updates.

- **`.github/prompts/generate-plan-local.prompt.md`**
  - References `CLAUDE.md` as a secondary project documentation source.
  - Generalizes "Affected packages" from a hardcoded list to `pkg/*`.
  - Replaces hardcoded file path references with a general instruction to consult the project structure documentation.

- **`.github/prompts/implement-plan.prompt.md`**
  - References `CLAUDE.md` for project conventions.
  - Replaces direct file-path citations with a general pattern reference.
  - Adds `CLAUDE.md` to the list of files updated when the project structure changes.

## Motivation

The project workflow relies on prompt files that guide AI tooling through feature development (generate-plan → implement-plan). With Claude Code now being used alongside GitHub Copilot, the prompts and project instructions need to be tool-agnostic so both assistants produce consistent, convention-compliant code.

## Test plan

- [ ] Verify `make test` passes
- [ ] Verify `make build` succeeds
- [ ] Verify `/generate-plan-local` and `/implement-plan` prompts work correctly with Claude Code
- [ ] Verify existing Copilot workflow is unaffected