### PR TITLE
feat(fronius): introduce Reason type and replace string literal reasons with constants

### DIFF
--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -55,7 +55,7 @@ type clockSegment struct {
 type froniusClient interface {
 	Handler(pw_forecast, pw_batt2charge, pw_batt_max, pw_consumption, max_charge, pw_batt_reserve float64,
 		start_hr, end_hr, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt, pw_upt float64,
-		forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, string, fronius.PowerState, error)
+		forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, fronius.Reason, fronius.PowerState, error)
 }
 
 var newFronius = func() froniusClient {

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -245,7 +245,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		return froniusErr
 	}
 
-	payload := makeBasePayload(decision.String(), reason, inChargeWindow, reserveWindowActive)
+	payload := makeBasePayload(decision.String(), reason.String(), inChargeWindow, reserveWindowActive)
 	payload.BatterySOCPct = &socPct
 	payload.BatteryCapacityWh = &capacityMax
 	payload.ForecastTodayWh = &solarPowerProduction

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -28,7 +28,7 @@ type fakeBatteryWriter struct {
 // interface and records the number of Handler calls.
 type stubFroniusClient struct{ calls int }
 
-func (s *stubFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, string, fronius.PowerState, error) {
+func (s *stubFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, fronius.Reason, fronius.PowerState, error) {
 	s.calls++
 	return 0, fronius.DecisionIdle, "stub", fronius.PowerState{}, nil
 }

--- a/pkg/cmd/schedule_test.go
+++ b/pkg/cmd/schedule_test.go
@@ -190,7 +190,7 @@ func TestSchedule_FroniusModbusFailurePublishesSkip(t *testing.T) {
 // non-skip payload.
 type fakeFroniusClient struct{}
 
-func (f *fakeFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, string, fronius.PowerState, error) {
+func (f *fakeFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, fronius.Reason, fronius.PowerState, error) {
 	ps := fronius.PowerState{PvNet: 0.0, Batt: 0.0, Net: 0.0, BattReserveNet: 0.0}
 	return int16(10), fronius.DecisionIdle, "fake-handler", ps, nil
 }
@@ -286,7 +286,7 @@ func (f *fakePowerClient) Handler(apiKey string, url string, cache_forecast bool
 type trackingFroniusClient struct {
 	err                  error
 	decision             fronius.Decision
-	reason               string
+	reason               fronius.Reason
 	chargePct            int16
 	powerState           fronius.PowerState
 	calls                int
@@ -295,7 +295,7 @@ type trackingFroniusClient struct {
 	lastReserveWindowArg bool
 }
 
-func (f *trackingFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, string, fronius.PowerState, error) {
+func (f *trackingFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, fronius.Reason, fronius.PowerState, error) {
 	_ = pw_batt2charge
 	_ = pw_batt_max
 	_ = pw_consumption

--- a/pkg/fronius/classify.go
+++ b/pkg/fronius/classify.go
@@ -16,6 +16,20 @@ func (d Decision) String() string {
 	return string(d)
 }
 
+type Reason string
+
+const (
+	ReasonBatteryFull    Reason = "Battery is full charged"
+	ReasonForecastCharge Reason = "Net Power (actual battery power + Net solar power) is not enough"
+	ReasonReserveCharge  Reason = "Battery charge is below reserve threshold"
+	ReasonIdle           Reason = "Net Power (actual battery power + Net solar power) is enough"
+	ReasonSkip           Reason = "unexpected power state"
+)
+
+func (r Reason) String() string {
+	return string(r)
+}
+
 type PowerState struct {
 	PvNet          float64
 	Batt           float64
@@ -31,7 +45,7 @@ func ClassifyDecision(
 	pwBatt2charge, pwForecast, pwConsumption, pwBattMax,
 	pwBattReserve, pwLwt float64,
 	forecastChargeEnabled, battReserveChargeEnabled bool,
-) (Decision, string, PowerState, error) {
+) (Decision, Reason, PowerState, error) {
 	pw := PowerState{
 		PvNet: pwForecast - pwConsumption,
 		Batt:  pwBattMax - pwBatt2charge,
@@ -43,15 +57,14 @@ func ClassifyDecision(
 
 	switch {
 	case pwBatt2charge == 0:
-		return DecisionBatteryFull, "Battery is full charged", pw, nil
+		return DecisionBatteryFull, ReasonBatteryFull, pw, nil
 	case pw.Net < -1*pwLwt && forecastChargeEnabled:
-		return DecisionForecastCharge, "Net Power (actual battery power + Net solar power) is not enough", pw, nil
+		return DecisionForecastCharge, ReasonForecastCharge, pw, nil
 	case pw.BattReserveNet < -1*pwLwt && battReserveChargeEnabled:
-		return DecisionReserveCharge, "Battery charge is below reserve threshold", pw, nil
+		return DecisionReserveCharge, ReasonReserveCharge, pw, nil
 	case pw.Net >= -1*pwLwt:
-		return DecisionIdle, "Net Power (actual battery power + Net solar power) is enough", pw, nil
+		return DecisionIdle, ReasonIdle, pw, nil
 	default:
-		reason := fmt.Sprintf("unexpected power state: %+v", pw)
-		return DecisionSkip, reason, pw, fmt.Errorf("%s", reason)
+		return DecisionSkip, ReasonSkip, pw, fmt.Errorf("unexpected power state: %+v", pw)
 	}
 }

--- a/pkg/fronius/classify_test.go
+++ b/pkg/fronius/classify_test.go
@@ -19,7 +19,7 @@ func TestClassifyDecision(t *testing.T) {
 		forecastChargeEnabled    bool
 		battReserveChargeEnabled bool
 		expectedDecision         fronius.Decision
-		expectedReason           string
+		expectedReason           fronius.Reason
 	}{
 		{
 			name:                     "battery full short-circuits regardless of other inputs",
@@ -32,7 +32,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    true,
 			battReserveChargeEnabled: true,
 			expectedDecision:         fronius.DecisionBatteryFull,
-			expectedReason:           "Battery is full charged",
+			expectedReason:           fronius.ReasonBatteryFull,
 		},
 		{
 			name:                     "forecast charge fires when net power is below -lwt and forecast enabled",
@@ -45,7 +45,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    true,
 			battReserveChargeEnabled: false,
 			expectedDecision:         fronius.DecisionForecastCharge,
-			expectedReason:           "Net Power (actual battery power + Net solar power) is not enough",
+			expectedReason:           fronius.ReasonForecastCharge,
 		},
 		{
 			name:                     "reserve charge fires when battery is below reserve and reserve charge enabled",
@@ -58,7 +58,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    false,
 			battReserveChargeEnabled: true,
 			expectedDecision:         fronius.DecisionReserveCharge,
-			expectedReason:           "Battery charge is below reserve threshold",
+			expectedReason:           fronius.ReasonReserveCharge,
 		},
 		{
 			name:                     "idle when net power is fine and reserve is satisfied",
@@ -71,7 +71,7 @@ func TestClassifyDecision(t *testing.T) {
 			forecastChargeEnabled:    true,
 			battReserveChargeEnabled: true,
 			expectedDecision:         fronius.DecisionIdle,
-			expectedReason:           "Net Power (actual battery power + Net solar power) is enough",
+			expectedReason:           fronius.ReasonIdle,
 		},
 	}
 

--- a/pkg/fronius/handler.go
+++ b/pkg/fronius/handler.go
@@ -6,7 +6,7 @@ func New() *Fronius {
 	return &Fronius{}
 }
 
-func (fronius *Fronius) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, Decision, string, PowerState, error) {
+func (fronius *Fronius) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, Decision, Reason, PowerState, error) {
 	p := "502"
 	if len(fronius_port) > 0 {
 		p = fronius_port[0]

--- a/pkg/fronius/schedule.go
+++ b/pkg/fronius/schedule.go
@@ -2,7 +2,7 @@ package fronius
 
 import u "sbam/src/utils"
 
-func SetFroniusChargeBatteryMode(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, Decision, string, PowerState, error) {
+func SetFroniusChargeBatteryMode(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, Decision, Reason, PowerState, error) {
 	p := "502"
 	if len(fronius_port) > 0 {
 		p = fronius_port[0]
@@ -14,7 +14,7 @@ func SetFroniusChargeBatteryMode(pw_forecast float64, pw_batt2charge float64, pw
 		pw_batt_reserve, pw_lwt,
 		forecast_charge_enabled, batt_reserve_charge_enabled,
 	)
-	u.Log.Infof("Decision: %s - %s", decision.String(), reason)
+	u.Log.Infof("Decision: %s - %s", decision, reason)
 	u.Log.Infof("Net Power: %.2f Wh", pw.Net)
 	u.Log.Infof("Battery: %.2f Wh, Reserve: %.2f Wh", pw.Batt, pw_batt_reserve)
 


### PR DESCRIPTION
## Summary
- Introduces a typed `Reason` (mirroring the existing `Decision` pattern) so `ClassifyDecision` and its callers carry typed reasons instead of raw string literals.
- Replaces all inline reason strings in the classifier switch with the corresponding `Reason` constants.
- Updates the full call chain: `ClassifyDecision` → `SetFroniusChargeBatteryMode` → `Handler` → runner/scheduler, plus all test stubs and fakes.

## Test plan
- [x] `make all` passes (fmt, vet, test -race, build)
- [x] All existing tests pass with updated types