### PR TITLE
feat(claude): add slash command shims and unify Copilot/Claude Code contributor docs

### DIFF
--- a/.claude/commands/generate-plan-from-issue.md
+++ b/.claude/commands/generate-plan-from-issue.md
@@ -1,0 +1,1 @@
+Read and execute the instructions in `.github/prompts/generate-plan-from-issue.prompt.md` verbatim. The user invoked this as `/generate-plan-from-issue <issue-ref>`. Use the `<issue-ref>` argument (if provided) exactly as described in that prompt. If no argument was given, ask for one before doing anything else.

--- a/.claude/commands/generate-plan-local.md
+++ b/.claude/commands/generate-plan-local.md
@@ -1,0 +1,1 @@
+Read and execute the instructions in `.github/prompts/generate-plan-local.prompt.md` verbatim. The user invoked this as `/generate-plan-local <feature-name>`. Use the `<feature-name>` argument (if provided) exactly as described in Phase 1 of that prompt. If no argument was given, ask for one before doing anything else.

--- a/.claude/commands/implement-plan.md
+++ b/.claude/commands/implement-plan.md
@@ -1,0 +1,1 @@
+Read and execute the instructions in `.github/prompts/implement-plan.prompt.md` verbatim. The user invoked this as `/implement-plan <feature-name>`. Use the `<feature-name>` argument (if provided) exactly as described in the "Resolving the PLAN" section of that prompt. If no argument was given, ask for one before doing anything else.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,13 +51,15 @@ The application must be:
 ## Project Structure
 
 ```
+.claude/
+  commands/                   - Claude Code slash commands (delegate to .github/prompts/)
 .github/
   ISSUE_TEMPLATE/
     bug_report.yml            - GitHub issue form for bug reports
     feature_request.yml       - GitHub issue form for feature requests
     config.yml                - Issue template chooser policy (blank issues disabled)
   dependabot.yml              - Dependabot updates for Go modules, GitHub Actions, and Dockerfiles
-  prompts/                    - Workflow prompts (generate-plan-*, implement-plan)
+  prompts/                    - Workflow prompts (generate-plan-*, implement-plan) — single source of truth for both Copilot and Claude Code
   workflows/                  - CI/CD workflow definitions
 
 docs/

--- a/docs/vibe/CONTRIBUTING.md
+++ b/docs/vibe/CONTRIBUTING.md
@@ -1,12 +1,13 @@
-Contributing with Copilot (Vibe Coding)
+Contributing with Copilot or Claude Code (Vibe Coding)
 
 Purpose
-- Provide guidance for contributors using Copilot prompts to propose and
-  implement changes.
+- Provide guidance for contributors using Copilot prompts or Claude Code
+  slash commands to propose and implement changes.
+- Both tools share the same prompt files in `.github/prompts/`.
 
 Principles
-- Iterate: use Copilot to generate a plan, then refine the plan with clarifying
-  answers.
+- Iterate: generate a plan with `/generate-plan-*`, then refine it with
+  clarifying answers.
 - Validate: always run tests and perform manual review of generated code.
 - Safety first: prefer draft PRs and require human approval before merging.
 

--- a/docs/vibe/PROMPTS.md
+++ b/docs/vibe/PROMPTS.md
@@ -1,19 +1,29 @@
-Available prompts (.github/prompts)
+Available prompts (.github/prompts) and Claude Code commands (.claude/commands)
 
 This repository includes a set of Copilot prompts designed to generate TASKs,
 PLANs and help implement features. Edit prompts carefully and include examples.
 
-Known prompts
-- `.github/prompts/generate-plan-from-issue.prompt.md` — Generate a TASK and
-  PLAN from a GitHub issue reference (fetches the issue, asks clarifying
-  questions, writes docs to `docs/implementations/<feature>/`).
-- `.github/prompts/generate-plan-local.prompt.md` — Generate a TASK and PLAN
-  from a local feature slug (useful for small, local features or experiments).
-- `.github/prompts/implement-plan.prompt.md` — Implement the PLAN: reads the
-  PLAN and TASK and can create documentation and make suggestions for code
-  changes (manual review required before merging).
+The same prompts are also exposed as **Claude Code slash commands** via thin
+wrapper files under `.claude/commands/`. Each command delegates to the
+corresponding prompt file in `.github/prompts/`, which is the single source of
+truth. Commands and prompts stay in sync automatically — edit the prompt to
+change behavior for both tools.
+
+Known prompts / commands
+- `.github/prompts/generate-plan-from-issue.prompt.md` → `/generate-plan-from-issue`
+  Generate a TASK and PLAN from a GitHub issue reference (fetches the issue,
+  asks clarifying questions, writes docs to `docs/implementations/<feature>/`).
+- `.github/prompts/generate-plan-local.prompt.md` → `/generate-plan-local`
+  Generate a TASK and PLAN from a local feature slug (useful for small, local
+  features or experiments).
+- `.github/prompts/implement-plan.prompt.md` → `/implement-plan`
+  Implement the PLAN: reads the PLAN and TASK and can create documentation and
+  make suggestions for code changes (manual review required before merging).
 
 Editing and versioning
+- **Source of truth:** `.github/prompts/*.prompt.md` — edit these to change
+  behavior for both Copilot and Claude Code. The `.claude/commands/*.md` files
+  are thin delegating shims and should not need separate edits.
 - When changing prompts, add an example output to [EXAMPLES.md](EXAMPLES.md) and
   describe the change in the corresponding TASK/PLAN.
 - Keep prompts small and explicit about safety checks (tests, draft PRs,


### PR DESCRIPTION
## Summary
- Add Claude Code slash command shims (`.claude/commands/`) that delegate to `.github/prompts/`
- Unify `CONTRIBUTING-COPILOT.md` into `CONTRIBUTING.md` covering both Copilot and Claude Code workflows
- Update `PROMPTS.md` to document the dual-tool usage
- Update `CLAUDE.md` project structure to reflect `.claude/commands/`

## Test plan
- Verify `/generate-plan-from-issue`, `/generate-plan-local`, `/implement-plan` work from Claude Code
- Verify `make test` passes
- Verify existing Copilot prompt workflow is unaffected