### PR TITLE
fix(ha): accept 0 0 0 0 0 as valid crontab in add-on config schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ pkg/
     schedule_mqtt_wiring_test.go - Unit tests for MQTT command subscription wiring and latest-state re-publish behavior
     schedule_lifecycle_test.go - Unit tests for runner lifecycle behavior in no-cron MQTT/no-MQTT modes
     precedence_test.go        - Unit tests for flag > env > yaml viper precedence
+    config_schema_test.go     - Unit tests for HA add-on config.json schema regex validation
   fronius/
     types.go                  - Fronius struct definitions
     handler.go                - Main battery control dispatcher

--- a/docs/implementations/142-issue-fix-crontab-default-validation/142-issue-fix-crontab-default-validation-PLAN.md
+++ b/docs/implementations/142-issue-fix-crontab-default-validation/142-issue-fix-crontab-default-validation-PLAN.md
@@ -1,0 +1,175 @@
+# PLAN: Fix crontab default validation in HA addon config
+
+> Date: 2026-05-27
+> TASK: [142-issue-fix-crontab-default-validation-TASK.md](142-issue-fix-crontab-default-validation-TASK.md)
+> Issue: [#142](https://github.com/atbore-phx/sbam/issues/142)
+
+## Task Analysis
+
+**Goal:** Fix the `crontab` regex in `home-assistant/addons/sbam/config.json` so that `0 0 0 0 0` passes schema validation.
+
+**Non-goals:**
+- Handling blank/empty crontab input
+- Changes to Go-side cron validation logic
+- Other config.json schema changes
+
+**Acceptance criteria:**
+- `0 0 0 0 0` passes HA add-on config schema validation
+- All previously valid crontab expressions remain accepted
+- `make test` and `make build` pass
+
+## Current State
+
+The crontab regex in `home-assistant/addons/sbam/config.json:47`:
+
+```json
+"crontab": "match(^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$)"
+```
+
+Decoded (JSON-unescaped) regex:
+```
+^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$
+```
+
+This regex has three top-level alternatives joined by `|`:
+1. Standard 5-7 field cron expressions
+2. `@` shorthand macros (`@daily`, `@hourly`, etc.)
+3. `@every` duration expressions
+
+In theory, `0 0 0 0 0` should match alternative 1 (each `0` matches the `\d+L?` sub-pattern). In practice, users report a regex validation error from Home Assistant. The fix adds `0 0 0 0 0` as a fourth explicit alternative, making the match independent of the complex field-by-field alternation logic.
+
+The Go application already handles `0 0 0 0 0` correctly — `pkg/cmd/schedule.go:40` defines `const_ct = "0 0 0 0 0"`, and at line 196 the code checks `if crontab != const_ct` to skip cron scheduling. The Go binary never passes this value to `robfig/cron`, so no runtime parsing issue arises.
+
+No existing tests cover the HA config.json schema regex.
+
+## Target Architecture
+
+Minimal change touching two files:
+
+| File | Change |
+|---|---|
+| `home-assistant/addons/sbam/config.json` | Add `(0 0 0 0 0)\|` as a fourth alternative in the crontab regex |
+| `pkg/cmd/config_schema_test.go` (new) | Unit test that extracts the regex from config.json and validates key inputs |
+
+No new packages, types, functions, or interfaces. No data flow changes.
+
+## Dependency Choices
+
+None. No new dependencies. The test uses only the standard library (`encoding/json`, `regexp`, `testing`) plus `github.com/stretchr/testify` (already in the project).
+
+## Configuration Changes
+
+**`home-assistant/addons/sbam/config.json`:**
+- Line 47: update `crontab` schema value to add `(0 0 0 0 0)` as an alternative
+
+New regex (JSON-escaped):
+```
+^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(0 0 0 0 0)|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$
+```
+
+The only addition is `(0 0 0 0 0)|` inserted before the `@` shorthand alternative.
+
+No CLI flags, env vars, config.yaml keys, or run.sh changes.
+
+## Implementation Blueprint
+
+### Step 1 — Fix the regex in config.json
+
+**File:** `home-assistant/addons/sbam/config.json`
+
+**Change:** On line 47, update the crontab schema value.
+
+**Current:**
+```
+"crontab": "match(^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$)"
+```
+
+**New:**
+```
+"crontab": "match(^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(0 0 0 0 0)|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$)"
+```
+
+**Rationale:** Adding `(0 0 0 0 0)|` as a literal alternative bypasses any engine-specific behavior in the complex field-by-field alternation. It is unambiguous and self-documenting — the disabled sentinel is clearly visible in the schema.
+
+### Step 2 — Add Go unit test for the config.json crontab regex
+
+**File:** `pkg/cmd/config_schema_test.go` (new)
+
+**What to add:** A test function `TestCrontabSchemaRegex` that:
+1. Reads `../../home-assistant/addons/sbam/config.json` relative to the test file
+2. Unmarshals the JSON to extract `schema.crontab`
+3. Strips the `match(` prefix and `)` suffix to get the bare regex
+4. Compiles the regex with `regexp.Compile`
+5. Asserts pass/fail for the inputs listed in the test plan below
+
+**Signature:** `func TestCrontabSchemaRegex(t *testing.T)`
+
+**Rationale:** This catches regressions where a future edit to the config.json regex accidentally drops `0 0 0 0 0` support. Reading the actual file rather than hardcoding the regex ensures the test stays in sync with the schema.
+
+## Test Plan
+
+### config_schema_test.go
+
+**Expected pass cases:**
+| Input | Notes |
+|---|---|
+| `0 0 0 0 0` | The fix target — disabled sentinel |
+| `00 00-05 * * *` | Default example in config.json options |
+| `*/5 * * * *` | Standard every-5-minutes |
+| `30 14 * * *` | Daily at 14:30 |
+| `1,15,30 * * * *` | Comma-separated values |
+| `0 0 * * 1-5` | Weekdays only |
+| `@daily` | Shorthand macro |
+| `@every 1h` | Duration expression |
+| `@every 5m` | Duration expression |
+
+**Expected fail cases:**
+| Input | Notes |
+|---|---|
+| `""` (empty string) | Empty input |
+| `not a cron expression` | Garbage input |
+| `0` | Too few fields |
+| `a b c d e` | Non-numeric fields in 5-field form |
+
+**Cleanup:** No external resources, no `defer` needed. Uses `require`/`assert` from testify.
+
+## Validation Gates
+
+```bash
+# Run the new test specifically
+go test ./pkg/cmd/ -run TestCrontabSchemaRegex -v
+
+# Full test suite
+make test
+
+# Build
+make build
+```
+
+## Rollout / Backward Compatibility
+
+- **Backward compatibility:** The change is purely additive — a new alternative in an existing `|` alternation. All previously accepted expressions continue to match against the unchanged alternatives. No valid input becomes invalid.
+- **Default behavior:** Unchanged. The `options.crontab` default remains `"00 00-05 * * *"`.
+- **Migration:** None required. Users who previously worked around the issue (e.g., by editing config directly) can now switch to using the HA UI with `0 0 0 0 0`.
+- **Home Assistant add-on CHANGELOG:** Should note the fix for the next release.
+
+## Security Considerations
+
+- The regex change is a pure validation relax — it accepts an additional input that was previously rejected. No security regression.
+- The regex is evaluated by HA Supervisor, not exposed to unauthenticated input. Even if an attacker could supply a crafted crontab value, the worst case is a regex match/no-match — no injection or code execution surface.
+- No secrets, keys, or credentials are involved.
+
+## Gotchas
+
+- The JSON escaping in config.json requires `\\d` for `\d`, `\\/` for `\/`, etc. The literal string `(0 0 0 0 0)` needs no escaping — it contains only spaces and digits.
+- The test must strip the `match(` prefix and trailing `)` from the schema value before compiling as a regex. The schema format is `match(<regex>)` where the regex already includes `^` and `$` anchors.
+- The test reads config.json with a relative path. The working directory when running `go test ./pkg/cmd/` is the project root, so the path `home-assistant/addons/sbam/config.json` works. Using `../../home-assistant/addons/sbam/config.json` from the test file's perspective is more robust against working-directory variation — but Go tests in `pkg/cmd/` are always run with the module root as the working directory.
+
+## Open Questions / Risks
+
+- RESOLVED: blank/empty crontab is out of scope.
+- RISK: The exact regex engine used by HA Supervisor is not documented. The explicit `(0 0 0 0 0)` alternative mitigates this — it's a plain literal match with no metacharacters, no character classes, no quantifiers. Should work in any regex engine.
+
+## Confidence Score
+
+**10/10** — Single-line regex addition plus a straightforward unit test. No new dependencies, no architectural changes, no data flow impact. The fix is additive and cannot regress existing behavior.

--- a/docs/implementations/142-issue-fix-crontab-default-validation/142-issue-fix-crontab-default-validation-TASK.md
+++ b/docs/implementations/142-issue-fix-crontab-default-validation/142-issue-fix-crontab-default-validation-TASK.md
@@ -1,0 +1,76 @@
+# Feature: Fix crontab default validation in HA addon config
+
+> Slug: `142-issue-fix-crontab-default-validation` · Created: 2026-05-27
+> Source issue: [#142](https://github.com/atbore-phx/sbam/issues/142)
+> Fetched: 2026-05-27
+
+## Summary
+
+The Home Assistant add-on `config.json` regex for the `crontab` field rejects `0 0 0 0 0` — the project's designated "disabled" default value. Users setting this value through the HA add-on configuration UI get a regex validation error.
+
+## Motivation / User Story
+
+As a Home Assistant add-on user, I want to disable scheduled cron execution by setting the crontab to `0 0 0 0 0` (the project's disabled sentinel), so that I can run sbam purely via MQTT commands without a recurring schedule.
+
+## Scope
+
+- In scope:
+  - Fix the `crontab` regex in `home-assistant/addons/sbam/config.json` to accept `0 0 0 0 0`
+  - Add a Go unit test that validates the crontab regex against key inputs
+- Out of scope:
+  - Handling blank/empty crontab input (requires Go-side validation changes)
+  - Changes to cron expression parsing in the Go application
+  - Changes to `robfig/cron` dependency
+  - Other config.json schema changes
+
+## Functional Requirements
+
+- `0 0 0 0 0` must pass the HA add-on config schema validation for the `crontab` field
+- All previously accepted crontab expressions must continue to be accepted
+
+## Non-functional Requirements
+
+- Backward compatibility: all previously accepted crontab expressions must still be accepted
+- Safety / defaults: the default crontab value in `config.json` options remains `"00 00-05 * * *"` (the example shown to new users); the disabled sentinel `0 0 0 0 0` must be an accepted (but not the default) value
+- Performance: N/A (regex evaluated once at config load)
+
+## Configuration Impact
+
+- New CLI flags: none
+- New config keys (`config.yaml`): none
+- New env vars: none
+- Home Assistant add-on schema changes (`home-assistant/addons/sbam/config.json`):
+  - Update the `crontab` `match` regex to accept `0 0 0 0 0`
+
+## External Integrations Touched
+
+- None. This is purely a config schema fix.
+
+## Acceptance Criteria
+
+- [ ] Setting `crontab` to `0 0 0 0 0` in the HA add-on configuration UI passes schema validation
+- [ ] All previously valid crontab expressions continue to be accepted
+- [ ] `make test` and `make build` pass
+
+## Test Strategy
+
+- Add a Go unit test (e.g., in `pkg/cmd/`) that loads the crontab regex from `config.json` and validates key inputs
+- Expected pass cases: `0 0 0 0 0`, `00 00-05 * * *`, `*/5 * * * *`, `@every 1h`, `@daily`, `1,15,30 * * * *`
+- Expected fail cases: `not a cron expression`, empty string, `0` (too few fields)
+- Use Go's `regexp.Compile` on the schema regex (extracted or replicated from `config.json`)
+
+## Risks / Open Questions
+
+- Why does the current regex (which appears to match `0 0 0 0 0` in standard PCRE and Python `re` engines) fail in Home Assistant? The HA `voluptuous` `match` filter may handle certain constructs differently. Regardless, the fix should explicitly add `0 0 0 0 0` as an accepted alternative so there is no ambiguity.
+- RESOLVED: blank/empty crontab handling is out of scope for this fix.
+
+## References
+
+- Issue: [#142](https://github.com/atbore-phx/sbam/issues/142)
+- Current crontab regex: `home-assistant/addons/sbam/config.json:47`
+- Go crontab validation: `pkg/cmd/schedule.go:376-379`
+- Disabled default constant: `pkg/cmd/schedule.go:40` (`const_ct = "0 0 0 0 0"`)
+
+## Clarifications
+
+- **2026-05-27**: Scope narrowed to `0 0 0 0 0` only — blank/empty crontab handling is out of scope (would require Go-side validation changes). Tests will be added as Go unit tests validating the regex from `config.json` against key inputs.

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Crontab default validation fix
+
+The Home Assistant add-on configuration schema now accepts `0 0 0 0 0` as a valid crontab value, allowing users to disable scheduled execution through the HA UI. Previously the regex validation rejected this value even though the Go application has always treated it as the disabled sentinel.
+
 ## What's New in v2.0.1
 
 ### ARM64/aarch64 Build Fix

--- a/home-assistant/addons/sbam/config.json
+++ b/home-assistant/addons/sbam/config.json
@@ -44,7 +44,7 @@
     "fronius_ip": "match(^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)(\\.(?!$)|$)){4}$)",
     "start_hr": "match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)",
     "end_hr": "match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)",
-    "crontab": "match(^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$)",
+    "crontab": "match(^((((\\d+,)+\\d+|(\\d+(\\/|-|#)\\d+)|\\d+L?|\\*(\\/\\d+)?|L(-\\d+)?|\\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(0 0 0 0 0)|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\\d+(ns|us|µs|ms|s|m|h))+)$)",
     "pw_consumption": "float",
     "max_charge": "float",
     "pw_lwt": "float",

--- a/pkg/cmd/config_schema_test.go
+++ b/pkg/cmd/config_schema_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrontabSchemaRegex(t *testing.T) {
+	data, err := os.ReadFile("../../home-assistant/addons/sbam/config.json")
+	require.NoError(t, err, "failed to read config.json — ensure test runs from module root")
+
+	var config struct {
+		Schema struct {
+			Crontab string `json:"crontab"`
+		} `json:"schema"`
+	}
+	err = json.Unmarshal(data, &config)
+	require.NoError(t, err)
+	require.NotEmpty(t, config.Schema.Crontab, "crontab schema entry is missing or empty")
+
+	raw := config.Schema.Crontab
+	require.True(t, len(raw) > 7, "unexpected crontab schema format")
+	require.Equal(t, "match(", raw[:6], "expected match(...) wrapper")
+	require.Equal(t, ")", raw[len(raw)-1:], "expected match(...) wrapper")
+	regexStr := raw[6 : len(raw)-1]
+
+	re, err := regexp.Compile(regexStr)
+	require.NoError(t, err, "failed to compile crontab schema regex")
+
+	passCases := []string{
+		"0 0 0 0 0",
+		"00 00-05 * * *",
+		"*/5 * * * *",
+		"30 14 * * *",
+		"1,15,30 * * * *",
+		"0 0 * * 1-5",
+		"@daily",
+		"@every 1h",
+		"@every 5m",
+	}
+	for _, tc := range passCases {
+		t.Run("pass/"+tc, func(t *testing.T) {
+			assert.True(t, re.MatchString(tc), "expected %q to match", tc)
+		})
+	}
+
+	failCases := []string{
+		"",
+		"not a cron expression",
+		"0",
+		"a b c d e",
+	}
+	for _, tc := range failCases {
+		t.Run("fail/"+tc, func(t *testing.T) {
+			assert.False(t, re.MatchString(tc), "expected %q to not match", tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the HA add-on `config.json` crontab regex to accept `0 0 0 0 0` (the project's disabled sentinel) as a valid value
- Adds a Go unit test that reads the live config.json, extracts and compiles the crontab regex, and validates key inputs

## Test plan
- [x] `make tidy`, `make vet`, `make test`, `make build` all pass
- [x] New `TestCrontabSchemaRegex` passes 9 expected-match and 4 expected-no-match cases
- [x] Manual test in HA add-on config UI with `0 0 0 0 0`

Closes #142