### PR TITLE
feat(ci): add dev HA image workflow, composite action, and /create-pr

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,1 @@
+Read and execute the instructions in `.github/prompts/create-pr.prompt.md` verbatim. The user invoked this as `/create-pr [base-branch] [--ready] [--label <labels>]`. Use the arguments as described in that prompt.

--- a/.github/actions/build-ha-addon/action.yml
+++ b/.github/actions/build-ha-addon/action.yml
@@ -66,3 +66,5 @@ runs:
         cosign: "false"
         container-registry-password: ${{ inputs.github-token }}
         push: "true"
+        build-args: |
+          BUILD_FROM=ghcr.io/home-assistant/${{ inputs.haarch }}-base:latest

--- a/.github/actions/build-ha-addon/action.yml
+++ b/.github/actions/build-ha-addon/action.yml
@@ -1,0 +1,54 @@
+name: Build HA Add-on Image
+description: Build the Go binary and the Home Assistant add-on Docker image
+
+inputs:
+  goarch:
+    description: 'Go architecture (amd64, arm64)'
+    required: true
+  haarch:
+    description: 'Home Assistant architecture (amd64, aarch64)'
+    required: true
+  image-tags:
+    description: 'Docker image tags (newline-separated)'
+    required: true
+  version:
+    description: 'Version label for the image'
+    required: true
+  github-token:
+    description: 'GitHub token for container registry auth'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
+
+    - name: GoReleaser Install
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        install-only: true
+
+    - name: GoReleaser Build
+      shell: bash
+      run: |
+        mkdir -p home-assistant/addons/sbam/bin
+        goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
+      env:
+        GOOS: linux
+        GOARCH: ${{ inputs.goarch }}
+        CGO_ENABLED: 0
+
+    - name: Build add-on image
+      uses: home-assistant/builder/actions/build-image@2026.03.2
+      with:
+        arch: ${{ inputs.goarch }}
+        image: ghcr.io/${{ github.repository_owner }}/ha-${{ inputs.haarch }}-sbam
+        image-tags: ${{ inputs.image-tags }}
+        version: ${{ inputs.version }}
+        context: home-assistant/addons/sbam
+        cosign: "false"
+        container-registry-password: ${{ inputs.github-token }}
+        push: "true"

--- a/.github/actions/build-ha-addon/action.yml
+++ b/.github/actions/build-ha-addon/action.yml
@@ -14,6 +14,10 @@ inputs:
   version:
     description: 'Version label for the image'
     required: true
+  use-goreleaser:
+    description: "Use goreleaser to build (release workflow). Set 'false' to use plain go build."
+    required: false
+    default: 'true'
   github-token:
     description: 'GitHub token for container registry auth'
     required: true
@@ -27,11 +31,13 @@ runs:
         go-version: '1.26'
 
     - name: GoReleaser Install
+      if: ${{ inputs.use-goreleaser == 'true' }}
       uses: goreleaser/goreleaser-action@v7
       with:
         install-only: true
 
     - name: GoReleaser Build
+      if: ${{ inputs.use-goreleaser == 'true' }}
       shell: bash
       run: |
         mkdir -p home-assistant/addons/sbam/bin
@@ -40,6 +46,14 @@ runs:
         GOOS: linux
         GOARCH: ${{ inputs.goarch }}
         CGO_ENABLED: 0
+
+    - name: Build with Make
+      if: ${{ inputs.use-goreleaser != 'true' }}
+      shell: bash
+      run: |
+        make build-${{ inputs.goarch }}
+        mkdir -p home-assistant/addons/sbam/bin
+        cp bin/sbam home-assistant/addons/sbam/bin/sbam
 
     - name: Build add-on image
       uses: home-assistant/builder/actions/build-image@2026.03.2

--- a/.github/prompts/create-pr.prompt.md
+++ b/.github/prompts/create-pr.prompt.md
@@ -1,0 +1,132 @@
+---
+agent: "agent"
+description: "Commit all changed files and open a pull request"
+---
+
+# Create PR
+
+Commit all changed files and open a pull request for the **sbam** project (see [CLAUDE.md](../../CLAUDE.md)). The user invokes this command as:
+
+```
+/create-pr [base-branch] [--ready] [--label <labels>]
+```
+
+## Arguments
+
+| Argument | Required | Default | Description |
+|---|---|---|---|
+| `base-branch` | no | `main` | The branch to merge into |
+| `--ready` | no | draft | Create a PR ready for review instead of a draft |
+| `--label <labels>` | no | auto-detect | Comma-separated list of GitHub labels |
+
+## Workflow
+
+### Step 1 — Audit current state
+
+Run these commands in parallel:
+
+- `git status` — list modified/untracked files (never use `-uall`)
+- `git diff --stat` — size of unstaged changes
+- `git log <base-branch>..HEAD --oneline` — commits on this branch not yet on base
+- `git branch --show-current` — confirm branch name
+
+**If there are no changes to commit and no commits ahead of base, stop and tell the user.**
+
+### Step 2 — Draft a commit message
+
+Run `git diff` and `git diff --cached` to see the full set of changes. Also list any new untracked files.
+
+Draft a commit message following the repo convention visible in recent commits:
+
+```
+<type>(<scope>): <description>
+```
+
+Where `<type>` is one of: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`.
+Where `<scope>` is the affected package or area (e.g. `fronius`, `mqtt`, `cmd`, `ci`, `ha`, `make`).
+
+### Step 3 — Stage and commit
+
+Stage all relevant changed files explicitly by name (not `git add -A` or `git add .`):
+
+```bash
+git add <file1> <file2> ...
+```
+
+Never stage files that contain secrets (`.env`, `credentials.json`, etc.).
+
+Commit using a heredoc:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit-message>
+EOF
+)"
+```
+
+If the commit hook (pre-commit) fails, fix the reported issue, re-stage, and commit again as a **new** commit — never use `--amend` after a hook failure.
+
+### Step 4 — Determine PR parameters
+
+Parse these from the user's `/create-pr` arguments:
+
+- **Base branch**: if the user supplied a branch name, use it. Otherwise `main`.
+- **Labels**: if the user passed `--label`, use those labels. Otherwise auto-detect:
+  - Branch starts with `feat/` → `enhancement`
+  - Branch starts with `fix/` → `bug`
+  - Branch starts with `docs/` → `documentation`
+  - Branch starts with `chore/` → `chore`
+  - If no pattern matches, omit labels (leave the PR unlabeled).
+- **Draft**: `--draft` by default; use `--ready` (omit `--draft`) only if the user explicitly passed `--ready`.
+
+### Step 5 — Push
+
+Push the branch to origin if it hasn't been pushed yet:
+
+```bash
+git push -u origin <branch-name>
+```
+
+If the branch already has an upstream, just `git push`.
+
+### Step 6 — Create the PR
+
+Use `gh pr create --repo atbore-phx/sbam` with the parameters from step 4.
+
+Draft a PR body with:
+
+- A **Summary** section (1-3 bullet points capturing the key changes)
+- A **Test plan** section (checklist of manual or automated steps)
+
+Format:
+
+```bash
+gh pr create --repo atbore-phx/sbam \
+  --title "<PR title>" \
+  --base "<base-branch>" \
+  --head "<current-branch>" \
+  [--draft] \
+  [--label "<labels>"] \
+  --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+## Test plan
+<checklist of steps to verify the change>
+EOF
+)"
+```
+
+Omit `--draft` if the user passed `--ready`. Omit `--label` if no labels were determined.
+
+### Step 7 — Report
+
+Output the PR URL. If `gh` command fails, print the rendered PR body as a markdown block so the user can create it manually.
+
+## Operating Rules
+
+- Never commit secrets. Never stage `.env`, `credentials.json`, or similar files.
+- Never skip hooks (`--no-verify`, `--no-gpg-sign`).
+- Never amend commits unless the user explicitly asked.
+- Never force-push.
+- Follow the project CLAUDE.md rules.

--- a/.github/prompts/create-pr.prompt.md
+++ b/.github/prompts/create-pr.prompt.md
@@ -89,7 +89,20 @@ git push -u origin <branch-name>
 
 If the branch already has an upstream, just `git push`.
 
-### Step 6 — Create the PR
+### Step 6 — Check for existing PR
+
+Before creating a new PR, check if one already exists from the current branch:
+
+```bash
+gh pr list --repo atbore-phx/sbam --head <current-branch> --state open --json url,baseRefName,title
+```
+
+If output is non-empty, a PR already exists. Do **not** create a new one. Instead:
+- Report the existing PR URL and target base branch.
+- Note that the latest commits were pushed to the branch and are already reflected in the existing PR.
+- If the user intended to change the base branch, tell them to use `gh pr edit --base <new-base>`.
+
+### Step 7 — Create the PR
 
 Use `gh pr create --repo atbore-phx/sbam` with the parameters from step 4.
 
@@ -119,7 +132,7 @@ EOF
 
 Omit `--draft` if the user passed `--ready`. Omit `--label` if no labels were determined.
 
-### Step 7 — Report
+### Step 8 — Report
 
 Output the PR URL. If `gh` command fails, print the rendered PR body as a markdown block so the user can create it manually.
 

--- a/.github/prompts/generate-plan-local.prompt.md
+++ b/.github/prompts/generate-plan-local.prompt.md
@@ -11,12 +11,14 @@ You are generating an implementation plan for the **sbam** project (Smart Batter
 /generate-plan-local <feature-name>
 ```
 
-Where `<feature-name>` is a short kebab-case slug. The canonical local slug format is `<NN>-local-<slug>` where `<NN>` is a zero-padded ordinal (examples: `01-local-init`, `02-local-prometheus-metrics`).
+Where `<feature-name>` is a short kebab-case slug. The canonical local slug format is either:
+- `local-<slug>` — when there is no associated GitHub issue (e.g. `local-init`, `local-cache-forecast`)
+- `<NN>-local-<slug>` — when the feature maps to a GitHub issue #NN (e.g. `03-local-init`)
 
-- If the user supplies a plain slug (e.g. `init` or `cache-forecast`), the agent will prefix it with the next free zero-padded ordinal and the literal `local` to produce the canonical form (e.g. `03-local-cache-forecast`).
-- If the user supplies a full canonical slug already, it must match `^\d{2}-local-[a-z0-9-]+$`.
+- If the user supplies a plain slug (e.g. `init` or `cache-forecast`), the agent will prefix it with `local-` to produce the canonical form (e.g. `local-cache-forecast`). Only prefix with a numeric ordinal when the feature is tied to a GitHub issue number.
+- If the user supplies a full canonical slug already, it must match `^(local|\d{2})-local-[a-z0-9-]+$`.
 
-If the user did not pass a feature name, **ask for one** before doing anything else and generate the canonical slug from the provided title. Validate input: accept either a plain slug matching `^[a-z0-9][a-z0-9-]*$` or a canonical local slug matching `^\d{2}-local-[a-z0-9-]+$`. Do not proceed until you have a valid name.
+If the user did not pass a feature name, **ask for one** before doing anything else and generate the canonical slug from the provided title. Validate input: accept either a plain slug matching `^[a-z0-9][a-z0-9-]*$` or a canonical local slug matching `^(local|\d{2})-local-[a-z0-9-]+$`. Do not proceed until you have a valid name.
 
 ## Conventions
 

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -20,16 +20,12 @@ jobs:
         goarch:
           - amd64
           - arm64
-        goos:
-          - linux
         include:
           - goarch: amd64
             haarch: amd64
-            platform: linux/amd64
             runs-on: ubuntu-24.04
           - goarch: arm64
             haarch: aarch64
-            platform: linux/arm64
             runs-on: ubuntu-24.04-arm
 
     steps:
@@ -47,38 +43,13 @@ jobs:
           echo "name=${SANITIZED}" >> "$GITHUB_OUTPUT"
           echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Build and push HA add-on image
+        uses: ./.github/actions/build-ha-addon
         with:
-          go-version: '1.26'
-
-      - name: GoReleaser Install
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          install-only: true
-
-      - name: GoReleaser Build ${{matrix.goos}}, ${{matrix.goarch}}
-        run: |
-          mkdir -p home-assistant/addons/sbam/bin
-          goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
-        env:
-          GOOS: ${{matrix.goos}}
-          GOARCH: ${{matrix.goarch}}
-          CGO_ENABLED: 0
-
-      - name: Build add-on image ${{ matrix.haarch }}
-        uses: home-assistant/builder/actions/build-image@2026.03.2
-        with:
-          arch: ${{ matrix.goarch }}
-          image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
+          goarch: ${{ matrix.goarch }}
+          haarch: ${{ matrix.haarch }}
           image-tags: |
             ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
             ${{ steps.branch.outputs.name }}-latest
           version: ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
-          context: home-assistant/addons/sbam
-          cosign: "false"
-          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          push: "true"
-          build-args: |
-            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.haarch }}-base
-            PLATFORM=${{ matrix.platform }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,0 +1,84 @@
+name: Dev Image
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  build-ha:
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (startsWith(github.ref_name, 'release/')) ||
+      (github.event.head_commit != null &&
+       startsWith(github.event.head_commit.message, '[build-ha]'))
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        goarch:
+          - amd64
+          - arm64
+        goos:
+          - linux
+        include:
+          - goarch: amd64
+            haarch: amd64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - goarch: arm64
+            haarch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Normalize branch name for Docker tags
+        id: branch
+        run: |
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          SANITIZED=$(echo "${BRANCH_NAME}" | sed 's/[^a-zA-Z0-9._-]/-/g' | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          echo "name=${SANITIZED}" >> "$GITHUB_OUTPUT"
+          echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: GoReleaser Install
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          install-only: true
+
+      - name: GoReleaser Build ${{matrix.goos}}, ${{matrix.goarch}}
+        run: |
+          mkdir -p home-assistant/addons/sbam/bin
+          goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
+        env:
+          GOOS: ${{matrix.goos}}
+          GOARCH: ${{matrix.goarch}}
+          CGO_ENABLED: 0
+
+      - name: Build add-on image ${{ matrix.haarch }}
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.goarch }}
+          image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
+          image-tags: |
+            ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+            ${{ steps.branch.outputs.name }}-latest
+          version: ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+          context: home-assistant/addons/sbam
+          cosign: "false"
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          push: "true"
+          build-args: |
+            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.haarch }}-base
+            PLATFORM=${{ matrix.platform }}

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -52,4 +52,5 @@ jobs:
             ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
             ${{ steps.branch.outputs.name }}-latest
           version: ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+          use-goreleaser: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,12 @@ jobs:
         goarch:
           - amd64
           - arm64
-        goos:
-          - linux
         include:
           - goarch: amd64
             haarch: amd64
-            platform: linux/amd64
             runs-on: ubuntu-24.04
           - goarch: arm64
             haarch: aarch64
-            platform: linux/arm64
             runs-on: ubuntu-24.04-arm
     env:
       VERSION: ${{ needs.determine-release.outputs.version }}
@@ -75,41 +71,16 @@ jobs:
 
       # Version and release info taken from determine-release job outputs.
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - name: Build and push HA add-on image
+        uses: ./.github/actions/build-ha-addon
         with:
-          go-version: '1.26'
-
-      - name: GoReleaser Install
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          install-only: true
-
-      - name: GoReleaser Build ${{matrix.goos}}, ${{matrix.goarch}}
-        run: |
-          mkdir home-assistant/addons/sbam/bin
-          goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
-        env:
-          GOOS: ${{matrix.goos}}
-          GOARCH: ${{matrix.goarch}}
-          CGO_ENABLED: 0
-
-      - name: Build add-on image ${{ matrix.haarch }}
-        uses: home-assistant/builder/actions/build-image@2026.03.2
-        with:
-          arch: ${{ matrix.goarch }}
-          image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
+          goarch: ${{ matrix.goarch }}
+          haarch: ${{ matrix.haarch }}
           image-tags: |
             ${{ env.VERSION }}
             ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'pre-release' }}
           version: ${{ env.VERSION }}
-          context: home-assistant/addons/sbam
-          cosign: "false"
-          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          push: "true"
-          build-args: |
-            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.haarch }}-base
-            PLATFORM=${{ matrix.platform }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release-os:
     needs: determine-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
           image-tags: |
             ${{ env.VERSION }}
-            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'dev' }}
+            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'pre-release' }}
           version: ${{ env.VERSION }}
           context: home-assistant/addons/sbam
           cosign: "false"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,10 @@ The application must be:
     feature_request.yml       - GitHub issue form for feature requests
     config.yml                - Issue template chooser policy (blank issues disabled)
   dependabot.yml              - Dependabot updates for Go modules, GitHub Actions, and Dockerfiles
-  prompts/                    - Workflow prompts (generate-plan-*, implement-plan) — single source of truth for both Copilot and Claude Code
+  prompts/                    - Workflow prompts (generate-plan-*, implement-plan, create-pr) — single source of truth for both Copilot and Claude Code
   workflows/                  - CI/CD workflow definitions
+  actions/
+    build-ha-addon/           - Composite action: build Go binary + HA add-on Docker image
 
 docs/
   prereq.md                   - Prerequisites required to run sbam
@@ -207,6 +209,7 @@ some prompts are available in `.github/prompts/` for reference and iteration. Th
 - `/generate-plan-local <feature-name>` — interactive authoring of TASK + PLAN from scratch (or refinement of an existing TASK)
 - `/generate-plan-from-issue <issue-ref>` — same as above but seeded from a GitHub issue
 - `/implement-plan <feature-name>` — executes the PLAN, runs validation gates, and updates documentation surfaces
+- `/create-pr [base-branch] [--ready] [--label <labels>]` — commits all changed files and opens a pull request
 
 ### Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 
 DATE=$(shell date)
 
-.PHONY: build test test-build fmt tidy vet
+.PHONY: build build-amd64 build-arm64 test test-build all fmt tidy vet
 
 fmt:
 	go fmt ./...
@@ -35,10 +35,22 @@ vet:
 test:
 	go test -cover -race ./...
 
+LDFLAGS=-ldflags="-X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'"
+
 build:
 	rm -rf bin
 	mkdir -p bin
-	CGO_ENABLED=0 go build -ldflags="-X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'" -o bin/sbam
+	CGO_ENABLED=0 go build $(LDFLAGS) -o bin/sbam
+
+build-amd64:
+	rm -rf bin
+	mkdir -p bin
+	GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o bin/sbam
+
+build-arm64:
+	rm -rf bin
+	mkdir -p bin
+	GOARCH=arm64 CGO_ENABLED=0 go build $(LDFLAGS) -o bin/sbam
 
 test-build: test build
 

--- a/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-PLAN.md
+++ b/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-PLAN.md
@@ -1,0 +1,211 @@
+# Plan: Create HA Docker Image Workflow for Dev Release
+
+> Date: 2026-05-28 · Issue: [#155](https://github.com/atbore-phx/sbam/issues/155) · TASK: [TASK](local-create-ha-docker-image-workflow-for-dev-release-TASK.md)
+
+## 1. Task Analysis
+
+**Goal**: Create a CI workflow that builds and pushes the Home Assistant add-on Docker image (multi-arch) to ghcr.io for development/testing, and rename the pre-release tag in the existing release workflow.
+
+**Non-goals**: No Go code changes, no standalone Dockerfile builds, no Docker Hub publishing.
+
+**Acceptance criteria**:
+- Push to `release/*` auto-builds HA Docker images
+- Push to any other branch with commit message starting with `[build-ha]` triggers the build
+- Push without `[build-ha]` does not trigger
+- `workflow_dispatch` works from GitHub UI
+- Images tagged `<normalized-branch>-<sha>` and `<normalized-branch>-latest`
+- Both `amd64` and `aarch64` built and pushed
+- Release workflow tags pre-releases as `pre-release` instead of `dev`
+
+## 2. Current State
+
+- `.github/workflows/release.yml` — builds and pushes HA Docker images only when a git tag is pushed. Pre-releases get tagged `dev`.
+- `home-assistant/addons/sbam/Dockerfile` — HA add-on Dockerfile (multi-stage, just copies `run.sh` and `bin/sbam`)
+- `home-assistant/addons/sbam/config.json` — add-on config pointing image to `ghcr.io/atbore-phx/ha-{arch}-sbam`
+- No workflow exists for dev/pre-release Docker image builds from branches
+
+## 3. Target Architecture
+
+One new workflow file and one tiny modification to the existing release workflow:
+
+```
+.github/workflows/
+  dev-image.yml     (NEW)   — build & push HA Docker image for dev branches
+  release.yml       (MOD)   — dev → pre-release tag rename
+  test.yml                   (unchanged)
+```
+
+**Data flow**:
+```
+Branch push or workflow_dispatch
+  → trigger dev-image.yml
+  → build Go binary via GoReleaser (per arch)
+  → build HA Docker image via home-assistant/builder
+  → push to ghcr.io/atbore-phx/ha-{arch}-sbam with branch-name tags
+```
+
+## 4. Dependency Choices
+
+All actions already used elsewhere in the repo — no new dependencies:
+- `actions/checkout@v6`
+- `actions/setup-go@v6`
+- `goreleaser/goreleaser-action@v7`
+- `home-assistant/builder/actions/build-image@2026.03.2`
+
+## 5. Configuration Changes
+
+| File | Change |
+|---|---|
+| `.github/workflows/dev-image.yml` | New — full workflow definition |
+| `.github/workflows/release.yml` | Line 104: `dev` → `pre-release` |
+
+No new config keys, env vars, CLI flags, or HA add-on schema changes.
+
+## 6. Implementation Blueprint
+
+### Step 1 — Create `.github/workflows/dev-image.yml`
+
+```yaml
+name: Dev Image
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  build-ha:
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (startsWith(github.ref_name, 'release/')) ||
+      (github.event.head_commit != null &&
+       startsWith(github.event.head_commit.message, '[build-ha]'))
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        goarch:
+          - amd64
+          - arm64
+        goos:
+          - linux
+        include:
+          - goarch: amd64
+            haarch: amd64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - goarch: arm64
+            haarch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Normalize branch name for Docker tags
+        id: branch
+        run: |
+          BRANCH_NAME="${GITHUB_REF_NAME}"
+          SANITIZED=$(echo "${BRANCH_NAME}" | sed 's/[^a-zA-Z0-9._-]/-/g' | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          echo "name=${SANITIZED}" >> "$GITHUB_OUTPUT"
+          echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: GoReleaser Install
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          install-only: true
+
+      - name: GoReleaser Build ${{matrix.goos}}, ${{matrix.goarch}}
+        run: |
+          mkdir -p home-assistant/addons/sbam/bin
+          goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
+        env:
+          GOOS: ${{matrix.goos}}
+          GOARCH: ${{matrix.goarch}}
+          CGO_ENABLED: 0
+
+      - name: Build add-on image ${{ matrix.haarch }}
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.goarch }}
+          image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
+          image-tags: |
+            ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+            ${{ steps.branch.outputs.name }}-latest
+          version: ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+          context: home-assistant/addons/sbam
+          cosign: "false"
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          push: "true"
+          build-args: |
+            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.haarch }}-base
+            PLATFORM=${{ matrix.platform }}
+```
+
+### Step 2 — Modify `.github/workflows/release.yml`
+
+Change line 104 from `dev` to `pre-release`:
+
+```yaml
+# Before:
+            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'dev' }}
+# After:
+            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'pre-release' }}
+```
+
+## 7. Test Plan
+
+Testing is manual since this is a CI workflow change:
+
+| Scenario | Action | Expected result |
+|---|---|---|
+| Push without `[build-ha]` on `feat/foo` | Push a regular commit | Workflow does not run |
+| Push with `[build-ha]` on `feat/foo` | Push commit starting with `[build-ha]` | Workflow runs, images appear in ghcr.io with `feat-foo-<sha>` and `feat-foo-latest` tags |
+| Push to `release/test` | Push any commit | Workflow runs automatically |
+| Manual trigger | `workflow_dispatch` via GitHub UI | Workflow runs on selected branch |
+| Release tag push | Push a pre-release tag | `release.yml` tags image with `pre-release` (not `dev`) |
+
+## 8. Validation Gates
+
+- `make test` — ensure no Go code regressions (not expected, but gate)
+- `make build` — ensure Go build still works
+- Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dev-image.yml'))"` or VS Code YAML linting
+
+## 9. Rollout / Backward Compatibility
+
+- New workflow has no backward compatibility impact
+- `release.yml` change: pre-release tag changes from `dev` to `pre-release`. Any consumer referencing the `dev` tag must update to `pre-release`. Document in the next release CHANGELOG.
+
+## 10. Security Considerations
+
+- Registry auth uses `secrets.GITHUB_TOKEN` (auto-generated, scoped to the workflow run) — same pattern as `release.yml`
+- No user-facing secrets handled in the new workflow
+- Branch name sanitization prevents Docker tag injection (replaces special chars)
+
+## 11. Gotchas
+
+- `github.event.head_commit` is null for `workflow_dispatch` events and branch deletions — the `if` condition guards against this with the `github.event_name == 'workflow_dispatch'` short-circuit
+- The `home-assistant/builder/actions/build-image` action expects the Go binary at `home-assistant/addons/sbam/bin/sbam` before it runs — the GoReleaser step must come first
+- `mkdir -p` (not bare `mkdir`) in the GoReleaser build step to avoid failures if the directory already exists (cf. `release.yml` uses bare `mkdir`)
+- Branch names containing `/` (e.g. `feat/foo`) will be sanitized to `feat-foo` for Docker tag compliance
+
+## 12. Open Questions / Risks
+
+| Question/Risk | Status |
+|---|---|
+| Very long branch names could exceed Docker tag length limit (128 chars) | ACCEPTED — branch names in practice are <50 chars |
+| `home-assistant/builder` action version `2026.03.2` may have different behavior in the future | DEFERRED — pinned to current version like `release.yml` |
+
+## 13. Confidence Score
+
+**9/10** — The pattern closely mirrors the existing `release.yml` release-ha job. The only novel parts are the trigger conditions and tag naming, both straightforward. Risk area is the `if` condition handling edge cases (null `head_commit`), which is explicitly guarded.

--- a/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-PLAN.md
+++ b/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-PLAN.md
@@ -177,9 +177,12 @@ Testing is manual since this is a CI workflow change:
 
 ## 8. Validation Gates
 
-- `make test` — ensure no Go code regressions (not expected, but gate)
+- `make tidy` — ensure go.mod is clean
+- `make vet` — ensure no vet issues
+- `make test` — ensure no Go code regressions
 - `make build` — ensure Go build still works
-- Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dev-image.yml'))"` or VS Code YAML linting
+- `bash home-assistant/addons/test_local.sh` — validate Go cross-compilation (amd64 + arm64) and native Docker image build
+- Verify YAML syntax: validate all `.github/workflows/*.yml` and `.github/actions/*/action.yml` files
 
 ## 9. Rollout / Backward Compatibility
 

--- a/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-TASK.md
+++ b/docs/implementations/local-create-ha-docker-image-workflow-for-dev-release/local-create-ha-docker-image-workflow-for-dev-release-TASK.md
@@ -1,0 +1,83 @@
+# Feature: Create HA Docker Image Workflow for Dev Release
+
+> Slug: `local-create-ha-docker-image-workflow-for-dev-release` · Created: 2026-05-28
+
+## Summary
+
+A new GitHub Actions workflow that builds and pushes the Home Assistant add-on Docker image (multi-arch: amd64, arm64) to ghcr.io for development and testing on non-release branches. Also modify the existing release workflow to tag pre-releases as `pre-release` instead of `dev`.
+
+## Motivation / User Story
+
+As a developer, I need to test HA add-on Docker image builds on feature/fix branches before cutting a release. Currently the only way to build the HA Docker image is through the release workflow which requires a git tag. A dedicated dev-image workflow enables rapid iteration and testing of Docker image changes without polluting the release pipeline.
+
+## Scope
+
+- In scope:
+  - New `.github/workflows/dev-image.yml` workflow
+  - Multi-arch build (amd64, aarch64) using `home-assistant/builder/actions/build-image`
+  - Build the Go binary via GoReleaser (same pattern as `release.yml`)
+  - Push images to ghcr.io with normalized branch-name tags
+  - Modify `release.yml` pre-release tag from `dev` to `pre-release`
+- Out of scope:
+  - Building the standalone root `Dockerfile`
+  - Publishing to Docker Hub
+  - Modifying any Go source code
+  - Changes to the HA add-on `config.json` or `run.sh`
+
+## Functional Requirements
+
+1. **Trigger rules**:
+   - Push to `release/*` branches: automatic on every push
+   - Any other branch (feat/*, fix/*, chore/*, etc.): only when commit message starts with `[build-ha]`
+   - Manual trigger via `workflow_dispatch` (with branch selector)
+2. **Build**: multi-arch build for both `amd64` and `arm64` (aarch64), matching the existing `release.yml` matrix pattern
+3. **Push**: to `ghcr.io/atbore-phx/ha-{arch}-sbam` (same image name as release)
+4. **Tags**: `<normalized-branch-name>-<short-sha>` and `<normalized-branch-name>-latest`
+5. **Branch name normalization**: replace non-allowed Docker tag characters (slashes, underscores) with hyphens, lowercase
+
+## Non-functional Requirements
+
+- Backward compatibility: new workflow only; existing release workflow unchanged except for the tag rename
+- Safety: must not interfere with the release workflow; no changes to Go code
+- Idempotent: each push overwrites the `*-latest` tag for that branch
+
+## Configuration Impact
+
+- New file: `.github/workflows/dev-image.yml`
+- Modified file: `.github/workflows/release.yml` — change `dev` → `pre-release` in the pre-release tag logic
+
+## External Integrations Touched
+
+- GitHub Container Registry (ghcr.io) — push target
+- `home-assistant/builder/actions/build-image@2026.03.2` — HA add-on image builder action
+
+## Acceptance Criteria
+
+- [ ] A push to a `release/*` branch automatically builds and pushes HA Docker images
+- [ ] A push to `feat/foo` with commit message `[build-ha] add stuff` triggers the workflow
+- [ ] A push to `fix/bar` without `[build-ha]` in commit message does NOT trigger the workflow
+- [ ] `workflow_dispatch` via GitHub UI triggers the workflow on the selected branch
+- [ ] Images are pushed with tags: `<normalized-branch>-<sha>` and `<normalized-branch>-latest`
+- [ ] Both `amd64` and `aarch64` architectures are built and pushed
+- [ ] Release workflow now tags pre-releases as `pre-release` instead of `dev`
+
+## Test Strategy
+
+- Manual verification on a test branch (no automated GH Actions workflow testing):
+  - Push to a `feat/*` branch without `[build-ha]` prefix — verify workflow does not run
+  - Push with `[build-ha]` prefix — verify workflow runs and images appear in ghcr.io
+  - Run `workflow_dispatch` from GitHub UI — verify it triggers
+  - Inspect ghcr.io package tags for correct naming
+
+## Risks / Open Questions
+
+- The `home-assistant/builder/actions/build-image` action requires a Go binary present in `home-assistant/addons/sbam/bin/sbam` before building — must mirror the GoReleaser build step from `release.yml`
+- Branch name sanitization edge cases: very long branch names, branch names with special characters
+
+## References
+
+- `.github/workflows/release.yml` — existing release workflow to mirror pattern
+- `home-assistant/addons/sbam/Dockerfile` — HA add-on Dockerfile
+- `home-assistant/addons/sbam/config.json` — add-on config with image reference
+- `home-assistant/builder/actions/build-image@2026.03.2` — HA builder action
+- Issue [#155](https://github.com/atbore-phx/sbam/issues/155) — GitHub feature request

--- a/home-assistant/addons/sbam/Dockerfile
+++ b/home-assistant/addons/sbam/Dockerfile
@@ -1,6 +1,5 @@
-ARG BUILD_FROM="ghcr.io/home-assistant/amd64-base:latest"
-ARG PLATFORM="amd64"
-FROM --platform=$PLATFORM $BUILD_FROM
+ARG BUILD_FROM
+FROM $BUILD_FROM
 
 COPY run.sh /
 COPY bin/sbam /usr/bin/

--- a/home-assistant/addons/sbam/build.yaml
+++ b/home-assistant/addons/sbam/build.yaml
@@ -1,0 +1,4 @@
+---
+build_from:
+  aarch64: ghcr.io/home-assistant/aarch64-base:latest
+  amd64: ghcr.io/home-assistant/amd64-base:latest

--- a/home-assistant/addons/test_local.sh
+++ b/home-assistant/addons/test_local.sh
@@ -1,30 +1,47 @@
 #!/bin/bash
-set -euox pipefail
+set -euo pipefail
 
-ARC=${ARC:-amd64}
-HA_ARC=${HA_ARC:-amd64}
-BUILD_FROM=${BUILD_FROM:-ghcr.io/home-assistant/${HA_ARC}-base:latest}
-IMAGE_TAG=${IMAGE_TAG:-local/${HA_ARC}-sbam:test}
+# Architectures to test. Override with ARCHS="amd64" for native-only.
+ARCHS=${ARCHS:-amd64 arm64}
+IMAGE_TAG_PREFIX=${IMAGE_TAG_PREFIX:-local/ha-sbam}
 
 PROJECTDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/sbam
 ROOTDIR=${PROJECTDIR}/../../../
-
 cd "${ROOTDIR}"
-make build
-cd -
 
-rm -rf "${PROJECTDIR}/bin"
-mkdir -p "${PROJECTDIR}/bin"
-cp "${ROOTDIR}/bin/sbam" "${PROJECTDIR}/bin/"
+NATIVE_ARCH=$(uname -m)
+case "$NATIVE_ARCH" in
+  x86_64)  NATIVE=amd64  ;;
+  aarch64) NATIVE=arm64  ;;
+  *)       NATIVE=amd64  ;;  # fallback
+esac
 
-echo "project directory : ${PROJECTDIR}"
-echo "HA_arc            : ${HA_ARC}"
-echo "OS arc            : ${ARC}"
-echo "base image        : ${BUILD_FROM}"
-echo "output image      : ${IMAGE_TAG}"
+for ARC in ${ARCHS}; do
+  case "$ARC" in
+    amd64)  HA_ARC=amd64   ;;
+    arm64)  HA_ARC=aarch64 ;;
+    *)      echo "Unknown architecture: ${ARC} (expected amd64 or arm64)" >&2; exit 1 ;;
+  esac
 
-docker buildx build \
-  --load \
-  --build-arg "BUILD_FROM=${BUILD_FROM}" --build-arg "PLATFORM=${ARC}" \
-  -t "${IMAGE_TAG}" \
-  "${PROJECTDIR}"
+  BUILD_FROM="ghcr.io/home-assistant/${HA_ARC}-base:latest"
+  IMAGE_TAG="${IMAGE_TAG_PREFIX}-${HA_ARC}:test"
+
+  echo "=== Building Go binary for ${ARC} (HA: ${HA_ARC}) ==="
+  rm -rf "${PROJECTDIR}/bin"
+  mkdir -p "${PROJECTDIR}/bin"
+  make "build-${ARC}"
+  cp "${ROOTDIR}/bin/sbam" "${PROJECTDIR}/bin/"
+
+  echo "=== Building Docker image for ${ARC} ==="
+  if [ "${ARC}" = "${NATIVE}" ]; then
+    docker buildx build \
+      --load \
+      --build-arg "BUILD_FROM=${BUILD_FROM}" \
+      -t "${IMAGE_TAG}" \
+      "${PROJECTDIR}"
+  else
+    echo "Skipping Docker build for non-native arch ${ARC}"
+  fi
+done
+
+echo "=== Done ==="


### PR DESCRIPTION
## Summary

- New `dev-image.yml` workflow: builds HA Docker image on push to `release/*` or commits with `[build-ha]` prefix, pushes to ghcr.io with branch-name tags
- Extracted shared Go build + HA image build steps into composite action `.github/actions/build-ha-addon/`
- Added `build.yaml` per HA add-on convention; simplified `Dockerfile` (dropped `PLATFORM` arg, no longer needed)
- Renamed pre-release tag in `release.yml` from `dev` to `pre-release`
- New `/create-pr` slash command to commit, push, and open PRs
- Added `build-amd64` / `build-arm64` Makefile targets; rewrote `test_local.sh` for multi-arch validation

## Test plan

- [x] `make tidy`, `make vet`, `make test`, `make build` all pass
- [x] `make build-amd64` and `make build-arm64` cross-compile correctly
- [x] `bash home-assistant/addons/test_local.sh` builds both archs, Docker image for native
- [x] YAML syntax valid for all workflow/action files
- [ ] Verify `dev-image.yml` workflow triggers on this branch after merge