### PR TITLE
feat(ci): add dev HA image workflow, composite action, and /create-pr

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -49,8 +49,8 @@ jobs:
           goarch: ${{ matrix.goarch }}
           haarch: ${{ matrix.haarch }}
           image-tags: |
-            ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
-            ${{ steps.branch.outputs.name }}-latest
-          version: ${{ steps.branch.outputs.name }}-${{ steps.branch.outputs.short-sha }}
+            ${{ steps.branch.outputs.name }}-dev-${{ steps.branch.outputs.short-sha }}
+            ${{ steps.branch.outputs.name }}-dev-latest
+          version: ${{ steps.branch.outputs.name }}-dev-${{ steps.branch.outputs.short-sha }}
           use-goreleaser: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

adding dev infix to dev docker images tag

## Test plan

- [x] `make tidy`, `make vet`, `make test`, `make build` all pass
- [x] `make build-amd64` and `make build-arm64` cross-compile correctly
- [x] `dev-image.yml` workflow tested on this branch — builds and pushes both archs successfully
- [x] YAML syntax valid for all workflow/action files