### PR TITLE
fix(cmd,utils): include effective/derived parameters in startup debug dump

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -29,7 +29,7 @@ var cfgCmd = &cobra.Command{
 		force_charge = viper.GetBool("force_charge")
 		power = viper.GetInt("power")
 
-		u.LogStartupParams(cmd)
+		u.LogStartupParams(cmd, nil)
 
 		err := checkConfigure(fronius_ip)
 		if err != nil {

--- a/pkg/cmd/estimate.go
+++ b/pkg/cmd/estimate.go
@@ -35,7 +35,7 @@ var estCmd = &cobra.Command{
 		e_cache_time = viper.GetInt32("cache_time")
 		e_forecast_horizon = viper.GetString("forecast_horizon")
 
-		u.LogStartupParams(cmd)
+		u.LogStartupParams(cmd, nil)
 
 		err := CheckEstimate(e_apiKey, e_url, fronius_ip)
 		if err != nil {

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -182,7 +182,16 @@ var scdCmd = &cobra.Command{
 			u.HandleError(err, "mqtt client setup failed")
 		}
 
-		u.LogStartupParams(cmd)
+		extras := map[string]interface{}{
+			"effective_start_hr":              w_start_hr,
+			"effective_end_hr":                w_end_hr,
+			"effective_batt_reserve_start_hr": batt_reserve_start_hr,
+			"effective_batt_reserve_end_hr":   batt_reserve_end_hr,
+		}
+		if len(windows) > 0 {
+			extras["window_count"] = len(windows)
+		}
+		u.LogStartupParams(cmd, extras)
 
 		err = checkScheduleschedule(crontab, s_apiKey, s_url, fronius_ip, pw_consumption, max_charge, pw_batt_reserve, w_start_hr, w_end_hr, windows)
 		if err != nil {

--- a/src/utils/startup.go
+++ b/src/utils/startup.go
@@ -59,8 +59,9 @@ func SourceOf(cmd *cobra.Command, key string) string {
 
 // DumpStartupParams returns a deterministic, multi-line block listing every
 // viper key together with its effective value and resolution source. Secret
-// keys are redacted. The function never panics on nil/empty inputs.
-func DumpStartupParams(cmd *cobra.Command) string {
+// keys are redacted. Any entries in extras are appended after the viper keys
+// with source=computed. The function never panics on nil/empty inputs.
+func DumpStartupParams(cmd *cobra.Command, extras map[string]interface{}) string {
 	var b strings.Builder
 
 	header := "effective startup parameters"
@@ -70,33 +71,51 @@ func DumpStartupParams(cmd *cobra.Command) string {
 	b.WriteString(header)
 
 	keys := viper.AllKeys()
-	if len(keys) == 0 {
-		return b.String()
-	}
-	sort.Strings(keys)
-
+	// Determine max key length across viper keys and extras for alignment.
 	maxKeyLen := 0
 	for _, k := range keys {
 		if len(k) > maxKeyLen {
 			maxKeyLen = len(k)
 		}
 	}
-
-	for _, k := range keys {
-		var rendered string
-		if _, secret := SecretKeys[k]; secret {
-			rendered = redacted
-		} else {
-			rendered = fmt.Sprintf("%#v", viper.Get(k))
+	for k := range extras {
+		if len(k) > maxKeyLen {
+			maxKeyLen = len(k)
 		}
-		b.WriteString(fmt.Sprintf("\n  %-*s = %-24s source=%s",
-			maxKeyLen, k, rendered, SourceOf(cmd, k)))
 	}
+
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		for _, k := range keys {
+			var rendered string
+			if _, secret := SecretKeys[k]; secret {
+				rendered = redacted
+			} else {
+				rendered = fmt.Sprintf("%#v", viper.Get(k))
+			}
+			b.WriteString(fmt.Sprintf("\n  %-*s = %-24s source=%s",
+				maxKeyLen, k, rendered, SourceOf(cmd, k)))
+		}
+	}
+
+	if len(extras) > 0 {
+		extraKeys := make([]string, 0, len(extras))
+		for k := range extras {
+			extraKeys = append(extraKeys, k)
+		}
+		sort.Strings(extraKeys)
+		for _, k := range extraKeys {
+			b.WriteString(fmt.Sprintf("\n  %-*s = %-24s source=computed",
+				maxKeyLen, k, fmt.Sprintf("%#v", extras[k])))
+		}
+	}
+
 	return b.String()
 }
 
 // LogStartupParams emits DumpStartupParams via Log.Debug. Safe to call from
 // any subcommand's Run; produces no output when zap level is above Debug.
-func LogStartupParams(cmd *cobra.Command) {
-	Log.Debug("\n" + DumpStartupParams(cmd))
+// extras are appended after the viper keys with source=computed.
+func LogStartupParams(cmd *cobra.Command, extras map[string]interface{}) {
+	Log.Debug("\n" + DumpStartupParams(cmd, extras))
 }

--- a/src/utils/startup_test.go
+++ b/src/utils/startup_test.go
@@ -62,7 +62,7 @@ func TestDumpStartupParams_Expected(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set("apikey", "super-secret-value"))
 	require.NoError(t, bindFlags(cmd))
 
-	out := DumpStartupParams(cmd)
+	out := DumpStartupParams(cmd, nil)
 
 	assert.Contains(t, out, "effective startup parameters (subcommand: schedule)")
 	assert.Contains(t, out, "apikey")
@@ -82,7 +82,7 @@ func TestDumpStartupParams_NumericAndBoolDefaults(t *testing.T) {
 	cmd.Flags().Bool("force_charge", false, "FORCE_CHARGE")
 	require.NoError(t, bindFlags(cmd))
 
-	out := DumpStartupParams(cmd)
+	out := DumpStartupParams(cmd, nil)
 
 	assert.Contains(t, out, "effective startup parameters (subcommand: configure)")
 	assert.Regexp(t, `power\s+=\s+0\s+source=default`, out)
@@ -93,7 +93,7 @@ func TestDumpStartupParams_NoFlagsNoConfig(t *testing.T) {
 	resetViper(t)
 
 	assert.NotPanics(t, func() {
-		out := DumpStartupParams(nil)
+		out := DumpStartupParams(nil, nil)
 		assert.Equal(t, "effective startup parameters", out)
 	})
 }
@@ -105,7 +105,7 @@ func TestDumpStartupParams_AutoDiscoversNewFlag(t *testing.T) {
 	cmd.Flags().String("brand_new_flag", "", "a flag the helper has never seen")
 	require.NoError(t, bindFlags(cmd))
 
-	out := DumpStartupParams(cmd)
+	out := DumpStartupParams(cmd, nil)
 
 	assert.Contains(t, out, "brand_new_flag",
 		"any newly registered flag must appear without editing the helper")
@@ -124,7 +124,7 @@ func TestDumpStartupParams_RedactsRegisteredSecret(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set(secretKey, "should-not-leak"))
 	require.NoError(t, bindFlags(cmd))
 
-	out := DumpStartupParams(cmd)
+	out := DumpStartupParams(cmd, nil)
 
 	assert.NotContains(t, out, "should-not-leak")
 	assert.True(t, strings.Contains(out, "***"),
@@ -141,7 +141,7 @@ func TestDumpStartupParams_RedactsMQTTSecrets(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set("mqtt_tls_client_cert_key", "top-secret-key"))
 	require.NoError(t, bindFlags(cmd))
 
-	out := DumpStartupParams(cmd)
+	out := DumpStartupParams(cmd, nil)
 
 	assert.NotContains(t, out, "top-secret-password")
 	assert.NotContains(t, out, "top-secret-key")
@@ -179,5 +179,62 @@ func TestLogStartupParams_DoesNotPanic(t *testing.T) {
 	cmd.Flags().String("foo", "bar", "foo")
 	require.NoError(t, bindFlags(cmd))
 
-	assert.NotPanics(t, func() { LogStartupParams(cmd) })
+	assert.NotPanics(t, func() { LogStartupParams(cmd, nil) })
+}
+
+func TestDumpStartupParams_Extras(t *testing.T) {
+	resetViper(t)
+
+	cmd := &cobra.Command{Use: "schedule", Run: func(*cobra.Command, []string) {}}
+	cmd.Flags().String("start_hr", "00:00", "START_HR")
+	require.NoError(t, bindFlags(cmd))
+
+	extras := map[string]interface{}{
+		"effective_start_hr": "02:00",
+		"window_count":       3,
+	}
+
+	out := DumpStartupParams(cmd, extras)
+
+	assert.Contains(t, out, "effective startup parameters (subcommand: schedule)")
+	assert.Regexp(t, `effective_start_hr\s+=\s+"02:00"\s+source=computed`, out)
+	assert.Regexp(t, `window_count\s+=\s+3\s+source=computed`, out)
+	// viper key still appears with its own source.
+	assert.Regexp(t, `start_hr\s+=\s+"00:00"\s+source=default`, out)
+}
+
+func TestDumpStartupParams_EmptyKeysWithExtras(t *testing.T) {
+	// viper.Reset clears all keys; even without any viper keys,
+	// extras should still render.
+	viper.Reset()
+	viper.AutomaticEnv()
+	t.Cleanup(viper.Reset)
+
+	extras := map[string]interface{}{
+		"computed_value": "hello",
+	}
+
+	out := DumpStartupParams(nil, extras)
+
+	assert.Contains(t, out, "effective startup parameters")
+	assert.Regexp(t, `computed_value\s+=\s+"hello"\s+source=computed`, out)
+	// No viper keys should appear (there are none).
+	assert.NotContains(t, out, "source=flag")
+	assert.NotContains(t, out, "source=default")
+	assert.NotContains(t, out, "source=env")
+	assert.NotContains(t, out, "source=yaml")
+}
+
+func TestLogStartupParams_WithExtras(t *testing.T) {
+	resetViper(t)
+
+	cmd := &cobra.Command{Use: "probe", Run: func(*cobra.Command, []string) {}}
+	cmd.Flags().String("foo", "bar", "foo")
+	require.NoError(t, bindFlags(cmd))
+
+	extras := map[string]interface{}{
+		"derived": 42,
+	}
+
+	assert.NotPanics(t, func() { LogStartupParams(cmd, extras) })
 }


### PR DESCRIPTION
## Summary
- `DumpStartupParams` now accepts an `extras` map so callers can inject computed key-value pairs that render with `source=computed`.
- The `schedule` command surfaces effective window boundaries (`effective_start_hr`, `effective_end_hr`, `effective_batt_reserve_start_hr`, `effective_batt_reserve_end_hr`) and `window_count` (when windows are configured).
- `configure` and `estimate` commands pass `nil` (no derived params needed).

## Test plan
- [x] `make test` — all 7 packages pass, including 3 new tests for extras rendering and edge cases
- [x] `make build` — compiles cleanly
- [ ] Manual: run `./bin/sbam schedule --debug ...` with windows configured and verify the dump shows effective_* keys with `source=computed`