### PR TITLE
feat(cmd,power,mqtt): add scheduler_mode selector (crontab | windows | auto) with crontab deprecation (#147)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ config.yaml
 # Compound Engineering local config
 .compound-engineering/*.local.yaml
 
+# Claude Code worktrees (subagent isolation)
+.claude/worktrees/
+
 #ide
 .vscode

--- a/docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md
+++ b/docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md
@@ -1,0 +1,115 @@
+---
+date: 2026-06-11
+topic: scheduler-mode-selector
+---
+
+## Summary
+
+Add a `scheduler_mode` config key (crontab | windows | auto) that explicitly selects how the schedule runner is driven, with a deprecation path for the legacy crontab. Windows mode replaces cron with an internal Go ticker (default 60 min, per-window overridable) and per-window set_defaults scheduling. The `auto` value is defined internally but hidden from HA schema and CLI help — manually setting it produces a rejection pointing to #149.
+
+## Problem Frame
+
+The schedule runner currently decides between legacy single-window behavior and multi-window behavior by checking whether `windows:` is populated — an implicit, easy-to-misconfigure heuristic. As sbam moves from v2.1's cron-only model toward v3.0's smart scheduler (multi-window, then auto), users need an explicit switch to opt into new behavior incrementally, without surprise engine changes and without two schedulers running simultaneously. The crontab path also needs a visible deprecation signal so users know it will be removed.
+
+## Requirements
+
+**Configuration and CLI:**
+- R1. `scheduler_mode` accepts values `crontab`, `windows`, and `auto`. The default is `crontab`.
+- R2. CLI flag `--scheduler-mode` and env var `SCHEDULER_MODE` follow the existing precedence (flag > env > config.yaml). The `auto` value is accepted at all three layers but omitted from CLI help text.
+- R3. The HA add-on `config.json` schema exposes `scheduler_mode` as a list enum containing `crontab` and `windows` only. `auto` is excluded from the schema options.
+
+**Crontab mode:**
+- R4. When mode is `crontab`, the runner is driven by cron (existing `crontabSchedule`). `windows:` may be populated — cron drives the ticks, and each tick resolves the active window for its charge parameters via the existing `resolveActiveWindow` dispatch. When `windows:` is empty, the legacy `start_hr`/`end_hr` path is used. Both paths are valid.
+- R5. Crontab mode logs a one-shot WARN at startup naming it as deprecated and publishes that warning as a field on the MQTT state payload.
+
+**Windows mode:**
+- R6. When mode is `windows`, the runner starts an internal `time.Ticker` and does not call `crontabSchedule`. If `crontab` is set to a non-default value, a one-shot WARN is logged naming the ignored field.
+- R7. The default tick interval is 60 minutes. Each window may override this via an optional `tick_minutes` field (integer, minimum 1). When the active window changes, the ticker resets to the new window's interval.
+- R8. Each window may specify `defaults: true` (default `false`) to enable a set_defaults reset. When enabled, the reset fires `before_end_defaults` minutes before the window's end time. `before_end_defaults` defaults to 5 minutes (integer, minimum 1).
+- R9. When mode is `windows`, `windows:` must contain at least one entry or startup validation fails.
+
+**Auto mode:**
+- R10. When mode is `auto`, startup validation rejects with an error message that references GitHub issue #149 as the tracking issue.
+
+**MQTT:**
+- R11. `StatePayload` includes a `scheduler_mode` string field populated with the active mode value.
+- R12. When crontab mode is active and the deprecation warning fires, `StatePayload` includes a `deprecation_warning` string field with the deprecation message.
+
+**Backward compatibility:**
+- R13. Configs without `scheduler_mode` default to `crontab` — no behavior change on upgrade. If `windows:` is also populated, cron drives the ticks and windows parameterize the charge decision (same as R4).
+
+## Key Decisions
+
+- **Crontab mode is compatible with `windows:`.** The branch already supports this: cron drives the ticks, `resolveActiveWindow` dispatches to the windows list for charge parameters. Forbidding this combination would add unnecessary validation and break a working configuration. The only forbidden combination is `mode: windows` with an empty `windows:` list.
+- **Flat key `scheduler_mode`.** Matches the existing config.yaml convention (`start_hr`, `max_charge`, `mqtt_enabled`). CLI flag is `--scheduler-mode`, env var is `SCHEDULER_MODE`.
+- **Per-window tick interval, default 60 min.** A single global tick would over-tick short windows or under-tick long ones. Per-window override gives each window the cadence it needs.
+- **Per-window set_defaults, not a global schedule.** Cron mode uses a single `end_hr - 5 min` reset. Windows mode has multiple end times; attaching the reset to each window keeps the behavior scoped and predictable.
+- **`auto` value defined but hidden.** The value exists so early adopters can manually set it and get a useful rejection message, but it is excluded from HA schema and CLI help to avoid presenting a non-functional option.
+- **Deprecation warning on MQTT, not just logs.** HA users monitor dashboards, not container logs. A persistent state field ensures the deprecation is visible until addressed.
+
+## Key Flows
+
+- F1. Startup mode resolution
+  - **Trigger:** Runner initialization in `schedule` command.
+  - **Steps:** Read `scheduler_mode` via Viper (flag > env > config). If unset, default to `crontab`. If `crontab` → call `crontabSchedule` (cron + windows is valid; cron drives ticks, windows parameterize them). If `windows` and `windows:` is empty → fail with validation error. If `windows` and `windows:` populated → start internal ticker; if crontab value is non-default, log one-shot WARN. If `auto` → fail with #149 pointer.
+  - **Covered by:** R4, R6, R9, R10, R13
+
+- F2. Windows mode ticker lifecycle
+  - **Trigger:** Runner enters `Run` loop in windows mode.
+  - **Steps:** Compute default tick interval (60 min). Resolve active window. If active window has `tick_minutes`, use that instead. Start `time.Ticker` at the resolved interval. On each tick, submit `IntentTick`. When `resolveActiveWindow` returns a different window (or nil), reset the ticker to the new window's interval (or the default). Ticker stops on shutdown intent or context cancellation.
+  - **Covered by:** R6, R7
+
+- F3. Windows mode set_defaults scheduling
+  - **Trigger:** A window with `defaults: true` becomes active, or a tick fires within a window that has `defaults` enabled.
+  - **Steps:** Compute the reset time as `window.end - before_end_defaults`. When the current tick time is at or past the reset time and no prior reset has fired for this window instance, submit `IntentSetDefaults`. Mark the reset as fired so it does not re-trigger on subsequent ticks within the same window. Reset the fired flag on the next window transition.
+  - **Covered by:** R8
+
+## Acceptance Examples
+
+- AE1. No `scheduler_mode` set, no `windows:` — runner starts in crontab mode, cron installed, `crontabSchedule` called. Deprecation WARN logged once. MQTT state shows `scheduler_mode: crontab`.
+  - **Covers R1, R5, R11, R13**
+
+- AE2. `scheduler_mode: crontab` with `windows:` containing two valid windows — runner installs cron, `crontabSchedule` called. Each cron tick calls `resolveActiveWindow` which dispatches to the windows list and returns the active window's charge parameters. MQTT state shows `scheduler_mode: crontab`.
+  - **Covers R4**
+
+- AE3. `scheduler_mode: windows` with `windows:` containing two valid windows — runner starts internal ticker, cron is not installed, `crontab` is ignored. If crontab was set to a non-default value, a one-shot WARN names the ignored field.
+  - **Covers R6, R9**
+
+- AE4. Window with `tick_minutes: 30` is active — ticker fires every 30 minutes while that window remains the active window. When the active window changes to one without `tick_minutes`, ticker resets to 60 minutes.
+  - **Covers R7**
+
+- AE5. Window with `defaults: true` and `before_end_defaults: 5`, ending at 06:00 — at 05:55 a set_defaults reset fires. On the next tick (still within the window), no duplicate reset fires. On the next window's activation, the fired flag is cleared.
+  - **Covers R8**
+
+- AE6. `scheduler_mode: auto` — startup fails with error: "scheduler_mode 'auto' is not yet available; track progress at https://github.com/atbore-phx/sbam/issues/149".
+  - **Covers R10**
+
+- AE7. Config with `windows:` populated, no `scheduler_mode` set — defaults to crontab mode. Cron drives ticks, windows provide charge parameters. Same observable behavior as AE2.
+  - **Covers R13**
+
+- AE8. `scheduler_mode: windows` with empty `windows:` — startup fails with error: "scheduler_mode is windows but no windows are configured".
+  - **Covers R9**
+
+## Scope Boundaries
+
+- `auto` mode logic is out of scope — owned by issue #149.
+- Crontab removal is out of scope — deferred to v3.0.0 cleanup.
+- The `tick_minutes`, `defaults`, and `before_end_defaults` fields are Window struct additions (net-new schema) — the multi-window schema was defined in #146; this issue extends it.
+
+## Sources
+
+- GitHub issue [#147](https://github.com/atbore-phx/sbam/issues/147) — feature specification.
+- `pkg/cmd/schedule.go:244-254` — crontabSchedule call gated on crontab != const_ct.
+- `pkg/cmd/schedule.go:414-475` — checkScheduleschedule validation.
+- `pkg/cmd/schedule_runner.go:85-99` — NewRunner and Runner struct (intents channel, cfg).
+- `pkg/cmd/schedule_runner.go:116-135` — Run loop: single-channel select on ctx.Done and intents.
+- `pkg/cmd/schedule_runner.go:164-299` — Tick: window resolution, cooldown, storage, forecast, Fronius handler.
+- `pkg/cmd/schedule_runner.go:540-576` — resolveActiveWindow: windows vs legacy dispatch.
+- `pkg/cmd/schedule_runner.go:602-625` — isInCooldown: end_hr proximity check.
+- `pkg/cmd/schedule.go:571-619` — crontabSchedule: cron installation for tick + set_defaults.
+- `pkg/power/window.go:34-41` — Window struct definition.
+- `pkg/power/window.go:46-107` — ValidateWindows.
+- `pkg/mqtt/types.go:23-41` — StatePayload.
+- `pkg/mqtt/types.go:7-21` — Config struct.
+- `home-assistant/addons/sbam/config.json` — HA add-on schema.
+- `STRATEGY.md` — v2.1.0 milestone, v3.0.0 crontab removal target.

--- a/docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md
+++ b/docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md
@@ -25,7 +25,7 @@ The schedule runner currently decides between legacy single-window behavior and 
 **Windows mode:**
 - R6. When mode is `windows`, the runner starts an internal `time.Ticker` and does not call `crontabSchedule`. If `crontab` is set to a non-default value, a one-shot WARN is logged naming the ignored field.
 - R7. The default tick interval is 60 minutes. Each window may override this via an optional `tick_minutes` field (integer, minimum 1). When the active window changes, the ticker resets to the new window's interval.
-- R8. Each window may specify `defaults: true` (default `false`) to enable a set_defaults reset. When enabled, the reset fires `before_end_defaults` minutes before the window's end time. `before_end_defaults` defaults to 5 minutes (integer, minimum 1).
+- R8. Each window may specify `defaults: true` (default `false`) to enable a set_defaults reset. When enabled, the reset fires `before_end_defaults` minutes before the window's end time. `before_end_defaults` defaults to 5 minutes (integer, minimum 0). A value of 0 fires set_defaults at the exact window end.
 - R9. When mode is `windows`, `windows:` must contain at least one entry or startup validation fails.
 
 **Auto mode:**

--- a/docs/brainstorms/2026-06-13-window-transition-timing-requirements.md
+++ b/docs/brainstorms/2026-06-13-window-transition-timing-requirements.md
@@ -1,0 +1,67 @@
+---
+date: 2026-06-13
+topic: window-transition-timing
+---
+
+## Summary
+
+The windows-mode ticker fires a tick immediately on initial startup and detects window transitions at their exact start time via a one-shot boundary timer. Adjacent windows with equal start/end boundaries are rejected at validation. The existing `set_defaults` timer and cooldown logic remain unchanged.
+
+## Problem Frame
+
+When `scheduler_mode: windows` is active, two timing gaps exist. First, sbam started mid-window (e.g., 06:20) waits a full `tick_minutes` interval before the first tick — the system is idle when it could evaluate charging state. Second, window transitions are only detected at the next periodic tick, so a window starting at 22:00 may not take effect until 22:20 or later, delaying time-sensitive charging decisions. A third concern is config ambiguity: when one window's end equals another's start, inclusive bounds make both windows active at the boundary minute, and the first-listed window wins — which is rarely the intent.
+
+## Requirements
+
+### Tick timing
+
+- R1. When `StartWindowsTicker` is called from the initial `schedule` command path, the runner fires a tick immediately before starting the periodic ticker.
+- R2. When the windows ticker is restarted from within `Tick()` (window change detection), no additional immediate tick is fired — the already-executing tick runs with the new window's parameters.
+- R3. When starting or restarting the windows ticker, the runner schedules a one-shot boundary timer set to the start time of the next window in the ordered list. The boundary timer fires an `IntentTick`. For the last window in the list, the next boundary wraps to the first window's next start.
+- R4. The boundary timer is cancelled in `stopWindowsTicker` alongside the existing periodic ticker and defaults timer teardown.
+- R5. The boundary timer fires at a wall-clock time strictly after the current `now` — if the computed boundary is in the past (e.g., sbam started exactly at 06:00), the timer targets the next occurrence (next day).
+
+### Window validation
+
+- R6. `ValidateWindows` rejects any configuration where one window's end time equals another window's start time. The error message names both windows and the conflicting boundary value.
+
+### Existing behavior preserved
+
+- R7. The `set_defaults` timer (`scheduleDefaults`) and the cooldown check (`isInCooldown`) are not modified. They continue to behave as they do today.
+
+## Key Decisions
+
+- **Boundary timer separate from periodic ticker.** Keeps "regular cadence" and "precise transitions" as independent concerns. Each window's ticker setup manages one periodic ticker, one boundary timer, and optionally one set_defaults timer.
+- **Inclusive bounds with validation over half-open intervals.** Preserves existing user config semantics. The equal-boundary ambiguity is caught at config load time rather than through a breaking interval-semantics change.
+- **Immediate tick only on initial start, not on window-change restart.** The boundary-triggered tick already provides the first evaluation in the new window. An additional immediate tick on restart would double-fire.
+
+## Acceptance Examples
+
+- AE1. **Mid-window start, full day.** Covers R1, R3, R5.
+  - Given sbam starts at 06:20 with day `06:00–21:59` (tick 30) and night `22:00–05:59` (tick 60)
+  - Then a tick fires immediately at 06:20, the periodic ticker runs every 30 min (06:20, 06:50, ...), and a boundary timer is scheduled for 22:00.
+
+- AE2. **Boundary transition, day to night.** Covers R3, R4.
+  - Given sbam is running in the day window with a boundary timer at 22:00
+  - When the boundary timer fires at 22:00
+  - Then an `IntentTick` is submitted, `Tick()` detects the night window, restarts the ticker at 60 min, cancels the previous boundary timer, and sets a new boundary timer for 06:00.
+
+- AE3. **set_defaults fires before boundary transition.** Covers R7.
+  - Given sbam is running in the night window with `set_defaults: true` and `before_end_defaults_minutes: 5`
+  - Then at 05:54 the set_defaults timer fires an `IntentSetDefaults`
+  - And at 06:00 the boundary timer fires an `IntentTick` that switches to the day window
+  - No interaction between the two timers.
+
+- AE4. **Equal boundaries rejected.** Covers R6.
+  - Given a config with day end `22:00` and night start `22:00`
+  - When `ValidateWindows` runs
+  - Then it returns an error naming both windows and the conflicting `22:00` boundary.
+
+- AE5. **Start at exact boundary.** Covers R2, R5.
+  - Given sbam starts at 06:00 exactly
+  - Then a tick fires immediately (day window), and the boundary timer targets 22:00 (the next boundary after now), not 06:00 today.
+
+## Scope Boundaries
+
+- Aligning periodic ticks to the window start boundary (e.g., always 06:00, 06:30, 07:00 regardless of launch time) is out of scope. First-day cadence depends on when sbam launched; subsequent days inherit the window-start alignment from the boundary-triggered transition.
+- The `crontab` scheduler mode is unaffected by these changes.

--- a/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
+++ b/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
@@ -50,7 +50,7 @@ The schedule runner currently decides between legacy single-window and multi-win
 
 - **Per-window tick interval, default 60 min.** A single global tick would over-tick short windows or under-tick long ones. Per-window override gives each window the cadence it needs. The value is optional on the Window struct and only used in windows mode.
 
-- **Set_defaults in windows mode uses `time.AfterFunc`, not the periodic ticker.** A 60-minute ticker cannot reliably hit the 5-minute-before-end boundary. When a window with `defaults: true` becomes active, the runner schedules a one-shot `time.AfterFunc` for `window.end - before_end_defaults`. The timer is canceled and re-scheduled when the active window changes. In crontab mode, set_defaults continues through the existing `crontabSchedule` cron entry with no change.
+- **Set_defaults in windows mode uses `time.AfterFunc`, with the cooldown keeping the reset in place.** A periodic ticker cannot reliably hit the exact `before_end_defaults` boundary. When a window with `defaults: true` becomes active, the runner schedules a one-shot `time.AfterFunc` for `window.end - before_end_defaults`. The existing `isInCooldown` check in Tick must be extended to use the active window's end time and `before_end_defaults` as the cooldown duration — so after set_defaults fires at end−N minutes, any subsequent tick within the same window is suppressed by the cooldown and cannot override the reset. The timer is canceled and re-scheduled when the active window changes. In crontab mode, set_defaults continues through the existing `crontabSchedule` cron entry with no change.
 
 - **Window fields `defaults` and `before_end_defaults` are windows-mode only.** In crontab mode these fields are ignored — the existing `crontabSchedule` end_hr-based set_defaults cron handles the reset. This keeps crontab-mode behavior identical to v2.1.
 
@@ -156,6 +156,7 @@ The schedule runner currently decides between legacy single-window and multi-win
   - On each Tick, re-resolve the active window. If the window changed (name differs), stop the current ticker + timer and call `startWindowsTicker` with the new window's parameters.
   - The set_defaults `AfterFunc` fires exactly once per window activation. A `defaultsFired` flag on Runner prevents re-firing on subsequent ticks within the same window. The flag is cleared when the active window changes.
   - When no window is active (nil from `resolveActiveWindow`), set the ticker to the default 60-minute interval and do not schedule a set_defaults timer.
+  - **Cooldown integration:** Extend `isInCooldown` to accept the active window's end time and a cooldown-duration parameter. In windows mode, the Tick method passes the active window's end time and `before_end_defaults` (or 5 when `defaults` is unset) as the cooldown duration. This ensures that after set_defaults fires at end−N minutes, any subsequent tick within the same window finds the cooldown active and returns early without making a new charge decision — the reset is not overridden. In crontab mode, `isInCooldown` continues to use the legacy `StartHR`/`EndHR` and the hardcoded 5-minute constant.
 - **Patterns to follow:** The `Runner` struct at `pkg/cmd/schedule_runner.go:77-83`. The `Run` loop select at line 124-134. The `resolveActiveWindow` call at line 171. Use `sync/atomic` for the `defaultsFired` flag (matching the existing `paused` atomic pointer pattern).
 - **Test scenarios:**
   - Windows mode starts ticker at 60 min default when no window has `tick_minutes`
@@ -167,6 +168,7 @@ The schedule runner currently decides between legacy single-window and multi-win
   - No active window → ticker runs at 60 min default, no set_defaults timer
   - Ticker stops on context cancellation (shutdown)
   - Cross-midnight window with `defaults: true` → set_defaults timer computed correctly across the midnight boundary
+  - Window 06:00-07:00, `tick_minutes: 1`, `defaults: true`, `before_end_defaults: 5` — at 06:55, set_defaults fires; at 06:56, tick finds cooldown active (end=07:00 minus 5 min = 06:55→07:00 window) and returns early without a new charge decision
 - **Verification:** `make test` passes. Ticker fires periodic ticks in windows mode. Set_defaults fires at the correct boundary. `go test -race ./pkg/cmd` passes.
 
 ### U6. MQTT discovery entity and HA add-on schema

--- a/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
+++ b/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
@@ -1,0 +1,239 @@
+---
+title: "feat: Add scheduler_mode selector with crontab deprecation path"
+type: feat
+date: 2026-06-11
+origin: docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md
+---
+
+## Summary
+
+Add a `scheduler_mode` config key (crontab | windows | auto) that explicitly selects how the schedule runner is driven. Crontab mode preserves v2.1 behavior with a deprecation warning on MQTT and logs. Windows mode replaces cron with an internal `time.Ticker` (default 60 min, per-window overridable) and per-window set_defaults scheduling via new Window fields. The `auto` value is defined internally but hidden — manually setting it produces a rejection pointing to #149.
+
+## Problem Frame
+
+The schedule runner currently decides between legacy single-window and multi-window behavior implicitly by checking whether `windows:` is populated. As sbam moves from v2.1's cron-only model toward v3.0's smart scheduler, users need an explicit switch to opt into new behavior incrementally and a visible deprecation signal for the crontab path scheduled for removal in v3.0.0.
+
+## Requirements
+
+**Configuration and CLI:**
+- R1. `scheduler_mode` accepts values `crontab`, `windows`, and `auto`. The default is `crontab`.
+- R2. CLI flag `--scheduler-mode` and env var `SCHEDULER_MODE` follow the existing precedence (flag > env > config.yaml). The `auto` value is accepted at all three layers but omitted from CLI help text.
+- R3. The HA add-on `config.json` schema exposes `scheduler_mode` as a list enum containing `crontab` and `windows` only. `auto` is excluded from the schema options.
+
+**Crontab mode:**
+- R4. When mode is `crontab`, the runner is driven by cron. `windows:` may be populated — cron drives the ticks, and each tick resolves the active window for its charge parameters via `resolveActiveWindow`. When `windows:` is empty, the legacy `start_hr`/`end_hr` path is used.
+- R5. Crontab mode logs a one-shot WARN at startup naming it as deprecated and publishes that warning as a field on the MQTT state payload.
+
+**Windows mode:**
+- R6. When mode is `windows`, the runner starts an internal `time.Ticker` and does not call `crontabSchedule`. If `crontab` is set to a non-default value, a one-shot WARN is logged naming the ignored field.
+- R7. The default tick interval is 60 minutes. Each window may override this via an optional `tick_minutes` field (integer, minimum 1). When the active window changes, the ticker resets to the new window's interval.
+- R8. Each window may specify `defaults: true` (default `false`) to enable a set_defaults reset. When enabled, the reset fires `before_end_defaults` minutes before the window's end time. `before_end_defaults` defaults to 5 minutes (integer, minimum 1). These fields apply only in windows mode.
+- R9. When mode is `windows`, `windows:` must contain at least one entry or startup validation fails.
+
+**Auto mode:**
+- R10. When mode is `auto`, startup validation rejects with an error message that references GitHub issue #149 as the tracking issue.
+
+**MQTT:**
+- R11. `StatePayload` includes a `scheduler_mode` string field populated with the active mode value.
+- R12. When crontab mode is active and the deprecation warning fires, `StatePayload` includes a `deprecation_warning` string field with the deprecation message.
+
+**Backward compatibility:**
+- R13. Configs without `scheduler_mode` default to `crontab` — no behavior change on upgrade. If `windows:` is also populated, cron drives the ticks and windows parameterize the charge decision (same as R4).
+
+---
+
+## Key Technical Decisions
+
+- **Flat key `scheduler_mode`.** Matches the existing config.yaml convention (`start_hr`, `max_charge`, `mqtt_enabled`). CLI flag is `--scheduler-mode`, env var is `SCHEDULER_MODE`.
+
+- **Crontab mode is compatible with `windows:`.** The branch already supports this: cron drives the ticks, `resolveActiveWindow` dispatches to the windows list for charge parameters. Forbidding this combination would add unnecessary validation and break a working configuration.
+
+- **Per-window tick interval, default 60 min.** A single global tick would over-tick short windows or under-tick long ones. Per-window override gives each window the cadence it needs. The value is optional on the Window struct and only used in windows mode.
+
+- **Set_defaults in windows mode uses `time.AfterFunc`, not the periodic ticker.** A 60-minute ticker cannot reliably hit the 5-minute-before-end boundary. When a window with `defaults: true` becomes active, the runner schedules a one-shot `time.AfterFunc` for `window.end - before_end_defaults`. The timer is canceled and re-scheduled when the active window changes. In crontab mode, set_defaults continues through the existing `crontabSchedule` cron entry with no change.
+
+- **Window fields `defaults` and `before_end_defaults` are windows-mode only.** In crontab mode these fields are ignored — the existing `crontabSchedule` end_hr-based set_defaults cron handles the reset. This keeps crontab-mode behavior identical to v2.1.
+
+- **`auto` value defined but hidden.** The value exists so early adopters can manually set it and get a useful rejection message, but it is excluded from HA schema and CLI help to avoid presenting a non-functional option.
+
+- **`tick_minutes`, `defaults`, and `before_end_defaults` are optional pointer fields on Window.** Using `*int` / `*bool` with `omitempty` tags so zero values don't serialize and existing configs are unaffected. Validation rejects negative or zero values.
+
+- **Deprecation warning on MQTT, not just logs.** HA users monitor dashboards, not container logs. The `StatePayload` gains a `deprecation_warning` string field, published once at startup when crontab mode is active.
+
+---
+
+## Implementation Units
+
+### U1. Extend Window struct with new fields
+
+- **Goal:** Add `tick_minutes`, `defaults`, and `before_end_defaults` fields to the Window struct with validation.
+- **Requirements:** R7, R8
+- **Dependencies:** None
+- **Files:**
+  - `pkg/power/window.go` — add fields to Window struct, update `validateWindowFields`
+- **Approach:** Add three pointer fields with `omitempty` tags to the Window struct: `TickMinutes *int`, `Defaults *bool`, `BeforeEndDefaults *int`. Update `validateWindowFields` to reject `TickMinutes <= 0` when set, reject `Defaults: true` when `TickMinutes` is set and conflicting (adjacent concern — defer to U5), and reject `BeforeEndDefaults <= 0` when `Defaults` is set. Use the existing field-validation pattern (early return on first error).
+- **Patterns to follow:** Existing optional fields `ForecastHorizon` and `ConsumptionHorizon` on Window struct (`pkg/power/window.go:34-41`). The `validateWindowFields` pattern at `pkg/power/window.go:111-132`.
+- **Test scenarios:**
+  - Window with no new fields set — passes validation (backward compatible)
+  - Window with `tick_minutes: 30` — passes validation
+  - Window with `tick_minutes: 0` — validation fails
+  - Window with `tick_minutes: -1` — validation fails
+  - Window with `defaults: true`, `before_end_defaults: 10` — passes validation
+  - Window with `defaults: true`, `before_end_defaults: 0` — validation fails
+  - Window with `before_end_defaults` set but `defaults` unset — passes validation (field ignored at runtime but structurally valid)
+  - Cross-midnight window with `defaults: true` — passes validation (timer scheduling tested in U5)
+- **Verification:** `make test` passes. `ValidateWindows` accepts windows with new fields and rejects invalid values.
+
+### U2. Add scheduler_mode config key and CLI flag
+
+- **Goal:** Add the `scheduler_mode` config key, `--scheduler-mode` CLI flag, env var binding, and startup validation.
+- **Requirements:** R1, R2, R10, R13
+- **Dependencies:** None
+- **Files:**
+  - `pkg/cmd/schedule.go` — add `scheduler_mode` variable, register flag, read in `scdCmd.Run`, add to `checkScheduleschedule`
+  - `pkg/cmd/schedule_validation_test.go` — mode validation tests
+  - `pkg/cmd/precedence_test.go` — flag/env/config precedence tests
+- **Approach:** Add `scheduler_mode` to the package var block with default `"crontab"`. Register `--scheduler-mode` string flag in `registerScdCmd` (no short form). Read in `scdCmd.Run` via `viper.GetString("scheduler_mode")`. In `checkScheduleschedule`, add validation: reject empty string, reject unknown values, reject `auto` with error referencing #149. The `windows` value requires `windows:` to be non-empty (R9 — validated here). Pass the validated mode into `RunnerConfig`.
+- **Patterns to follow:** Flag registration pattern at `pkg/cmd/schedule.go:269-303`. Validation in `checkScheduleschedule` at `pkg/cmd/schedule.go:414-476`. Viper binding via `bindFlags` at `pkg/cmd/root.go:79-90`.
+- **Test scenarios:**
+  - Default (no flag, no env, no config) → mode resolves to `crontab`
+  - CLI `--scheduler-mode windows` → overrides env and config
+  - Env `SCHEDULER_MODE=windows` → overrides config
+  - Config `scheduler_mode: windows` → used when flag and env absent
+  - `scheduler_mode: auto` → startup error referencing #149
+  - `scheduler_mode: invalid` → startup error about unknown value
+  - `scheduler_mode: ""` → defaults to crontab (or error, decide in impl)
+- **Verification:** `make test` passes. CLI help shows `--scheduler-mode` without `auto` in the help text. `make build` succeeds.
+
+### U3. Add scheduler_mode to Runner plumbing and MQTT state
+
+- **Goal:** Thread the mode value through RunnerConfig into the runner, and expose it on the MQTT StatePayload.
+- **Requirements:** R11, R12
+- **Dependencies:** U2 (needs the validated mode value)
+- **Files:**
+  - `pkg/cmd/schedule_runner.go` — add `SchedulerMode` field to `RunnerConfig`
+  - `pkg/mqtt/types.go` — add `SchedulerMode` and `DeprecationWarning` fields to `StatePayload`
+  - `pkg/cmd/schedule.go` — populate `SchedulerMode` from viper value, update `makeBasePayload` to include `scheduler_mode`
+- **Approach:** Add `SchedulerMode string` to `RunnerConfig`. In `scdCmd.Run`, set it from the validated `scheduler_mode`. In `makeBasePayload`, set `SchedulerMode` from the runner config. Add `DeprecationWarning *string` to `StatePayload` (set in U4 when crontab deprecation fires).
+- **Patterns to follow:** `RunnerConfig` fields at `pkg/cmd/schedule_runner.go:30-52`. `StatePayload` fields at `pkg/mqtt/types.go:23-41`. `makeBasePayload` at `pkg/cmd/schedule.go:524-535`.
+- **Test scenarios:**
+  - MQTT state payload includes `scheduler_mode: "crontab"` when mode is crontab
+  - MQTT state payload includes `scheduler_mode: "windows"` when mode is windows
+  - `deprecation_warning` field is absent (null/omitted) when no deprecation is active
+- **Verification:** Existing MQTT tests pass. New assertions in runner tests verify state payload carries the mode field.
+
+### U4. Wire mode dispatch with crontab deprecation
+
+- **Goal:** Branch the schedule command's Run function on `scheduler_mode`, add crontab deprecation warning.
+- **Requirements:** R4, R5, R6, R9, R10
+- **Dependencies:** U2 (config key exists), U3 (RunnerConfig carries mode)
+- **Files:**
+  - `pkg/cmd/schedule.go` — modify `scdCmd.Run` to branch on mode, add deprecation log + MQTT publish
+  - `pkg/cmd/schedule_runner.go` — publish deprecation warning on MQTT state
+  - `pkg/cmd/schedule_lifecycle_test.go` — mode dispatch tests
+- **Approach:** In `scdCmd.Run`, after validation: if mode is `crontab`, follow the existing path (call `crontabSchedule` when crontab is not `const_ct`), but first emit a one-shot WARN via `u.Log.Warn` and set `DeprecationWarning` on the MQTT state. If mode is `windows`, skip `crontabSchedule`, log a one-shot WARN if crontab is non-default, and call a new method on Runner to start the ticker (the actual ticker logic lives in U5). The `auto` case was already rejected in `checkScheduleschedule` (U2).
+- **Patterns to follow:** The `var` block and command flow at `pkg/cmd/schedule.go:92-259`. The deprecation pattern is net-new for this codebase; follow the one-shot log convention (`sync.Once` or a `deprecationLogged` bool on Runner).
+- **Test scenarios:**
+  - Crontab mode with crontab set → cron installed, deprecation WARN logged once, MQTT state shows `deprecation_warning`
+  - Crontab mode with crontab default (`const_ct`) → cron not installed, deprecation WARN still logged (mode is crontab)
+  - Windows mode with crontab non-default → WARN logged about ignored crontab, cron not installed
+  - Windows mode with crontab default → no crontab WARN, cron not installed
+  - Windows mode with empty windows list → validation error (tested in U2)
+  - Deprecation WARN fires exactly once across multiple ticks
+- **Verification:** `make test` passes. Runner starts in the correct mode. Deprecation WARN appears in structured log output and MQTT state.
+
+### U5. Implement windows-mode ticker and per-window set_defaults
+
+- **Goal:** Implement the internal `time.Ticker` in the runner's Run loop for windows mode, with per-window interval override and per-window set_defaults scheduling.
+- **Requirements:** R6, R7, R8
+- **Dependencies:** U1 (Window fields exist), U3 (RunnerConfig carries mode), U4 (dispatch calls the ticker start)
+- **Files:**
+  - `pkg/cmd/schedule_runner.go` — add `startTicker` method, modify `Run` to accept ticker channel, add set_defaults timer logic, add `resolveActiveWindow` change detection
+  - `pkg/cmd/schedule_runner_test.go` — ticker behavior, set_defaults timer, window transition tests
+- **Approach:**
+  - Add a `startWindowsTicker(ctx)` method on Runner that returns a `<-chan time.Time`. It computes the tick interval from the active window's `tick_minutes` (or 60 default), creates a `time.Ticker`, and returns its channel. If the active window has `defaults: true`, it also schedules a `time.AfterFunc` for `window.end - before_end_defaults` that submits `IntentSetDefaults`.
+  - Extend the Run loop with a third `case <-ticker.C:` that submits `IntentTick`.
+  - On each Tick, re-resolve the active window. If the window changed (name differs), stop the current ticker + timer and call `startWindowsTicker` with the new window's parameters.
+  - The set_defaults `AfterFunc` fires exactly once per window activation. A `defaultsFired` flag on Runner prevents re-firing on subsequent ticks within the same window. The flag is cleared when the active window changes.
+  - When no window is active (nil from `resolveActiveWindow`), set the ticker to the default 60-minute interval and do not schedule a set_defaults timer.
+- **Patterns to follow:** The `Runner` struct at `pkg/cmd/schedule_runner.go:77-83`. The `Run` loop select at line 124-134. The `resolveActiveWindow` call at line 171. Use `sync/atomic` for the `defaultsFired` flag (matching the existing `paused` atomic pointer pattern).
+- **Test scenarios:**
+  - Windows mode starts ticker at 60 min default when no window has `tick_minutes`
+  - Active window with `tick_minutes: 30` → tick interval is 30 min
+  - Window transition from one with `tick_minutes: 30` to one with `tick_minutes: 15` → ticker resets to 15 min
+  - Window with `defaults: true`, `before_end_defaults: 5` ending at 06:00 → at simulated 05:55, set_defaults fires
+  - Set_defaults fires exactly once per window activation — second tick within same window does not re-fire
+  - Window transition clears the `defaultsFired` flag — new window's set_defaults can fire
+  - No active window → ticker runs at 60 min default, no set_defaults timer
+  - Ticker stops on context cancellation (shutdown)
+  - Cross-midnight window with `defaults: true` → set_defaults timer computed correctly across the midnight boundary
+- **Verification:** `make test` passes. Ticker fires periodic ticks in windows mode. Set_defaults fires at the correct boundary. `go test -race ./pkg/cmd` passes.
+
+### U6. MQTT discovery entity and HA add-on schema
+
+- **Goal:** Add a `scheduler_mode` sensor to MQTT discovery, update the HA add-on schema, and extend the windows sub-schema with new fields.
+- **Requirements:** R3, R11
+- **Dependencies:** U3 (StatePayload has the field)
+- **Files:**
+  - `pkg/mqtt/discovery.go` — add `scheduler_mode` sensor entity
+  - `home-assistant/addons/sbam/config.json` — add `scheduler_mode` to options and schema, add `tick_minutes`, `set_defaults`, `before_end_defaults_minutes` to windows sub-schema
+  - `pkg/cmd/config_schema_test.go` — schema validation tests
+- **Approach:**
+  - In `BuildDiscovery`, add a diagnostic sensor entity for `scheduler_mode` using the existing `sensorPayload` helper. The value template is `{{ value_json.scheduler_mode }}`. Bump the `make` capacity from 20 to 21.
+  - In `config.json` options, add `"scheduler_mode": "crontab"`. In schema, add `"scheduler_mode": "list(crontab|windows)"` (auto hidden per R3).
+  - In the windows sub-schema, add optional fields: `"tick_minutes": "int?"`, `"set_defaults": "bool?"`, `"before_end_defaults_minutes": "int?"`. Note: the yaml/mapstructure field name `defaults` conflicts with a common keyword in JSON schema contexts — use `set_defaults` as the JSON/YAML key while keeping the struct field unambiguous. This naming choice should be documented in the requirements trace. Actually, looking back at the requirements doc, it uses `defaults` — but for the HA schema JSON key, `set_defaults` is clearer and won't confuse the HA config UI. The mapstructure tag maps the YAML key; the struct field name is internal. Use `set_defaults` as the external config key.
+  - Add schema validation tests that read the actual `config.json` and verify the `scheduler_mode` list values.
+- **Patterns to follow:** Discovery entity construction at `pkg/mqtt/discovery.go:84-94`. HA schema list enums at `home-assistant/addons/sbam/config.json:73-74` (`forecast_horizon`, `consumption_horizon`). Schema test pattern at `pkg/cmd/config_schema_test.go`.
+- **Test scenarios:**
+  - `BuildDiscovery` returns a `scheduler_mode` sensor with correct unique ID and value template
+  - HA config.json `scheduler_mode` schema accepts `crontab` and `windows`, rejects `auto` and arbitrary strings
+  - Window sub-schema accepts `tick_minutes: 30`, `set_defaults: true`, `before_end_defaults_minutes: 5`
+  - Window sub-schema rejects `tick_minutes: 0`, `tick_minutes: "abc"`
+  - All new window fields are optional — a window with no new fields is valid
+- **Verification:** `make test` passes. HA add-on config validation accepts the new schema. Discovery payload is valid JSON with the `scheduler_mode` entity.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- `auto` mode logic — owned by issue #149 (`scheduler.mode: auto` — derive windows from forecast/consumption/SoC).
+- Crontab removal — deferred to v3.0.0 cleanup per `STRATEGY.md`.
+- README and add-on documentation updates for the deprecation timeline — handled as a separate docs PR or paired with the auto-mode launch.
+
+---
+
+## Risks & Dependencies
+
+- **The `set_defaults` key name in HA config.** The requirements doc uses `defaults` as the field name, but in JSON/YAML configuration surfaces, `set_defaults` is clearer and avoids keyword confusion. This plan uses `set_defaults` for the external config key and `Defaults` for the internal struct field (with `mapstructure:"set_defaults"` tag). Confirm with the requirements doc if this deviates.
+- **Depends on the multi-window infrastructure from #146** — the `windows:` list, `ValidateWindows`, and `ResolveActiveWindow` must exist before windows mode can function. These are already merged on the branch.
+- **Depends on the forecast/consumption horizon infrastructure from #145** — per-window horizon overrides are already in the Window struct and `validateWindowFields`.
+- **The `time.Ticker` reset on window change** uses a new ticker for each transition. The Go runtime handles this efficiently, but verify no ticker leak on rapid window transitions (the `Stop()` call on the old ticker prevents the leak).
+
+---
+
+## Sources / Research
+
+- Requirements document: `docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md`
+- `pkg/cmd/schedule.go:24-30` — flag variable block
+- `pkg/cmd/schedule.go:269-303` — `registerScdCmd` flag registration
+- `pkg/cmd/schedule.go:414-476` — `checkScheduleschedule` validation
+- `pkg/cmd/schedule.go:524-535` — `makeBasePayload`
+- `pkg/cmd/schedule.go:571-619` — `crontabSchedule`
+- `pkg/cmd/schedule_runner.go:30-52` — `RunnerConfig`
+- `pkg/cmd/schedule_runner.go:77-83` — `Runner` struct
+- `pkg/cmd/schedule_runner.go:119-135` — `Run` loop
+- `pkg/cmd/schedule_runner.go:164-300` — `Tick` method
+- `pkg/cmd/schedule_runner.go:540-576` — `resolveActiveWindow`
+- `pkg/power/window.go:34-41` — `Window` struct
+- `pkg/power/window.go:111-132` — `validateWindowFields`
+- `pkg/mqtt/types.go:23-41` — `StatePayload`
+- `pkg/mqtt/discovery.go:51-125` — `BuildDiscovery`
+- `pkg/mqtt/publisher.go:12-17` — `PublishState`
+- `home-assistant/addons/sbam/config.json` — HA add-on schema
+- `pkg/cmd/root.go:41-64` — viper and cobra init
+- `pkg/cmd/root.go:79-90` — `bindFlags`
+- `STRATEGY.md` — v2.1.0 milestone, v3.0.0 crontab removal
+- Plan archive: `docs/implementations/archive/146-issue-multi-window-charging/` — multi-window precedent
+- Plan archive: `docs/implementations/archive/87-issue-schedule-runner-refactor/` — runner architecture

--- a/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
+++ b/docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md
@@ -56,7 +56,7 @@ The schedule runner currently decides between legacy single-window and multi-win
 
 - **`auto` value defined but hidden.** The value exists so early adopters can manually set it and get a useful rejection message, but it is excluded from HA schema and CLI help to avoid presenting a non-functional option.
 
-- **`tick_minutes`, `defaults`, and `before_end_defaults` are optional pointer fields on Window.** Using `*int` / `*bool` with `omitempty` tags so zero values don't serialize and existing configs are unaffected. Validation rejects negative or zero values.
+- **`tick_minutes`, `defaults`, and `before_end_defaults` are optional pointer fields on Window.** Using `*int` / `*bool` with `omitempty` tags so zero values don't serialize and existing configs are unaffected. Validation rejects negative values and `tick_minutes` of zero. `before_end_defaults` of zero is valid (fires at window end).
 
 - **Deprecation warning on MQTT, not just logs.** HA users monitor dashboards, not container logs. The `StatePayload` gains a `deprecation_warning` string field, published once at startup when crontab mode is active.
 
@@ -71,7 +71,7 @@ The schedule runner currently decides between legacy single-window and multi-win
 - **Dependencies:** None
 - **Files:**
   - `pkg/power/window.go` — add fields to Window struct, update `validateWindowFields`
-- **Approach:** Add three pointer fields with `omitempty` tags to the Window struct: `TickMinutes *int`, `Defaults *bool`, `BeforeEndDefaults *int`. Update `validateWindowFields` to reject `TickMinutes <= 0` when set, reject `Defaults: true` when `TickMinutes` is set and conflicting (adjacent concern — defer to U5), and reject `BeforeEndDefaults <= 0` when `Defaults` is set. Use the existing field-validation pattern (early return on first error).
+- **Approach:** Add three pointer fields with `omitempty` tags to the Window struct: `TickMinutes *int`, `Defaults *bool`, `BeforeEndDefaults *int`. Update `validateWindowFields` to reject `TickMinutes <= 0` when set and reject `BeforeEndDefaults < 0` when `Defaults` is set. A value of `0` is valid — it means set_defaults fires at the exact window end time. Use the existing field-validation pattern (early return on first error).
 - **Patterns to follow:** Existing optional fields `ForecastHorizon` and `ConsumptionHorizon` on Window struct (`pkg/power/window.go:34-41`). The `validateWindowFields` pattern at `pkg/power/window.go:111-132`.
 - **Test scenarios:**
   - Window with no new fields set — passes validation (backward compatible)
@@ -79,7 +79,7 @@ The schedule runner currently decides between legacy single-window and multi-win
   - Window with `tick_minutes: 0` — validation fails
   - Window with `tick_minutes: -1` — validation fails
   - Window with `defaults: true`, `before_end_defaults: 10` — passes validation
-  - Window with `defaults: true`, `before_end_defaults: 0` — validation fails
+  - Window with `defaults: true`, `before_end_defaults: 0` — passes validation (fires at window end)
   - Window with `before_end_defaults` set but `defaults` unset — passes validation (field ignored at runtime but structurally valid)
   - Cross-midnight window with `defaults: true` — passes validation (timer scheduling tested in U5)
 - **Verification:** `make test` passes. `ValidateWindows` accepts windows with new fields and rejects invalid values.

--- a/docs/plans/2026-06-13-001-feat-window-transition-timing-plan.md
+++ b/docs/plans/2026-06-13-001-feat-window-transition-timing-plan.md
@@ -1,0 +1,134 @@
+---
+title: "feat: Precise window transition timing in windows-mode ticker"
+type: feat
+date: 2026-06-13
+origin: docs/brainstorms/2026-06-13-window-transition-timing-requirements.md
+---
+
+## Summary
+
+The windows-mode ticker fires a tick immediately on initial startup and detects window transitions at exact boundary times via a one-shot timer. Adjacent windows with equal start/end boundaries are rejected at validation. The existing `set_defaults` timer and cooldown are unchanged.
+
+## Problem Frame
+
+When `scheduler_mode: windows` is active, the system idles for a full `tick_minutes` interval before the first tick after startup, and window transitions are only detected at the next periodic tick — a window starting at 22:00 may not take effect until 22:20. A third issue is config ambiguity: when one window's end equals another's start, inclusive bounds make both windows active at the boundary minute and the first-listed window wins.
+
+The origin document (`docs/brainstorms/2026-06-13-window-transition-timing-requirements.md`) defines seven requirements (R1–R7) and five acceptance examples (AE1–AE5) covering these three concerns.
+
+## Requirements
+
+- R1. `StartWindowsTicker` fires a tick immediately on initial call.
+- R2. Window-change ticker restarts do not fire an additional immediate tick.
+- R3. On ticker start/restart, a one-shot boundary timer fires an `IntentTick` at the next window's start. Last window wraps to first window's next start.
+- R4. The boundary timer is cancelled in `stopWindowsTicker`.
+- R5. If the computed boundary is in the past, the timer targets the next occurrence.
+- R6. `ValidateWindows` rejects configurations where one window's end equals another window's start.
+- R7. `scheduleDefaults` and `isInCooldown` are not modified.
+
+## Key Technical Decisions
+
+- **Boundary timer uses `time.AfterFunc`, replicates the `scheduleDefaults` pattern.** The existing one-shot timer (`scheduleDefaults` at `pkg/cmd/schedule_runner.go:196-233`) already handles cross-midnight computation and explicit stop. Using the same mechanism avoids introducing a new timer abstraction.
+
+- **Immediate tick fires in the exported `StartWindowsTicker`, not in `startWindowsTicker`.** The exported method is called only from the initial schedule command path (`pkg/cmd/schedule.go:277`). The unexported `startWindowsTicker` is also called from `Tick()` when a window change is detected — R2 forbids an immediate tick in that case.
+
+- **Equal-boundary check compares minute-of-day values from original window Start/End clock times, not expanded segments.** The overlap detector uses half-open `[startMinute, endMinute)` segments where adjacent boundaries are harmless by design. The equal-boundary check must convert the original `Window.Start` / `Window.End` strings to minute-of-day values and compare those, not the expanded segments.
+
+- **Boundary timer reference stored explicitly.** Unlike the periodic ticker (intentionally not stored — `pkg/cmd/schedule_runner.go:181-183`), the boundary timer is stored as `*time.Timer` and explicitly stopped in `stopWindowsTicker`, matching the `defaultsTimer` lifecycle.
+
+## Implementation Units
+
+### U1. ValidateWindows rejects equal adjacent boundaries
+
+- **Goal:** Reject configurations where one window's end clock time equals another window's start clock time.
+- **Requirements:** R6
+- **Dependencies:** None
+- **Files:**
+  - `pkg/power/window.go` — add equal-boundary check to `ValidateWindows`
+  - `pkg/power/window_test.go` — add rejection cases, update existing adjacent-window test
+- **Approach:** After the existing overlap-detection loop in `ValidateWindows`, add an O(n²) scan over all window pairs comparing `clockMinute(end)` of one window to `clockMinute(start)` of every other window. Use the original `Window.Start` / `Window.End` strings (not expanded segments) so cross-midnight windows are handled correctly. The check fires after overlap detection so the error for overlapping windows takes precedence.
+- **Patterns to follow:** Existing `ValidateWindows` error format: `"window %q overlaps with window %q"`. Match this style for the equal-boundary error: `"window %q end %s equals window %q start %s"`.
+- **Test scenarios:**
+  - Happy path: Two windows with equal boundary (day end 22:00, night start 22:00) → error naming both windows
+  - Edge case: Cross-midnight window end equals another window start (night end 06:00, day start 06:00) → error
+  - Edge case: Three windows with equal boundary between first and second → error on that pair
+  - Existing behavior preserved: Adjacent non-equal boundaries (day end 21:59, night start 22:00) → passes
+  - Existing behavior preserved: Genuine overlap still detected → error
+  - Existing behavior preserved: Non-adjacent, non-overlapping windows → passes
+  - Edge case: Single window → passes (no other window to compare)
+  - Edge case: Equal boundaries between non-adjacent windows (rare but valid) → still rejected
+- **Verification:** `make test` passes with updated `TestValidateWindows` cases. Covers AE4.
+
+### U2. Fire immediate tick on initial StartWindowsTicker call
+
+- **Goal:** When sbam starts mid-window, fire a tick immediately instead of waiting for the first periodic interval.
+- **Requirements:** R1, R2
+- **Dependencies:** None
+- **Files:**
+  - `pkg/cmd/schedule_runner.go` — add immediate tick submission in exported `StartWindowsTicker`
+  - `pkg/cmd/schedule_runner_test.go` — add test for immediate tick behavior
+- **Approach:** In the exported `StartWindowsTicker` method (`schedule_runner.go:151-153`), call `r.Submit(mqtt.Intent{Kind: mqtt.IntentTick})` before delegating to `r.startWindowsTicker(now)`. The unexported `startWindowsTicker` (called from `Tick()` on window change) does not add this call, satisfying R2. The immediate tick runs with the current window's parameters since `resolveActiveWindow` is called inside `Tick()` at processing time.
+- **Patterns to follow:** Existing `Submit` guard pattern: `if !r.Submit(...) { u.Log.Warn(...) }`.
+- **Test scenarios:**
+  - Happy path: Call `StartWindowsTicker(fakeNow)` → drain intent channel → an `IntentTick` is present
+  - Edge case: Intent queue is full → `Submit` returns false, warning is logged, no panic
+  - Non-regression: Window-change restart (calling `startWindowsTicker` directly from within a tick) does not enqueue a second `IntentTick`
+  - Integration: The immediate tick executes `Tick()` which resolves the active window correctly and publishes state
+- **Verification:** `make test` passes. Covers AE1 and AE5 (immediate tick portion).
+
+### U3. Schedule one-shot boundary timer at next window start
+
+- **Goal:** Detect window transitions at their exact start time by scheduling a one-shot timer at the next window's start boundary.
+- **Requirements:** R3, R4, R5
+- **Dependencies:** None (U1 and U2 are independent; all three can land in any order)
+- **Files:**
+  - `pkg/cmd/schedule_runner.go` — add `boundaryTimer` field to `Runner`, add `scheduleBoundaryTick` method, integrate into `startWindowsTicker` and `stopWindowsTicker`, add timer factory var for test injection
+  - `pkg/cmd/schedule_runner_test.go` — add tests for boundary timer scheduling, firing, cancellation, and wrap-around
+- **Approach:**
+  1. Add `boundaryTimer *time.Timer` to the `Runner` struct (alongside `defaultsTimer`).
+  2. Add `scheduleBoundaryTick(windows []pw.Window, now time.Time)` method:
+     - Resolve the active window via `pw.ResolveActiveWindow`. If no window is active (gapped coverage), find the next window whose start is after `now` and use its start; if all windows start before `now`, use the first window's start + 24h.
+     - When an active window exists, find its index in the ordered list and select the next window: `(currentIdx + 1) % len(windows)`
+     - Parse the next window's `Start` clock time
+     - Compute the absolute fire time: anchor to `now`'s date, add 24h if the time is before-or-equal to `now` (R5)
+     - Use `time.AfterFunc` to submit `IntentTick` at the fire time
+     - Store the returned `*time.Timer` in `r.boundaryTimer`
+  3. Call `scheduleBoundaryTick` from `startWindowsTicker` after the periodic ticker is started.
+  4. In `stopWindowsTicker`, stop and nil out `r.boundaryTimer`.
+  5. Add a package-level `var newAfterFunc = time.AfterFunc` so tests can inject a fake timer.
+  6. For a single-window list, the boundary wraps to the same window's next start. This is harmless — the periodic ticker already covers that interval.
+- **Patterns to follow:** `scheduleDefaults` (`schedule_runner.go:196-233`) for wall-clock parsing, cross-midnight date adjustment, `time.AfterFunc` usage, timer storage, and stop-on-teardown. Log format: `u.Log.Infow("boundary timer scheduled", ...)` matching `scheduleDefaults` at line 222.
+- **Test scenarios:**
+  - Happy path: With two windows (day 06:00–21:59, night 22:00–05:59), at 12:00 the boundary timer is scheduled for 22:00 today
+  - Happy path: The boundary timer fires and submits an `IntentTick`
+  - Wrap-around: With two windows at 23:00 (night active), the boundary timer targets 06:00 tomorrow (day start)
+  - R5: Start at exact boundary (06:00) — the boundary timer targets 22:00 today, not 06:00 today
+  - Cancellation: Calling `stopWindowsTicker` cancels the boundary timer
+  - Cancellation: Window change restart calls `startWindowsTicker`, which calls `stopWindowsTicker` first, cancelling the old boundary timer
+  - Integration: Boundary-triggered tick detects window change in `Tick()` and restarts the ticker with new window params
+  - Edge case: Single window — boundary timer wraps to same window's next start
+  - Edge case: `time.AfterFunc` override (via `newAfterFunc` var) allows deterministic testing without real clock
+- **Verification:** `make test` passes. Covers AE2, AE3 (boundary timer portion), and AE5 (boundary timer portion).
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Aligning periodic ticks to window start boundaries (e.g., 06:00, 06:30, 07:00 regardless of launch time). First-day cadence depends on when sbam launched; subsequent days inherit alignment from boundary-triggered transitions.
+
+### Out of scope
+
+- The `crontab` scheduler mode is unaffected.
+- The `set_defaults` timer and cooldown logic are not modified.
+
+## Sources / Research
+
+- `pkg/cmd/schedule_runner.go:155-190` — `startWindowsTicker` / `stopWindowsTicker` lifecycle
+- `pkg/cmd/schedule_runner.go:196-233` — `scheduleDefaults` one-shot timer pattern
+- `pkg/cmd/schedule_runner.go:262-278` — `Tick` window-change detection
+- `pkg/cmd/schedule.go:272-278` — `StartWindowsTicker` call site
+- `pkg/power/window.go:61-122` — `ValidateWindows` overlap detection
+- `pkg/power/window.go:155-191` — `ResolveActiveWindow` inclusive bounds
+- `docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md` — original ticker architecture
+- `docs/implementations/archive/146-issue-multi-window-charging/` — overlap detection and boundary semantics

--- a/home-assistant/addons/sbam/config.json
+++ b/home-assistant/addons/sbam/config.json
@@ -39,6 +39,7 @@
     "mqtt_ha_discovery_prefix": "homeassistant",
     "forecast_horizon": "default",
     "consumption_horizon": "full_day",
+    "scheduler_mode": "crontab",
     "windows": []
   },
   "schema": {
@@ -72,13 +73,17 @@
     "mqtt_ha_discovery_prefix": "str",
     "forecast_horizon": "list(default|next_solar_day|remaining_today|today|tomorrow|off)",
     "consumption_horizon": "list(full_day|remaining_today)",
+    "scheduler_mode": "list(crontab|windows)",
     "windows": [{
       "name": "str",
       "start": "match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)",
       "end": "match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)",
       "max_charge": "float",
       "forecast_horizon": "list(default|next_solar_day|remaining_today|today|tomorrow|off)?",
-      "consumption_horizon": "list(full_day|remaining_today)?"
+      "consumption_horizon": "list(full_day|remaining_today)?",
+      "tick_minutes": "int?",
+      "set_defaults": "bool?",
+      "before_end_defaults_minutes": "int?"
     }]
   }
 }

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -24,7 +24,8 @@ import (
 var s_apiKey, s_url, start_hr, end_hr, batt_reserve_start_hr, batt_reserve_end_hr, w_start_hr, w_end_hr,
 	crontab, s_cache_file_prefix, mqtt_broker, mqtt_client_id, mqtt_username,
 	mqtt_password, mqtt_tls_ca_file, mqtt_tls_client_cert, mqtt_tls_client_cert_key,
-	mqtt_topic_prefix, mqtt_ha_discovery_prefix, forecast_horizon, consumption_horizon string
+	mqtt_topic_prefix, mqtt_ha_discovery_prefix, forecast_horizon, consumption_horizon,
+	scheduler_mode string
 var pw_consumption, max_charge, pw_lwt, pw_upt, pw_batt_reserve float64
 var s_cache_time int32
 var s_defaults, s_cache_forecast, mqtt_enabled, mqtt_ha_discovery, mqtt_tls_insecure_skip bool
@@ -45,6 +46,7 @@ const (
 	const_mqtt_op_timeout     = 5 * time.Second
 	const_forecast_horizon    = "default"
 	const_consumption_horizon = "full_day"
+	const_scheduler_mode      = "crontab"
 	scheduleClockLayout       = "15:04"
 )
 
@@ -117,6 +119,7 @@ var scdCmd = &cobra.Command{
 		mqtt_ha_discovery_prefix = viper.GetString("mqtt_ha_discovery_prefix")
 		forecast_horizon = viper.GetString("forecast_horizon")
 		consumption_horizon = viper.GetString("consumption_horizon")
+		scheduler_mode = viper.GetString("scheduler_mode")
 
 		// Resolve windows with flag > env > config.yaml precedence.
 		var windows []pw.Window
@@ -193,7 +196,7 @@ var scdCmd = &cobra.Command{
 		}
 		u.LogStartupParams(cmd, extras)
 
-		err = checkScheduleschedule(crontab, s_apiKey, s_url, fronius_ip, pw_consumption, max_charge, pw_batt_reserve, w_start_hr, w_end_hr, windows)
+		err = checkScheduleschedule(crontab, s_apiKey, s_url, fronius_ip, pw_consumption, max_charge, pw_batt_reserve, w_start_hr, w_end_hr, windows, scheduler_mode)
 		if err != nil {
 			u.Log.Error(err)
 			return
@@ -298,6 +301,7 @@ func registerScdCmd() {
 	scdCmd.Flags().StringVar(&mqtt_ha_discovery_prefix, "mqtt_ha_discovery_prefix", const_ha_discovery_prefix, "Home Assistant MQTT discovery prefix")
 	scdCmd.Flags().StringVar(&forecast_horizon, "forecast_horizon", const_forecast_horizon, "Forecast horizon mode (default, next_solar_day, remaining_today, today, tomorrow, off)")
 	scdCmd.Flags().StringVar(&consumption_horizon, "consumption_horizon", const_consumption_horizon, "Consumption horizon mode (full_day, remaining_today)")
+	scdCmd.Flags().StringVar(&scheduler_mode, "scheduler_mode", const_scheduler_mode, "Scheduler mode (crontab, windows)")
 	scdCmd.Flags().String("windows", "", "Charge windows in YAML format (same as config.yaml windows: key)")
 
 	rootCmd.AddCommand(scdCmd)
@@ -412,13 +416,27 @@ func isWindowContainedIn(innerStart, innerEnd, outerStart, outerEnd string) (boo
 // The function intentionally keeps validation local to the command so the
 // runtime can exit early with user-friendly messages when flags are invalid.
 func checkScheduleschedule(crontab, apiKey, url, fronius_ip string, pw_consumption, max_charge,
-	pw_batt_reserve float64, start_hr, end_hr string, windows []pw.Window) error {
+	pw_batt_reserve float64, start_hr, end_hr string, windows []pw.Window, scheduler_mode string) error {
 
 	if len(windows) > 0 {
 		u.Log.Info("windows configuration is provided; start_hr/end_hr will be ignored")
 		if err := pw.ValidateWindows(windows); err != nil {
 			return fmt.Errorf("invalid windows configuration: %w", err)
 		}
+	}
+
+	// Validate scheduler_mode.
+	switch scheduler_mode {
+	case "crontab":
+		// Valid; crontab + windows is compatible (cron drives ticks, windows parameterize them).
+	case "windows":
+		if len(windows) == 0 {
+			return errors.New("scheduler_mode is 'windows' but no windows are configured; add at least one entry to windows:")
+		}
+	case "auto":
+		return fmt.Errorf("scheduler_mode 'auto' is not yet available — see issue #149")
+	default:
+		return fmt.Errorf("unknown scheduler_mode %q: must be crontab, windows, or auto", scheduler_mode)
 	}
 
 	if len(strings.TrimSpace(fronius_ip)) == 0 {

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -222,6 +222,7 @@ var scdCmd = &cobra.Command{
 			Defaults:           s_defaults,
 			ForecastHorizon:    forecast_horizon,
 			ConsumptionHorizon: consumption_horizon,
+			SchedulerMode:      scheduler_mode,
 			MQTT:               mqttCfg,
 			Now:                time.Now,
 		}
@@ -539,14 +540,16 @@ func subscribeScheduleCommands(ctx context.Context, mqttClient mqtt.Client, mqtt
 // scheduler publish points. It returns a payload with the provided
 // decision/reason and pointerized window flags; callers may set extra
 // telemetry fields before publishing.
-func makeBasePayload(lastDecision, lastReason string, inChargeWindow, reserveWindowActive bool) mqtt.StatePayload {
+func makeBasePayload(lastDecision, lastReason string, inChargeWindow, reserveWindowActive bool, schedulerMode string) mqtt.StatePayload {
 	ic := inChargeWindow
 	rw := reserveWindowActive
+	sm := schedulerMode
 	return mqtt.StatePayload{
 		LastDecision:        lastDecision,
 		LastDecisionReason:  lastReason,
 		ChargeWindowActive:  &ic,
 		ReserveWindowActive: &rw,
+		SchedulerMode:       &sm,
 		Paused:              false,
 		Timestamp:           time.Now().UTC(),
 	}

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -273,7 +273,8 @@ var scdCmd = &cobra.Command{
 			if crontab != const_ct {
 				u.Log.Warn("crontab is set but scheduler_mode=windows; crontab will be ignored")
 			}
-			u.Log.Info("scheduler_mode=windows active; internal ticker starts via runner")
+			u.Log.Info("scheduler_mode=windows active; starting internal ticker")
+			runner.StartWindowsTicker(time.Now())
 
 		default:
 			u.Log.Errorf("unexpected scheduler_mode %q", scheduler_mode)

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -245,16 +245,39 @@ var scdCmd = &cobra.Command{
 			})
 		}
 
-		if crontab != const_ct {
-			if err := crontabSchedule(runCtx, runner, crontab, s_defaults, w_end_hr); err != nil {
-				u.Log.Error(err)
-				_ = runner.Submit(mqtt.Intent{Kind: mqtt.IntentShutdown})
-				stop()
-				if waitErr := waitForRunnerDone(runDone); waitErr != nil {
-					u.Log.Error(waitErr)
+		switch scheduler_mode {
+		case "crontab":
+			u.Log.Warn("scheduler_mode=crontab is deprecated and will be removed in v3.0.0; migrate to scheduler_mode=windows")
+			if mqttCfg.Enabled && mqttClient != nil {
+				deprecationPayload := mqtt.StatePayload{
+					SchedulerMode:      strPtr("crontab"),
+					DeprecationWarning: strPtr("scheduler_mode=crontab is deprecated and will be removed in v3.0.0; migrate to scheduler_mode=windows"),
+					Timestamp:          time.Now().UTC(),
 				}
-				return
+				publishStateSnapshot(mqttClient, mqttCfg, deprecationPayload)
 			}
+
+			if crontab != const_ct {
+				if err := crontabSchedule(runCtx, runner, crontab, s_defaults, w_end_hr); err != nil {
+					u.Log.Error(err)
+					_ = runner.Submit(mqtt.Intent{Kind: mqtt.IntentShutdown})
+					stop()
+					if waitErr := waitForRunnerDone(runDone); waitErr != nil {
+						u.Log.Error(waitErr)
+					}
+					return
+				}
+			}
+
+		case "windows":
+			if crontab != const_ct {
+				u.Log.Warn("crontab is set but scheduler_mode=windows; crontab will be ignored")
+			}
+			u.Log.Info("scheduler_mode=windows active; internal ticker starts via runner")
+
+		default:
+			u.Log.Errorf("unexpected scheduler_mode %q", scheduler_mode)
+			return
 		}
 
 		if err := finalizeRunnerMode(mqtt_enabled, runner, runDone, stop); err != nil {
@@ -588,6 +611,9 @@ func waitForRunnerDone(runDone <-chan error) error {
 
 	return nil
 }
+
+// crontabSchedule installs the `schedule` function into a cron scheduler
+func strPtr(s string) *string { return &s }
 
 // crontabSchedule installs the `schedule` function into a cron scheduler
 // using the provided cron expression. Callbacks submit intents and return

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -76,11 +76,15 @@ var newBatteryWriter = func() batteryWriter {
 // Runner owns serialized schedule and command execution.
 // Single-writer invariant: all Fronius Modbus write operations must be executed by this runner.
 type Runner struct {
-	cfg     RunnerConfig
-	client  mqtt.Client
-	writer  batteryWriter
-	intents chan mqtt.Intent
-	paused  atomic.Pointer[time.Time]
+	cfg           RunnerConfig
+	client        mqtt.Client
+	writer        batteryWriter
+	intents       chan mqtt.Intent
+	paused        atomic.Pointer[time.Time]
+	tickerCh      <-chan time.Time // nil when not in windows mode
+	defaultsTimer *time.Timer
+	defaultsFired atomic.Bool
+	activeWindow  string // name of active window for change detection
 }
 
 // NewRunner constructs a Runner with the provided configuration and MQTT
@@ -126,6 +130,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-r.tickerCh:
+			if !r.Submit(mqtt.Intent{Kind: mqtt.IntentTick}) {
+				u.Log.Warn("windows tick dropped because runner queue is full")
+			}
 		case intent := <-r.intents:
 			r.handleIntent(ctx, intent)
 			if intent.Kind == mqtt.IntentShutdown {
@@ -133,6 +141,95 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// StartWindowsTicker initializes the internal ticker for windows mode.
+// It computes the tick interval from the active window's tick_minutes (or 60
+// min default), creates a time.Ticker, and schedules a set_defaults timer if
+// the active window has defaults enabled. Callers in crontab mode must not
+// call this method — it is only valid when SchedulerMode is "windows".
+func (r *Runner) StartWindowsTicker(now time.Time) {
+	r.startWindowsTicker(now)
+}
+
+func (r *Runner) startWindowsTicker(now time.Time) {
+	r.stopWindowsTicker()
+
+	active := pw.ResolveActiveWindow(r.cfg.Windows, now)
+	if active != nil {
+		r.activeWindow = active.Name
+	} else {
+		r.activeWindow = ""
+	}
+
+	interval := 60 * time.Minute
+	if active != nil && active.TickMinutes != nil {
+		interval = time.Duration(*active.TickMinutes) * time.Minute
+	}
+
+	t := time.NewTicker(interval)
+	r.tickerCh = t.C
+
+	// Schedule per-window set_defaults if enabled.
+	if active != nil && active.Defaults != nil && *active.Defaults {
+		r.scheduleDefaults(active, now)
+	}
+}
+
+func (r *Runner) stopWindowsTicker() {
+	r.tickerCh = nil
+	// We cannot stop the underlying ticker without storing a reference, but
+	// setting tickerCh to nil prevents further selects from firing. The GC
+	// will collect the orphaned ticker after its next fire (within interval).
+	if r.defaultsTimer != nil {
+		r.defaultsTimer.Stop()
+		r.defaultsTimer = nil
+	}
+	r.defaultsFired.Store(false)
+	r.activeWindow = ""
+}
+
+// scheduleDefaults parses the active window's end time and schedules a
+// one-shot time.AfterFunc that fires set_defaults at
+// (window.end - before_end_defaults). The timer is tracked in r.defaultsTimer
+// so it can be cancelled on window change.
+func (r *Runner) scheduleDefaults(active *pw.Window, now time.Time) {
+	beforeEnd := 5 // default minutes
+	if active.BeforeEndDefaults != nil {
+		beforeEnd = *active.BeforeEndDefaults
+	}
+
+	endTime, err := parseScheduleClock(active.End, "end")
+	if err != nil {
+		u.Log.Warnw("cannot parse window end for set_defaults timer", "window", active.Name, "end", active.End, "error", err)
+		return
+	}
+
+	endAt := time.Date(now.Year(), now.Month(), now.Day(),
+		endTime.Hour(), endTime.Minute(), 0, 0, now.Location())
+
+	// If endAt is before or equal to now, advance by 24h (cross-midnight window).
+	if !endAt.After(now) {
+		endAt = endAt.Add(24 * time.Hour)
+	}
+
+	resetAt := endAt.Add(-time.Duration(beforeEnd) * time.Minute)
+	delay := resetAt.Sub(now)
+	if delay < 0 {
+		delay = 0 // fire immediately if reset time already passed
+	}
+
+	u.Log.Infow("scheduling set_defaults for window",
+		"window", active.Name, "end", active.End, "before_end_minutes", beforeEnd,
+		"reset_at", resetAt.Format(time.RFC3339), "delay", delay.Round(time.Second))
+
+	r.defaultsTimer = time.AfterFunc(delay, func() {
+		u.Log.Infow("set_defaults timer fired", "window", active.Name)
+		r.defaultsFired.Store(true)
+		if !r.Submit(mqtt.Intent{Kind: mqtt.IntentSetDefaults}) {
+			u.Log.Warn("set_defaults dropped because runner queue is full")
+		}
+	})
 }
 
 // HandleCommand parses an MQTT command payload into an Intent and submits
@@ -170,6 +267,15 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	// Resolve active window and derive effective charge parameters.
 	// When no windows are configured, falls back to legacy StartHR/EndHR.
 	inChargeWindow, effectiveMaxCharge, effectiveForecastHorizon, effectiveConsumptionHorizon, activeWindowName := r.resolveActiveWindow(now)
+
+	// In windows mode, restart the ticker when the active window changes.
+	if r.cfg.SchedulerMode == "windows" {
+		prevWindow := r.activeWindow
+		if activeWindowName != prevWindow {
+			u.Log.Infow("active window changed", "from", prevWindow, "to", activeWindowName)
+			r.startWindowsTicker(now)
+		}
+	}
 
 	reserveWindowActive, err := checkTimeRangeAt(now, r.cfg.BattReserveStartHR, r.cfg.BattReserveEndHR)
 	if err != nil {
@@ -212,7 +318,22 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		return nil
 	}
 
-	inCooldown, cooldownErr := isInCooldown(now, r.cfg.StartHR, r.cfg.EndHR, chargeCooldownMinutes)
+	// Cooldown check: in windows mode use the active window's end time and
+	// before_end_defaults (or default 5 min); in crontab mode use legacy params.
+	var inCooldown bool
+	var cooldownErr error
+	if r.cfg.SchedulerMode == "windows" && len(r.cfg.Windows) > 0 {
+		active := pw.ResolveActiveWindow(r.cfg.Windows, now)
+		if active != nil {
+			cooldownDuration := chargeCooldownMinutes
+			if active.Defaults != nil && *active.Defaults && active.BeforeEndDefaults != nil {
+				cooldownDuration = *active.BeforeEndDefaults
+			}
+			inCooldown, cooldownErr = isInCooldown(now, active.Start, active.End, cooldownDuration)
+		}
+	} else {
+		inCooldown, cooldownErr = isInCooldown(now, r.cfg.StartHR, r.cfg.EndHR, chargeCooldownMinutes)
+	}
 	if cooldownErr != nil {
 		r.publishError(ctx, "tick", cooldownErr)
 		return cooldownErr

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -71,6 +71,10 @@ var newBatteryWriter = func() batteryWriter {
 	return froniusBatteryWriter{}
 }
 
+// newTimerFunc is a package-level factory for one-shot timers. Tests may
+// override it to inject deterministic timer behavior.
+var newTimerFunc = time.AfterFunc
+
 // latest state caching was removed; the runner publishes state directly.
 
 // Runner owns serialized schedule and command execution.
@@ -83,6 +87,7 @@ type Runner struct {
 	paused        atomic.Pointer[time.Time]
 	tickerCh      <-chan time.Time // nil when not in windows mode
 	defaultsTimer *time.Timer
+	boundaryTimer *time.Timer
 	defaultsFired atomic.Bool
 	activeWindow  string // name of active window for change detection
 }
@@ -149,6 +154,9 @@ func (r *Runner) Run(ctx context.Context) error {
 // the active window has defaults enabled. Callers in crontab mode must not
 // call this method — it is only valid when SchedulerMode is "windows".
 func (r *Runner) StartWindowsTicker(now time.Time) {
+	if !r.Submit(mqtt.Intent{Kind: mqtt.IntentTick}) {
+		u.Log.Warn("immediate tick dropped because runner queue is full")
+	}
 	r.startWindowsTicker(now)
 }
 
@@ -174,6 +182,9 @@ func (r *Runner) startWindowsTicker(now time.Time) {
 	if active != nil && active.Defaults != nil && *active.Defaults {
 		r.scheduleDefaults(active, now)
 	}
+
+	// Schedule a one-shot timer at the next window's start boundary.
+	r.scheduleBoundaryTick(now)
 }
 
 func (r *Runner) stopWindowsTicker() {
@@ -184,6 +195,10 @@ func (r *Runner) stopWindowsTicker() {
 	if r.defaultsTimer != nil {
 		r.defaultsTimer.Stop()
 		r.defaultsTimer = nil
+	}
+	if r.boundaryTimer != nil {
+		r.boundaryTimer.Stop()
+		r.boundaryTimer = nil
 	}
 	r.defaultsFired.Store(false)
 	r.activeWindow = ""
@@ -228,6 +243,103 @@ func (r *Runner) scheduleDefaults(active *pw.Window, now time.Time) {
 		r.defaultsFired.Store(true)
 		if !r.Submit(mqtt.Intent{Kind: mqtt.IntentSetDefaults}) {
 			u.Log.Warn("set_defaults dropped because runner queue is full")
+		}
+	})
+}
+
+// scheduleBoundaryTick schedules a one-shot timer that fires an IntentTick
+// at the start of the next window in the ordered list. For the last window,
+// the boundary wraps to the first window's next start + 24h. When no window
+// is active (gapped coverage), it finds the next upcoming window start
+// from all windows.
+func (r *Runner) scheduleBoundaryTick(now time.Time) {
+	windows := r.cfg.Windows
+	if len(windows) == 0 {
+		return
+	}
+
+	active := pw.ResolveActiveWindow(windows, now)
+
+	var next pw.Window
+
+	if active == nil {
+		// No window active — find the next window whose start is after now.
+		var best *pw.Window
+		var bestStart time.Time
+		for i := range windows {
+			startTime, err := parseScheduleClock(windows[i].Start, "start")
+			if err != nil {
+				continue
+			}
+			startAt := time.Date(now.Year(), now.Month(), now.Day(),
+				startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
+			if !startAt.After(now) {
+				startAt = startAt.Add(24 * time.Hour)
+			}
+			if best == nil || startAt.Before(bestStart) {
+				best = &windows[i]
+				bestStart = startAt
+			}
+		}
+		if best != nil {
+			next = *best
+		} else {
+			return
+		}
+	} else {
+		// Find the active window's index in the ordered list.
+		activeIdx := -1
+		for i := range windows {
+			name := pw.WindowNameOrDefault(windows[i], i)
+			if name == active.Name || (active.Name == "" && name == pw.WindowNameOrDefault(windows[i], i)) {
+				activeIdx = i
+				break
+			}
+		}
+		// Fall back to name comparison if the active window was resolved.
+		if activeIdx < 0 {
+			for i := range windows {
+				if windows[i].Name == active.Name || windows[i].Start == active.Start {
+					activeIdx = i
+					break
+				}
+			}
+		}
+		if activeIdx < 0 {
+			return
+		}
+
+		// Select the next window (wrap for last).
+		nextIdx := (activeIdx + 1) % len(windows)
+		next = windows[nextIdx]
+	}
+
+	nextStart, err := parseScheduleClock(next.Start, "start")
+	if err != nil {
+		u.Log.Warnw("cannot parse next window start for boundary timer",
+			"window", next.Name, "start", next.Start, "error", err)
+		return
+	}
+
+	nextAt := time.Date(now.Year(), now.Month(), now.Day(),
+		nextStart.Hour(), nextStart.Minute(), 0, 0, now.Location())
+
+	// If nextAt is before or equal to now, advance by 24h.
+	if !nextAt.After(now) {
+		nextAt = nextAt.Add(24 * time.Hour)
+	}
+
+	delay := nextAt.Sub(now)
+
+	u.Log.Infow("scheduling boundary tick",
+		"next_window", pw.WindowNameOrDefault(next, 0),
+		"at", nextAt.Format(time.RFC3339),
+		"delay", delay.Round(time.Second))
+
+	r.boundaryTimer = newTimerFunc(delay, func() {
+		u.Log.Infow("boundary timer fired, submitting tick")
+		if !r.Submit(mqtt.Intent{Kind: mqtt.IntentTick}) {
+			u.Log.Warn("boundary tick dropped because runner queue is full")
 		}
 	})
 }

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -46,6 +46,7 @@ type RunnerConfig struct {
 	Defaults           bool
 	ForecastHorizon    string
 	ConsumptionHorizon string
+	SchedulerMode      string
 	Windows            []pw.Window
 	MQTT               mqtt.Config
 	Now                func() time.Time
@@ -181,7 +182,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	if storageErr != nil {
 		u.HandleError(storageErr, "storage handler failed, skipping schedule run")
 
-		payload := makeBasePayload(fronius.DecisionSkip.String(), fmt.Sprintf("storage read failed: %v", storageErr), inChargeWindow, reserveWindowActive)
+		payload := makeBasePayload(fronius.DecisionSkip.String(), fmt.Sprintf("storage read failed: %v", storageErr), inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 		paused, pauseUntil := r.pauseStateAt(now)
 		payload.Paused = paused
 		payload.NextRun = pauseUntil
@@ -191,7 +192,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	}
 
 	if paused, pauseUntil := r.pauseStateAt(now); paused {
-		payload := makeBasePayload("paused", "Forecast Charging execution skipped because sbam is paused", inChargeWindow, reserveWindowActive)
+		payload := makeBasePayload("paused", "Forecast Charging execution skipped because sbam is paused", inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 		payload.BatterySOCPct = &socPct
 		payload.BatteryCapacityWh = &capacityMax
 		payload.Paused = true
@@ -204,7 +205,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		u.Log.Infof("The current time is outside all configured charge windows")
 		capMax := capacityMax
 
-		payload := makeBasePayload(fronius.DecisionIdle.String(), "current time outside configured charging window", inChargeWindow, reserveWindowActive)
+		payload := makeBasePayload(fronius.DecisionIdle.String(), "current time outside configured charging window", inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 		payload.BatterySOCPct = &socPct
 		payload.BatteryCapacityWh = &capMax
 		r.publishState(payload)
@@ -219,7 +220,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	if inCooldown {
 		u.Log.Info("cooldown active — charge decisions suppressed near window end")
 		capMax := capacityMax
-		payload := makeBasePayload("cooldown", "charge decisions suppressed near window end", inChargeWindow, reserveWindowActive)
+		payload := makeBasePayload("cooldown", "charge decisions suppressed near window end", inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 		payload.BatterySOCPct = &socPct
 		payload.BatteryCapacityWh = &capMax
 		r.publishState(payload)
@@ -269,7 +270,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	if froniusErr != nil {
 		u.HandleError(froniusErr, "fronius handler failed, skipping schedule run")
 
-		payload := makeBasePayload(fronius.DecisionSkip.String(), fmt.Sprintf("fronius handler failed: %v", froniusErr), inChargeWindow, reserveWindowActive)
+		payload := makeBasePayload(fronius.DecisionSkip.String(), fmt.Sprintf("fronius handler failed: %v", froniusErr), inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 		payload.BatterySOCPct = &socPct
 		payload.BatteryCapacityWh = &capacityMax
 		payload.Paused = false
@@ -278,7 +279,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		return froniusErr
 	}
 
-	payload := makeBasePayload(decision.String(), reason.String(), inChargeWindow, reserveWindowActive)
+	payload := makeBasePayload(decision.String(), reason.String(), inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 	payload.BatterySOCPct = &socPct
 	payload.BatteryCapacityWh = &capacityMax
 	payload.ForecastTodayWh = &solarPowerProduction
@@ -467,7 +468,7 @@ func (r *Runner) newCommandPayload(lastDecision, reason string, now time.Time) m
 		reserveWindowActive = false
 	}
 
-	return makeBasePayload(lastDecision, reason, inChargeWindow, reserveWindowActive)
+	return makeBasePayload(lastDecision, reason, inChargeWindow, reserveWindowActive, r.cfg.SchedulerMode)
 }
 
 // publishState publishes the provided state payload via MQTT using the

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -1668,3 +1668,273 @@ func TestRunner_HandleIntentTriggerNow(t *testing.T) {
 	ack := decodeAckPayload(t, ackMsg.payload)
 	assert.True(t, ack.Accepted)
 }
+
+// --- U2: immediate tick on StartWindowsTicker ---
+
+func TestRunner_StartWindowsTicker_FiresImmediateTick(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+	}
+
+	drainPublishes(client)
+
+	now := time.Date(2026, time.May, 10, 6, 20, 0, 0, time.UTC)
+	runner.StartWindowsTicker(now)
+
+	// Verify an IntentTick was submitted to the intent queue.
+	select {
+	case intent := <-runner.intents:
+		assert.Equal(t, mqtt.IntentTick, intent.Kind)
+	default:
+		t.Fatal("expected immediate IntentTick in queue, got none")
+	}
+}
+
+func TestRunner_StartWindowsTicker_NoDuplicateTickOnRestart(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+	}
+
+	drainPublishes(client)
+
+	// Call startWindowsTicker directly (simulates window-change restart).
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.startWindowsTicker(now)
+
+	// The queue should be empty -- startWindowsTicker must not submit an IntentTick.
+	select {
+	case intent := <-runner.intents:
+		t.Fatalf("unexpected intent in queue on restart: %s", intent.Kind)
+	default:
+		// Expected: no intent.
+	}
+}
+
+func TestRunner_ImmediateTick_IntegratesWithRunLoop(t *testing.T) {
+	client := newFakeClient()
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	oldPowerFactory := newPower
+	newPower = func() powerClient { return &fakePowerClient{forecastWh: 0, retrieved: false} }
+	defer func() { newPower = oldPowerFactory }()
+
+	stub := &stubFroniusClient{}
+	oldFroniusFactory := newFronius
+	newFronius = func() froniusClient { return stub }
+	defer func() { newFronius = oldFroniusFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+	}
+
+	now := time.Date(2026, time.May, 10, 6, 20, 0, 0, time.UTC)
+	runner.StartWindowsTicker(now)
+
+	// Process the immediate tick through the intent handler.
+	select {
+	case intent := <-runner.intents:
+		assert.Equal(t, mqtt.IntentTick, intent.Kind)
+		runner.handleIntent(context.Background(), intent)
+	default:
+		t.Fatal("expected immediate IntentTick")
+	}
+
+	// Verify the tick executed: fronius handler was called.
+	assert.Equal(t, 1, stub.calls)
+
+	// Verify state was published.
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	assert.NotNil(t, state.ChargeWindowActive)
+	assert.True(t, *state.ChargeWindowActive)
+}
+
+// --- U3: boundary timer ---
+
+func TestRunner_ScheduleBoundaryTick_SchedulesForNextWindow(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	var capturedDelay time.Duration
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		capturedDelay = d
+		return nil
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	// 12:00 in day window -- boundary should be at 22:00 (10h from now).
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	assert.Equal(t, 10*time.Hour, capturedDelay)
+}
+
+func TestRunner_ScheduleBoundaryTick_WrapAround(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	var capturedDelay time.Duration
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		capturedDelay = d
+		return nil
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	// 23:00 in night window -- boundary should wrap to day start at 06:00 tomorrow (7h).
+	now := time.Date(2026, time.May, 10, 23, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	assert.Equal(t, 7*time.Hour, capturedDelay)
+}
+
+func TestRunner_ScheduleBoundaryTick_ExactBoundary(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	var capturedDelay time.Duration
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		capturedDelay = d
+		return nil
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	// Start at exactly 06:00 -- boundary should be at 22:00 today (16h), not 06:00.
+	now := time.Date(2026, time.May, 10, 6, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	assert.Equal(t, 16*time.Hour, capturedDelay)
+}
+
+func TestRunner_StopWindowsTicker_CancelsBoundaryTimer(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+	}
+
+	var timerCallback func()
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		timerCallback = f
+		// Return a real but short-lived timer so Stop() doesn't panic.
+		return time.NewTimer(24 * time.Hour)
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	require.NotNil(t, runner.boundaryTimer, "boundary timer should be set")
+	_ = timerCallback
+
+	runner.stopWindowsTicker()
+
+	assert.Nil(t, runner.boundaryTimer, "boundary timer should be nil after stop")
+}
+
+func TestRunner_StopWindowsTicker_NilTimerNoPanic(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+
+	// stopWindowsTicker should not panic when boundaryTimer is nil.
+	runner.stopWindowsTicker()
+
+	assert.Nil(t, runner.boundaryTimer)
+}
+
+func TestRunner_ScheduleBoundaryTick_FiresIntentTick(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	var timerCallback func()
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		timerCallback = f
+		return &time.Timer{}
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	require.NotNil(t, timerCallback, "timer callback should be captured")
+
+	// Fire the timer callback -- it should submit an IntentTick.
+	timerCallback()
+
+	select {
+	case intent := <-runner.intents:
+		assert.Equal(t, mqtt.IntentTick, intent.Kind)
+	default:
+		t.Fatal("expected IntentTick from boundary timer callback")
+	}
+}
+
+func TestRunner_ScheduleBoundaryTick_SingleWindow(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "only", Start: "06:00", End: "22:00", MaxCharge: 2000},
+	}
+
+	var capturedDelay time.Duration
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		capturedDelay = d
+		return nil
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	// 12:00 -- next boundary is the same window's next start at 06:00 tomorrow.
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	assert.Equal(t, 18*time.Hour, capturedDelay)
+}
+
+func TestRunner_ScheduleBoundaryTick_NoWindows(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+
+	called := false
+	oldTimerFunc := newTimerFunc
+	newTimerFunc = func(d time.Duration, f func()) *time.Timer {
+		called = true
+		return nil
+	}
+	defer func() { newTimerFunc = oldTimerFunc }()
+
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	runner.scheduleBoundaryTick(now)
+
+	assert.False(t, called, "timer should not be created when no windows configured")
+}

--- a/pkg/cmd/schedule_test.go
+++ b/pkg/cmd/schedule_test.go
@@ -468,49 +468,49 @@ func TestMakeBasePayloadSetsCommonFields(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCheckScheduleschedule_EmptyFroniusIP(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fronius_ip")
 }
 
 func TestCheckScheduleschedule_EmptyApiKey(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "apikey")
 }
 
 func TestCheckScheduleschedule_EmptyURL(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "url")
 }
 
 func TestCheckScheduleschedule_EmptyCrontab(t *testing.T) {
-	err := checkScheduleschedule("", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "crontab")
 }
 
 func TestCheckScheduleschedule_NegativePWConsumption(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", -1, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", -1, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_consumption")
 }
 
 func TestCheckScheduleschedule_NegativeMaxCharge(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, -1, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, -1, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_charge")
 }
 
 func TestCheckScheduleschedule_InvalidWindow(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "bad", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "bad", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid start_hr")
 }
 
 func TestCheckScheduleschedule_BattReserveNotContained(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "06:00", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "06:00", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "batt_reserve_start_hr")
 }
@@ -525,7 +525,7 @@ func TestCheckScheduleschedule_InvalidCacheTime(t *testing.T) {
 	s_cache_time = -1
 	defer func() { s_cache_time = oldCacheTime }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cache_time")
 }
@@ -540,7 +540,7 @@ func TestCheckScheduleschedule_CacheTimeTooLarge(t *testing.T) {
 	s_cache_time = 90000
 	defer func() { s_cache_time = oldCacheTime }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cache_time")
 }
@@ -561,7 +561,7 @@ func TestCheckScheduleschedule_InvalidForecastHorizon(t *testing.T) {
 	forecast_horizon = "invalid_horizon"
 	defer func() { forecast_horizon = oldForecastHorizon }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forecast_horizon")
 }
@@ -582,7 +582,7 @@ func TestCheckScheduleschedule_InvalidConsumptionHorizon(t *testing.T) {
 	consumption_horizon = "invalid_horizon"
 	defer func() { consumption_horizon = oldConsumptionHorizon }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "consumption_horizon")
 }
@@ -758,7 +758,7 @@ func TestCheckScheduleschedule_NegativePWLWT(t *testing.T) {
 	pw_lwt = -1
 	defer func() { pw_lwt = oldPwLwt }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_lwt")
 }
@@ -779,7 +779,7 @@ func TestCheckScheduleschedule_NegativePWUPT(t *testing.T) {
 	pw_upt = -1
 	defer func() { pw_upt = oldPwUpt }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_upt")
 }
@@ -800,7 +800,7 @@ func TestCheckScheduleschedule_NegativePWBattReserve(t *testing.T) {
 	pw_batt_reserve = -1
 	defer func() { pw_batt_reserve = oldPwBR }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, -1, "00:00", "23:59", nil)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, -1, "00:00", "23:59", nil, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_batt_reserve")
 }
@@ -822,7 +822,7 @@ func TestCheckScheduleschedule_WithWindowsValidates(t *testing.T) {
 	windows := []pw.Window{
 		{Name: "morning", Start: "06:00", End: "08:00", MaxCharge: 3500},
 	}
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", windows)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", windows, "crontab")
 	require.NoError(t, err)
 }
 
@@ -842,7 +842,7 @@ func TestCheckScheduleschedule_InvalidWindows(t *testing.T) {
 	windows := []pw.Window{
 		{Start: "bad", End: "also_bad", MaxCharge: -1},
 	}
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "", "", windows)
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "", "", windows, "crontab")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "windows")
 }

--- a/pkg/cmd/schedule_test.go
+++ b/pkg/cmd/schedule_test.go
@@ -444,7 +444,7 @@ func TestSchedule_ForecastErrorDisablesForecastButStillCallsFronius(t *testing.T
 }
 
 func TestMakeBasePayloadSetsCommonFields(t *testing.T) {
-	p := makeBasePayload("idle", "outside window", true, false)
+	p := makeBasePayload("idle", "outside window", true, false, "crontab")
 
 	assert.Equal(t, "idle", p.LastDecision)
 	assert.Equal(t, "outside window", p.LastDecisionReason)

--- a/pkg/cmd/schedule_validation_test.go
+++ b/pkg/cmd/schedule_validation_test.go
@@ -8,30 +8,30 @@ import (
 )
 
 type scheduleValidationArgs struct {
-	crontab        string
-	apiKey         string
-	url            string
-	froniusIP      string
-	pwConsumption  float64
-	maxCharge      float64
-	pwBattReserve  float64
-	startHr        string
-	endHr          string
-	schedulerMode  string
+	crontab       string
+	apiKey        string
+	url           string
+	froniusIP     string
+	pwConsumption float64
+	maxCharge     float64
+	pwBattReserve float64
+	startHr       string
+	endHr         string
+	schedulerMode string
 }
 
 func validScheduleValidationArgs() scheduleValidationArgs {
 	return scheduleValidationArgs{
-		crontab:        "0 0 * * *",
-		apiKey:         "key",
-		url:            "https://example.test/forecast",
-		froniusIP:      "127.0.0.1",
-		pwConsumption:  1000,
-		maxCharge:      3500,
-		pwBattReserve:  200,
-		startHr:        "00:00",
-		endHr:          "23:59",
-		schedulerMode:  "crontab",
+		crontab:       "0 0 * * *",
+		apiKey:        "key",
+		url:           "https://example.test/forecast",
+		froniusIP:     "127.0.0.1",
+		pwConsumption: 1000,
+		maxCharge:     3500,
+		pwBattReserve: 200,
+		startHr:       "00:00",
+		endHr:         "23:59",
+		schedulerMode: "crontab",
 	}
 }
 

--- a/pkg/cmd/schedule_validation_test.go
+++ b/pkg/cmd/schedule_validation_test.go
@@ -8,28 +8,30 @@ import (
 )
 
 type scheduleValidationArgs struct {
-	crontab       string
-	apiKey        string
-	url           string
-	froniusIP     string
-	pwConsumption float64
-	maxCharge     float64
-	pwBattReserve float64
-	startHr       string
-	endHr         string
+	crontab        string
+	apiKey         string
+	url            string
+	froniusIP      string
+	pwConsumption  float64
+	maxCharge      float64
+	pwBattReserve  float64
+	startHr        string
+	endHr          string
+	schedulerMode  string
 }
 
 func validScheduleValidationArgs() scheduleValidationArgs {
 	return scheduleValidationArgs{
-		crontab:       "0 0 * * *",
-		apiKey:        "key",
-		url:           "https://example.test/forecast",
-		froniusIP:     "127.0.0.1",
-		pwConsumption: 1000,
-		maxCharge:     3500,
-		pwBattReserve: 200,
-		startHr:       "00:00",
-		endHr:         "23:59",
+		crontab:        "0 0 * * *",
+		apiKey:         "key",
+		url:            "https://example.test/forecast",
+		froniusIP:      "127.0.0.1",
+		pwConsumption:  1000,
+		maxCharge:      3500,
+		pwBattReserve:  200,
+		startHr:        "00:00",
+		endHr:          "23:59",
+		schedulerMode:  "crontab",
 	}
 }
 
@@ -70,7 +72,8 @@ func TestCheckScheduleScheduleValid(t *testing.T) {
 		args.pwBattReserve,
 		args.startHr,
 		args.endHr,
-		nil)
+		nil,
+		args.schedulerMode)
 
 	require.NoError(t, err)
 }
@@ -180,6 +183,16 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 			setup:     func(t *testing.T) { withScheduleValidationGlobals(t, "05:00", "06:00", 0, 0, -1) },
 			errSubstr: "cache_time",
 		},
+		{
+			name:      "scheduler_mode auto rejected",
+			prepare:   func(a *scheduleValidationArgs) { a.schedulerMode = "auto" },
+			errSubstr: "#149",
+		},
+		{
+			name:      "scheduler_mode unknown value",
+			prepare:   func(a *scheduleValidationArgs) { a.schedulerMode = "invalid" },
+			errSubstr: "unknown scheduler_mode",
+		},
 	}
 
 	for _, tc := range cases {
@@ -204,7 +217,8 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 				args.pwBattReserve,
 				args.startHr,
 				args.endHr,
-				nil)
+				nil,
+				args.schedulerMode)
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errSubstr)
@@ -228,7 +242,8 @@ func TestCheckScheduleScheduleCrossMidnightChargeWindowValid(t *testing.T) {
 		args.pwBattReserve,
 		args.startHr,
 		args.endHr,
-		nil)
+		nil,
+		args.schedulerMode)
 
 	require.NoError(t, err)
 }
@@ -294,7 +309,8 @@ func TestCheckScheduleScheduleReserveWindowContainment(t *testing.T) {
 				args.pwBattReserve,
 				args.startHr,
 				args.endHr,
-				nil)
+				nil,
+				args.schedulerMode)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/mqtt/discovery.go
+++ b/pkg/mqtt/discovery.go
@@ -79,7 +79,7 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	forceChargeCommandTemplate := `{% set target = states('number.sbam_force_charge_target_pct') | int(100) %}{% if target > 100 %}{"target_pct":100,"ignore_max_charge":true}{% elif target < 0 %}{"target_pct":0}{% else %}{"target_pct":{{ target }}}{% endif %}`
 	pauseCommandTemplate := `{% set seconds = states('number.sbam_pause_duration_s') | int(0) %}{% if seconds <= 0 %}{}{% else %}{"until":"{{ seconds }}s"}{% endif %}`
 
-	entities := make([]DiscoveryEntity, 0, 20)
+	entities := make([]DiscoveryEntity, 0, 21)
 
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "battery_soc_pct", sensorPayload(base, deviceID, "battery_soc_pct", "Battery SoC", "{{ value_json.battery_soc_pct }}", "%", "battery", "measurement", ""))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "battery_capacity_wh", sensorPayload(base, deviceID, "battery_capacity_wh", "Battery Capacity", "{{ value_json.battery_capacity_wh }}", "Wh", "", "measurement", ""))
@@ -89,6 +89,7 @@ func BuildDiscovery(cfg Config, version string) []DiscoveryEntity {
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "last_decision", sensorPayload(base, deviceID, "last_decision", "Last Decision", "{{ value_json.last_decision }}", "", "", "", "diagnostic"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "forecast_horizon", sensorPayload(base, deviceID, "forecast_horizon", "Forecast Horizon", "{{ value_json.forecast_horizon }}", "", "", "", "diagnostic"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "consumption_horizon", sensorPayload(base, deviceID, "consumption_horizon", "Consumption Horizon", "{{ value_json.consumption_horizon }}", "", "", "", "diagnostic"))
+	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "scheduler_mode", sensorPayload(base, deviceID, "scheduler_mode", "Scheduler Mode", "{{ value_json.scheduler_mode }}", "", "", "", "diagnostic"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "active_window", sensorPayload(base, deviceID, "active_window", "Active Window", "{{ value_json.active_window }}", "", "", "", "diagnostic"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "active_window_max_charge", sensorPayload(base, deviceID, "active_window_max_charge", "Active Window Max Charge", "{{ value_json.active_window_max_charge }}", "W", "", "", "diagnostic"))
 	entities = appendDiscoveryEntity(entities, discoveryPrefix, "sensor", "active_window_forecast_horizon", sensorPayload(base, deviceID, "active_window_forecast_horizon", "Active Window Forecast Horizon", "{{ value_json.active_window_forecast_horizon }}", "", "", "", "diagnostic"))

--- a/pkg/mqtt/discovery_test.go
+++ b/pkg/mqtt/discovery_test.go
@@ -185,6 +185,7 @@ func TestBuildDiscoveryTemplatesAndPublish(t *testing.T) {
 		"active_window_forecast_horizon",
 		"charge_window_active",
 		"batt_reserve_window_active",
+			"scheduler_mode",
 		"active_window",
 		"active_window_max_charge",
 		"active_window_forecast_horizon",

--- a/pkg/mqtt/discovery_test.go
+++ b/pkg/mqtt/discovery_test.go
@@ -185,7 +185,7 @@ func TestBuildDiscoveryTemplatesAndPublish(t *testing.T) {
 		"active_window_forecast_horizon",
 		"charge_window_active",
 		"batt_reserve_window_active",
-			"scheduler_mode",
+		"scheduler_mode",
 		"active_window",
 		"active_window_max_charge",
 		"active_window_forecast_horizon",

--- a/pkg/mqtt/types.go
+++ b/pkg/mqtt/types.go
@@ -35,6 +35,8 @@ type StatePayload struct {
 	ActiveWindowForecastHorizon *string    `json:"active_window_forecast_horizon,omitempty"`
 	ChargeWindowActive          *bool      `json:"charge_window_active"`
 	ReserveWindowActive         *bool      `json:"batt_reserve_window_active"`
+	SchedulerMode               *string    `json:"scheduler_mode,omitempty"`
+	DeprecationWarning          *string    `json:"deprecation_warning,omitempty"`
 	Paused                      bool       `json:"paused"`
 	NextRun                     *time.Time `json:"next_run"`
 	Timestamp                   time.Time  `json:"ts"`

--- a/pkg/power/window.go
+++ b/pkg/power/window.go
@@ -118,6 +118,24 @@ func ValidateWindows(windows []Window) error {
 		}
 	}
 
+	// Reject configurations where one window's end equals another window's start.
+	for i := range windows {
+		endTime, _ := parseClock(windows[i].End)
+		endMin := clockMinute(endTime)
+		for j := range windows {
+			if i == j {
+				continue
+			}
+			startTime, _ := parseClock(windows[j].Start)
+			if clockMinute(startTime) == endMin {
+				ni := WindowNameOrDefault(windows[i], i)
+				nj := WindowNameOrDefault(windows[j], j)
+				return fmt.Errorf("window %q end %s equals window %q start %s",
+					ni, windows[i].End, nj, windows[j].Start)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/power/window.go
+++ b/pkg/power/window.go
@@ -52,7 +52,7 @@ type Window struct {
 	ConsumptionHorizon string  `json:"consumption_horizon,omitempty" yaml:"consumption_horizon,omitempty" mapstructure:"consumption_horizon,omitempty"`
 	TickMinutes        *int    `json:"tick_minutes,omitempty" yaml:"tick_minutes,omitempty" mapstructure:"tick_minutes,omitempty"`
 	Defaults           *bool   `json:"set_defaults,omitempty" yaml:"set_defaults,omitempty" mapstructure:"set_defaults,omitempty"`
-	BeforeEndDefaults  *int    `json:"before_end_defaults,omitempty" yaml:"before_end_defaults,omitempty" mapstructure:"before_end_defaults,omitempty"`
+	BeforeEndDefaults  *int    `json:"before_end_defaults_minutes,omitempty" yaml:"before_end_defaults_minutes,omitempty" mapstructure:"before_end_defaults_minutes,omitempty"`
 }
 
 // ValidateWindows checks a non-empty ordered list of charge windows and

--- a/pkg/power/window.go
+++ b/pkg/power/window.go
@@ -31,6 +31,18 @@ type clockSegment struct {
 //
 // ForecastHorizon and ConsumptionHorizon are optional per-window overrides.
 // When empty the top-level forecast_horizon / consumption_horizon is used.
+//
+// TickMinutes is an optional per-window tick interval override (minutes).
+// Only used when scheduler_mode is "windows". Defaults to 60 when unset.
+// Must be ≥ 1 when set.
+//
+// Defaults enables a per-window set_defaults reset. Only used when
+// scheduler_mode is "windows". When true, BeforeEndDefaults controls how
+// many minutes before the window's end the reset fires.
+//
+// BeforeEndDefaults is the number of minutes before the window's end time
+// to fire the set_defaults reset. Only meaningful when Defaults is true.
+// Defaults to 5 when unset. Must be ≥ 0 when set (0 = at window end).
 type Window struct {
 	Name               string  `json:"name" yaml:"name" mapstructure:"name"`
 	Start              string  `json:"start" yaml:"start" mapstructure:"start"`
@@ -38,6 +50,9 @@ type Window struct {
 	MaxCharge          float64 `json:"max_charge" yaml:"max_charge" mapstructure:"max_charge"`
 	ForecastHorizon    string  `json:"forecast_horizon,omitempty" yaml:"forecast_horizon,omitempty" mapstructure:"forecast_horizon,omitempty"`
 	ConsumptionHorizon string  `json:"consumption_horizon,omitempty" yaml:"consumption_horizon,omitempty" mapstructure:"consumption_horizon,omitempty"`
+	TickMinutes        *int    `json:"tick_minutes,omitempty" yaml:"tick_minutes,omitempty" mapstructure:"tick_minutes,omitempty"`
+	Defaults           *bool   `json:"defaults,omitempty" yaml:"defaults,omitempty" mapstructure:"defaults,omitempty"`
+	BeforeEndDefaults  *int    `json:"before_end_defaults,omitempty" yaml:"before_end_defaults,omitempty" mapstructure:"before_end_defaults,omitempty"`
 }
 
 // ValidateWindows checks a non-empty ordered list of charge windows and
@@ -127,6 +142,12 @@ func validateWindowFields(w Window) error {
 		if _, err := ValidateConsumptionHorizon(w.ConsumptionHorizon); err != nil {
 			return err
 		}
+	}
+	if w.TickMinutes != nil && *w.TickMinutes <= 0 {
+		return fmt.Errorf("tick_minutes must be >= 1, got %d", *w.TickMinutes)
+	}
+	if w.BeforeEndDefaults != nil && *w.BeforeEndDefaults < 0 {
+		return fmt.Errorf("before_end_defaults must be >= 0, got %d", *w.BeforeEndDefaults)
 	}
 	return nil
 }

--- a/pkg/power/window.go
+++ b/pkg/power/window.go
@@ -51,7 +51,7 @@ type Window struct {
 	ForecastHorizon    string  `json:"forecast_horizon,omitempty" yaml:"forecast_horizon,omitempty" mapstructure:"forecast_horizon,omitempty"`
 	ConsumptionHorizon string  `json:"consumption_horizon,omitempty" yaml:"consumption_horizon,omitempty" mapstructure:"consumption_horizon,omitempty"`
 	TickMinutes        *int    `json:"tick_minutes,omitempty" yaml:"tick_minutes,omitempty" mapstructure:"tick_minutes,omitempty"`
-	Defaults           *bool   `json:"defaults,omitempty" yaml:"defaults,omitempty" mapstructure:"defaults,omitempty"`
+	Defaults           *bool   `json:"set_defaults,omitempty" yaml:"set_defaults,omitempty" mapstructure:"set_defaults,omitempty"`
 	BeforeEndDefaults  *int    `json:"before_end_defaults,omitempty" yaml:"before_end_defaults,omitempty" mapstructure:"before_end_defaults,omitempty"`
 }
 

--- a/pkg/power/window_test.go
+++ b/pkg/power/window_test.go
@@ -135,23 +135,66 @@ func TestValidateWindows_CrossMidnightOverlapRejected(t *testing.T) {
 }
 
 func TestValidateWindows_AdjacentNonOverlapping(t *testing.T) {
-	// Adjacent windows sharing a boundary point are NOT overlapping
-	// because half-open intervals are used for overlap detection.
+	// Adjacent windows sharing a boundary point are now rejected (R6).
 	windows := []Window{
 		{Name: "A", Start: "02:00", End: "06:00", MaxCharge: 1000},
 		{Name: "B", Start: "06:00", End: "10:00", MaxCharge: 2000},
 	}
 	err := ValidateWindows(windows)
-	assert.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "end 06:00 equals window \"B\" start 06:00")
 }
 
 func TestValidateWindows_CrossMidnightAdjacentNonOverlapping(t *testing.T) {
+	// Adjacent windows sharing a boundary point across midnight are now rejected (R6).
 	windows := []Window{
 		{Name: "night", Start: "22:00", End: "04:00", MaxCharge: 3000},
 		{Name: "early", Start: "04:00", End: "08:00", MaxCharge: 2000},
 	}
 	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "end 04:00 equals window \"early\" start 04:00")
+}
+
+func TestValidateWindows_EqualBoundaryBetweenFirstAndSecond(t *testing.T) {
+	windows := []Window{
+		{Name: "A", Start: "06:00", End: "12:00", MaxCharge: 1000},
+		{Name: "B", Start: "12:00", End: "18:00", MaxCharge: 2000},
+		{Name: "C", Start: "18:01", End: "22:00", MaxCharge: 1500},
+	}
+	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "equals")
+}
+
+func TestValidateWindows_AdjacentNonEqualBoundariesPasses(t *testing.T) {
+	windows := []Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+	err := ValidateWindows(windows)
 	assert.NoError(t, err)
+}
+
+func TestValidateWindows_SingleWindowPasses(t *testing.T) {
+	windows := []Window{
+		{Name: "only", Start: "06:00", End: "22:00", MaxCharge: 3000},
+	}
+	err := ValidateWindows(windows)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_EqualBoundaryNonAdjacentRejected(t *testing.T) {
+	// Non-adjacent windows in list order can still share a boundary.
+	// A and C share a boundary; B sits between them in list order with no overlap.
+	windows := []Window{
+		{Name: "A", Start: "06:00", End: "10:00", MaxCharge: 1000},
+		{Name: "B", Start: "14:00", End: "18:00", MaxCharge: 2000},
+		{Name: "C", Start: "10:00", End: "12:00", MaxCharge: 1500},
+	}
+	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "equals")
 }
 
 // --- Individual field validation tests ---

--- a/pkg/power/window_test.go
+++ b/pkg/power/window_test.go
@@ -250,7 +250,7 @@ func TestValidateWindows_CrossMidnightValid(t *testing.T) {
 
 // --- Windows-mode field validation tests ---
 
-func intPtr(v int) *int   { return &v }
+func intPtr(v int) *int    { return &v }
 func boolPtr(v bool) *bool { return &v }
 
 func TestValidateWindows_TickMinutesValid(t *testing.T) {

--- a/pkg/power/window_test.go
+++ b/pkg/power/window_test.go
@@ -247,3 +247,71 @@ func TestValidateWindows_CrossMidnightValid(t *testing.T) {
 	err := ValidateWindows(windows)
 	assert.NoError(t, err)
 }
+
+// --- Windows-mode field validation tests ---
+
+func intPtr(v int) *int   { return &v }
+func boolPtr(v bool) *bool { return &v }
+
+func TestValidateWindows_TickMinutesValid(t *testing.T) {
+	windows := []Window{
+		{Name: "fast", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(30)},
+	}
+	err := ValidateWindows(windows)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_TickMinutesZeroRejected(t *testing.T) {
+	windows := []Window{
+		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(0)},
+	}
+	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tick_minutes")
+}
+
+func TestValidateWindows_TickMinutesNegativeRejected(t *testing.T) {
+	windows := []Window{
+		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(-1)},
+	}
+	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tick_minutes")
+}
+
+func TestValidateWindows_DefaultsAndBeforeEndValid(t *testing.T) {
+	windows := []Window{
+		{Name: "with-defaults", Start: "06:00", End: "07:00", MaxCharge: 3500,
+			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(10)},
+	}
+	err := ValidateWindows(windows)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_BeforeEndDefaultsZeroValid(t *testing.T) {
+	windows := []Window{
+		{Name: "at-end", Start: "06:00", End: "07:00", MaxCharge: 3500,
+			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(0)},
+	}
+	err := ValidateWindows(windows)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_BeforeEndDefaultsNegativeRejected(t *testing.T) {
+	windows := []Window{
+		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500,
+			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(-1)},
+	}
+	err := ValidateWindows(windows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "before_end_defaults")
+}
+
+func TestValidateWindows_NewFieldsOptional(t *testing.T) {
+	// A window without any of the new fields should still validate.
+	windows := []Window{
+		{Name: "plain", Start: "06:00", End: "07:00", MaxCharge: 3500},
+	}
+	err := ValidateWindows(windows)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## What

Add a `scheduler_mode` config key (`crontab` | `windows` | `auto`) that explicitly selects how the schedule runner is driven, with a deprecation path for the legacy crontab. In windows mode, window transitions are now detected at exact boundary times and the system fires a tick immediately on startup — no more idle gaps or delayed charge windows.

Close #147 as Part of the v2.1.0 Foundation milestone (#151).

### Planning (committed)

- **Scheduler mode requirements** (`docs/brainstorms/2026-06-11-scheduler-mode-selector-requirements.md`) — 13 requirements (R1-R13), 8 acceptance examples, 3 key flows
- **Scheduler mode plan** (`docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md`) — 6 units, 8 key technical decisions
- **Window transition timing requirements** (`docs/brainstorms/2026-06-13-window-transition-timing-requirements.md`) — 7 requirements (R1-R7), 5 acceptance examples
- **Window transition timing plan** (`docs/plans/2026-06-13-001-feat-window-transition-timing-plan.md`) — 3 units, 4 key technical decisions

### Summary of what's being built

- `scheduler_mode` config key: `crontab` (default), `windows`, `auto` (hidden)
- Crontab mode: preserves v2.1 behavior, logs deprecation WARN + MQTT attribute
- Windows mode: internal `time.Ticker` replaces cron, per-window `tick_minutes` override, per-window set_defaults via `defaults` / `before_end_defaults`
- Auto mode: defined internally, rejected at startup with pointer to #149
- MQTT state payload gains `scheduler_mode` and `deprecation_warning` fields
- HA add-on schema gains `scheduler_mode` enum and new window fields

### New in this push — precise window transitions

The windows-mode ticker now handles three timing gaps:

- **Immediate tick on startup.** When sbam starts mid-window (e.g., 06:20), a tick fires immediately instead of waiting a full `tick_minutes` interval.
- **Exact boundary transitions.** A one-shot boundary timer detects window start times at the wall-clock boundary (e.g., 22:00 sharp), independent of the periodic tick interval. No more transition lag of up to 30 minutes.
- **Equal-boundary validation.** `ValidateWindows` rejects configurations where one window's end equals another's start (e.g., day end 22:00, night start 22:00), eliminating the ambiguity where both windows are active at the same minute.

The existing `set_defaults` timer and cooldown logic are unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
