### PR TITLE
feat: add HA dev image CI workflow and rename pre-release tag

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -1,0 +1,86 @@
+name: Dev Image
+
+on:
+  push:
+    branches:
+      - "release/**"
+      - "**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build-ha-dev:
+    if: |
+      startsWith(github.ref, 'refs/heads/release/') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.head_commit != null && startsWith(github.event.head_commit.message, '[build-ha]'))
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        goarch:
+          - amd64
+          - arm64
+        goos:
+          - linux
+        include:
+          - goarch: amd64
+            haarch: amd64
+            platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - goarch: arm64
+            haarch: aarch64
+            platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          RAW_BRANCH="${GITHUB_REF#refs/heads/}"
+          NORMALIZED=$(echo "$RAW_BRANCH" | tr '/' '-' | tr -cs 'a-zA-Z0-9-' '-' | sed 's/-$//')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "sha_tag=${NORMALIZED}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "latest_tag=${NORMALIZED}-latest" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+
+      - name: GoReleaser Install
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          install-only: true
+
+      - name: GoReleaser Build ${{ matrix.goos }}, ${{ matrix.goarch }}
+        run: |
+          mkdir home-assistant/addons/sbam/bin
+          goreleaser build --clean --single-target --output home-assistant/addons/sbam/bin/sbam
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+
+      - name: Build add-on image ${{ matrix.haarch }}
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.goarch }}
+          image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
+          image-tags: |
+            ${{ steps.tags.outputs.sha_tag }}
+            ${{ steps.tags.outputs.latest_tag }}
+          version: ${{ steps.tags.outputs.sha_tag }}
+          context: home-assistant/addons/sbam
+          cosign: "false"
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          push: "true"
+          build-args: |
+            BUILD_FROM=ghcr.io/home-assistant/${{ matrix.haarch }}-base
+            PLATFORM=${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           image: ghcr.io/${{ github.repository_owner }}/ha-${{ matrix.haarch }}-sbam
           image-tags: |
             ${{ env.VERSION }}
-            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'dev' }}
+            ${{ needs.determine-release.outputs.release == 'latest' && 'latest' || 'pre-release' }}
           version: ${{ env.VERSION }}
           context: home-assistant/addons/sbam
           cosign: "false"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/dev-image.yml` that builds multi-arch HA add-on Docker images (amd64 + aarch64) on `release/**` branches automatically, on any branch whose commit message starts with `[build-ha]`, and via `workflow_dispatch`
- Images are tagged `<normalized-branch>-<short-sha>` and `<normalized-branch>-latest`, where the branch name is normalized by replacing `/` and non-alphanumeric characters with `-`
- Update `.github/workflows/release.yml` line 104: rename the pre-release fallback tag from `dev` to `pre-release` to prevent tag collisions with the new dev workflow

## Why this matters

Currently the HA add-on image only builds on tag pushes (releases), making it impossible to validate multi-arch image builds during feature or fix branch development. Developers had no way to catch image-build failures before cutting a release. This adds an opt-in CI path (`[build-ha]` prefix) for any branch and an automatic path for `release/**` branches, closing the feedback loop before tagging.

Fixes #155
