### PR TITLE
feat(power,cmd): add weekday filtering to charge windows

### DIFF
--- a/docs/brainstorms/2026-06-17-weekday-windows-requirements.md
+++ b/docs/brainstorms/2026-06-17-weekday-windows-requirements.md
@@ -1,0 +1,182 @@
+---
+date: 2026-06-17
+topic: weekday-windows
+---
+
+## Summary
+
+Add optional `weekdays` filtering to charge windows so users can configure
+different charging behavior on different days of the week. The feature is
+gated behind `weekday_feature` (default `true`) as a kill switch.
+
+## Requirements
+
+### Configuration
+
+- R1. Each window accepts an optional `weekdays` field. When absent or
+  empty, the window is active every day (backward compatible).
+- R2. `weekdays` accepts one or more weekdays in any combination of:
+  - `mon` — single day
+  - `mon,fri` — comma-separated individual days
+  - `mon-fri` — inclusive range
+  - `mon-fri,sun` — range and individual day combined
+- R3. Day names use lowercase 3-letter English abbreviations:
+  `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun`.
+
+### Resolution (Start-Day Model)
+
+- R4. A window's weekday applies to the **day the window starts**. For a
+  same-day window this is the current calendar day. For a cross-midnight
+  window, the post-midnight portion inherits the start day — `23:00–03:00`
+  on `fri` means Friday 23:00 through Saturday 03:00.
+
+### Validation
+
+- R5. `ValidateWindows` rejects unknown weekday tokens (e.g., `mon-fri,xyz`)
+  with a message naming the invalid token.
+- R6. `ValidateWindows` rejects empty elements (`mon,,fri`) with a message
+  naming the offending entry.
+- R7. `ValidateWindows` does not flag two windows as overlapping when their
+  weekday sets are disjoint, even if their clock ranges overlap.
+
+### Scheduling
+
+- R8. `ResolveActiveWindow` returns `nil` for a window whose weekday set
+  does not include the resolved start day.
+- R9. `scheduleBoundaryTick` computes the next future time a window starts on
+  a matching weekday, across multiple days if needed, and picks the earliest.
+
+### Feature Flag
+
+- R10. `weekday_feature` is a top-level boolean (default `true`). When
+  `false`, the `weekdays` field is ignored at validation and resolution
+  time — all windows are active every day.
+- R11. When `weekday_feature` is `false`, `ValidateWindows` skips weekday
+  token validation and does not perform weekday-set overlap skipping.
+
+## Key Decisions
+
+- **Start-day model.** A window is active on the weekday its `start` time
+  falls on, regardless of whether `end` spills into the next day. This avoids
+  splitting cross-midnight windows into two unintuitive entries.
+- **Format: single, comma, range.** Parsing accepts `mon`, `mon,fri`,
+  `mon-fri`, and `mon-fri,sun`. Ranges are always start–end (mon–fri, not
+  fri–mon). Overlapping ranges are flattened so `mon-wed,tue-thu` produces
+  `[mon, tue, wed, thu]`.
+- **Feature flag default true.** The flag ships enabled. It exists as a
+  maintainer kill switch — set to `false` in `config.yaml` to disable all
+  weekday logic without a code change.
+- **Omitted = all days.** An empty or absent `weekdays` field means the
+  window is active every day. Existing configs work without modification.
+
+## Acceptance Examples
+
+### AE1. Beta-tester use case — weekday cross-midnight
+
+```yaml
+weekday_feature: true
+scheduler_mode: windows
+windows:
+  - name: "weekday-offpeak"
+    start: "21:00"
+    end: "07:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+```
+
+| Time | Active? | Why |
+|---|---|---|
+| Monday 22:00 | Yes | Start day is Monday, in range |
+| Tuesday 03:00 | Yes | Start-day Monday's post-midnight tail |
+| Friday 23:00 | Yes | Start day is Friday |
+| Saturday 01:00 | No | Friday's window ended at 07:00 Saturday — Sat not in mon-fri |
+| Saturday 22:00 | No | Saturday not in mon-fri |
+| Sunday 22:00 | No | Sunday not in mon-fri |
+
+### AE2. Weekend-only daytime (no cross-midnight)
+
+```yaml
+windows:
+  - name: "weekend-solar"
+    start: "06:00"
+    end: "22:00"
+    max_charge: 0
+    weekdays: "sat,sun"
+```
+
+Saturday 12:00 → active. Monday 12:00 → not active (Mon not in sat,sun).
+
+### AE3. Same clock range, different weekdays — no overlap error
+
+```yaml
+windows:
+  - name: "weekday-night"
+    start: "22:00"
+    end: "04:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+  - name: "weekend-night"
+    start: "22:00"
+    end: "04:00"
+    max_charge: 5000
+    weekdays: "sat,sun"
+```
+
+Validation passes. The clock ranges overlap but the weekday sets are
+disjoint, so the windows never collide on the same calendar day.
+
+### AE4. Single-day special rate
+
+```yaml
+windows:
+  - name: "wed-free-power"
+    start: "12:00"
+    end: "15:00"
+    max_charge: 5000
+    weekdays: "wed"
+```
+
+Active only on Wednesday 12:00–15:00. All other days this window is
+invisible to the scheduler.
+
+### AE5. Mixed weekday/weekend with day-only windows
+
+```yaml
+windows:
+  - name: "weekday-morning"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+  - name: "weekend-morning"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 5000
+    weekdays: "sat,sun"
+  - name: "sunday-extended"
+    start: "06:00"
+    end: "10:00"
+    max_charge: 4000
+    weekdays: "sun"
+```
+
+Three windows at the same clock times but different day assignments. All
+validate without overlap errors. The scheduler picks the one matching the
+current day.
+
+## Scope Boundaries
+
+- Weekday filtering applies to window activation only. It does not affect
+  forecast horizon resolution, MQTT discovery, or Modbus operations.
+- Holiday calendars, timezone-aware day-boundary logic, and UI-based
+  scheduling are out of scope.
+
+## Dependencies / Assumptions
+
+- The existing `Window` struct, `ResolveActiveWindow`, `ValidateWindows`,
+  and `scheduleBoundaryTick` in `pkg/power/window.go` and
+  `pkg/cmd/schedule_runner.go` provide the integration points.
+- `time.Weekday()` provides the day-of-week source. Cross-midnight
+  resolution uses `now.Add(-24h).Weekday()` for the post-midnight check.
+- The `scheduler_mode: windows` path is the primary beneficiary. Crontab
+  mode with legacy `start_hr`/`end_hr` is unaffected.

--- a/docs/plans/2026-06-17-001-feat-weekday-windows-plan.md
+++ b/docs/plans/2026-06-17-001-feat-weekday-windows-plan.md
@@ -1,0 +1,335 @@
+---
+title: "feat: Add weekday filtering to charge windows"
+type: feat
+date: 2026-06-17
+origin: docs/brainstorms/2026-06-17-weekday-windows-requirements.md
+---
+
+## Summary
+
+Add an optional `weekdays` field to charge windows so users can configure
+different charging behavior on different days of the week. The feature is
+gated behind `weekday_feature` (default `true`) as a maintainer kill switch.
+
+## Problem Frame
+
+Beta tester feedback from
+[discussion #164](https://github.com/atbore-phx/sbam/discussions/164): the
+multi-window scheduler supports cross-midnight windows but cannot distinguish
+weekdays from weekends. A user with off-peak rates Monday–Friday needs
+different charge windows than on Saturday–Sunday. Without weekday filtering,
+the only workaround is running separate sbam instances with different configs.
+
+## Requirements
+
+### Configuration
+
+- R1. Each window accepts an optional `weekdays` field. When absent or empty,
+  the window is active every day.
+- R2. `weekdays` accepts any combination of single days (`mon`), comma lists
+  (`mon,fri`), inclusive ranges (`mon-fri`), and mixed (`mon-fri,sun`).
+- R3. Day names use lowercase 3-letter English abbreviations.
+
+### Resolution (Start-Day Model)
+
+- R4. A window's weekday applies to the day the window starts. Cross-midnight
+  windows inherit the start day throughout — `23:00–03:00` on `fri` means
+  Friday 23:00 through Saturday 03:00.
+
+### Validation
+
+- R5. `ValidateWindows` rejects unknown weekday tokens.
+- R6. `ValidateWindows` rejects empty elements (`mon,,fri`).
+- R7. `ValidateWindows` does not flag two windows as overlapping when their
+  weekday sets are disjoint, even if clock ranges overlap.
+
+### Scheduling
+
+- R8. `ResolveActiveWindow` returns `nil` for a window whose weekday set does
+  not include the resolved start day.
+- R9. `scheduleBoundaryTick` computes the next future time a window starts on
+  a matching weekday, across multiple days if needed, and picks the earliest.
+
+### Feature Flag
+
+- R10. `weekday_feature` is a top-level boolean (default `true`). When
+  `false`, the `weekdays` field is ignored at validation and resolution.
+- R11. When `weekday_feature` is `false`, `ValidateWindows` skips weekday
+  token validation and does not adjust overlap detection.
+
+---
+
+## Key Technical Decisions
+
+- **Weekday stored as a raw string, parsed on demand.** The `Weekdays` field
+  is `string` with `omitempty`. Empty string means all days. Parsing into a
+  `map[time.Weekday]bool` set happens at validation and resolution time, not
+  at config load. This follows the existing `ForecastHorizon` /
+  `ConsumptionHorizon` pattern (string stored, validated at use).
+- **Start-day model for cross-midnight.** When a window crosses midnight, the
+  post-midnight portion uses the start day's weekday. Implementation: in
+  `ResolveActiveWindow`, for a cross-midnight window where `now` is before
+  `endAt` (post-midnight), resolve the weekday against `startAt` which is on
+  the previous calendar day.
+- **Feature flag gating at two chokepoints.** The `weekday_feature` bool is
+  checked at (a) `ValidateWindows` — controls whether weekday token validation
+  runs and whether disjoint-weekday overlap skipping activates, and (b)
+  `ResolveActiveWindow` call sites — controls whether the weekday filter is
+  applied. `scheduleBoundaryTick` inherits gating from `ResolveActiveWindow`.
+- **Weekday name resolution via explicit map.** A package-level
+  `map[string]time.Weekday` maps `"mon"`..`"sun"` to `time.Monday`..
+  `time.Sunday`. This avoids depending on `time.Weekday.String()` casing and
+  makes validation self-contained.
+
+---
+
+## Implementation Units
+
+### U1. Add Weekdays field and weekday parsing
+
+- **Goal:** Add the `Weekdays` field to the `Window` struct and implement
+  parsing/validation of the weekday string format.
+- **Requirements:** R1, R2, R3, R5, R6
+- **Dependencies:** none
+- **Files:**
+  - `pkg/power/window.go` — add `Weekdays` field, weekday name map,
+    `parseWeekdays` and `validateWeekdays` helpers
+  - `pkg/power/window_test.go` — parsing and validation tests
+- **Approach:**
+  - Add `Weekdays string` to the `Window` struct with
+    `json:"weekdays,omitempty" yaml:"weekdays,omitempty" mapstructure:"weekdays,omitempty"`
+  - Define `var weekdayNames = map[string]time.Weekday{...}` as a package-level map
+  - `parseWeekdays(s string) (map[time.Weekday]bool, error)` splits on comma,
+    expands ranges, deduplicates
+  - `validateWeekdays(s string) error` wraps `parseWeekdays` and returns an
+    error for unknown tokens or empty elements
+  - Call `validateWeekdays` from `validateWindowFields` when `w.Weekdays != ""`
+  - Ranges expand inclusively: `"mon-wed"` → `{Monday, Tuesday, Wednesday}`
+  - Overlapping ranges flatten: `"mon-wed,tue-thu"` → `{Mon, Tue, Wed, Thu}`
+- **Patterns to follow:** `validateWindowFields` early-return error pattern;
+  `ForecastHorizon`/`ConsumptionHorizon` validation pattern (validate at
+  struct level, use at resolution)
+- **Test scenarios:**
+  - Parse `"mon"` → `{Monday: true}`
+  - Parse `"mon,fri"` → `{Monday: true, Friday: true}`
+  - Parse `"mon-fri"` → 5 weekdays
+  - Parse `"mon-fri,sun"` → 6 days
+  - Parse `"mon-wed,tue-thu"` → flattened to 4 days
+  - Parse `""` → empty set (all days)
+  - Reject `"mon,xyz"` — unknown token
+  - Reject `"mon,,fri"` — empty element
+  - Reject `"MON"` — case-sensitive, lowercase only
+  - Reject `"mon-FRI"` — mixed case in range
+  - Parse `"mon-mon"` → `{Monday: true}` (single-day range)
+
+### U2. Add weekday filtering to ResolveActiveWindow
+
+- **Goal:** `ResolveActiveWindow` skips windows whose weekday set does not
+  include the start day.
+- **Requirements:** R4, R8, R10
+- **Dependencies:** U1
+- **Files:**
+  - `pkg/power/window.go` — modify `ResolveActiveWindow` to accept
+    `weekdayFeature bool` and apply the weekday filter
+  - `pkg/power/window_test.go` — resolution tests with weekday filtering
+- **Approach:**
+  - Add `weekdayFeature bool` parameter to `ResolveActiveWindow`
+  - When `weekdayFeature` is `true` and `w.Weekdays != ""`:
+    - Parse the weekday set (cache in a local var to avoid re-parsing across
+      loop iterations, or parse once)
+    - For cross-midnight windows where `now` is post-midnight (before `endAt`
+      on the same calendar day), determine the start day as
+      `now.Add(-24 * time.Hour).Weekday()`
+    - For same-day windows or the pre-midnight portion of cross-midnight,
+      use `now.Weekday()`
+    - If the resolved weekday is not in the set, `continue` to the next window
+  - When `weekdayFeature` is `false`, skip the weekday check entirely
+  - Update all call sites (`Runner.resolveActiveWindow`, test helpers)
+- **Patterns to follow:** Existing `ResolveActiveWindow` iteration and
+  cross-midnight detection logic.
+- **Test scenarios:**
+  - Window with `weekdays: "mon-fri"` active at Monday 12:00
+  - Window with `weekdays: "mon-fri"` not active at Saturday 12:00
+  - Cross-midnight `weekdays: "fri"`, `start: "22:00"`, `end: "04:00"`:
+    active at Friday 23:00 and Saturday 03:00
+  - Cross-midnight `weekdays: "fri"` not active at Saturday 23:00 (start day
+    is Sat, not in set)
+  - Empty `weekdays` — active every day (backward compatible)
+  - `weekdayFeature: false` — window active regardless of `weekdays` value
+
+### U3. Add weekday-aware overlap skip to ValidateWindows
+
+- **Goal:** `ValidateWindows` skips overlap detection when two windows have
+  disjoint weekday sets.
+- **Requirements:** R7, R11
+- **Dependencies:** U1
+- **Files:**
+  - `pkg/power/window.go` — modify `ValidateWindows` to accept
+    `weekdayFeature bool` and add the disjoint-weekday guard
+  - `pkg/power/window_test.go` — overlap tests with weekday sets
+- **Approach:**
+  - Add `weekdayFeature bool` parameter to `ValidateWindows`
+  - In the overlap detection inner loop (where `a` and `b` are compared),
+    when `weekdayFeature` is `true` and both windows have non-empty
+    `Weekdays`, parse both weekday sets. If they have no intersection, skip
+    the overlap check for this pair (`continue`)
+  - When either window has an empty `Weekdays` (all days), the sets always
+    intersect — proceed with normal overlap detection
+  - When `weekdayFeature` is `false`, skip the weekday-set check entirely
+  - Update all call sites (`checkScheduleschedule`, tests)
+- **Patterns to follow:** Existing `ValidateWindows` segment-sorting and
+  overlap-detection logic.
+- **Test scenarios:**
+  - Same clock range, different weekdays (`mon-fri` vs `sat,sun`) — no
+    overlap error
+  - Same clock range, overlapping weekdays (`mon-fri` vs `fri,sat`) —
+    overlap error
+  - Same clock range, both empty weekdays — overlap error (backward compatible)
+  - Same clock range, one empty one set — overlap error (empty = all days)
+  - `weekdayFeature: false`, overlapping weekdays exists — no overlap error
+    (weekday logic disabled, overlap passes)
+
+### U4. Add weekday-aware boundary tick advancement
+
+- **Goal:** `scheduleBoundaryTick` finds the next window start on a matching
+  weekday, advancing across days when needed.
+- **Requirements:** R9
+- **Dependencies:** U2
+- **Files:**
+  - `pkg/cmd/schedule_runner.go` — modify `scheduleBoundaryTick` to advance
+    past non-matching weekdays
+  - `pkg/cmd/schedule_runner_test.go` — boundary tick tests with weekdays
+- **Approach:**
+  - In the "no active window" branch (iterating all windows for the next
+    start), after computing `startAt` for a candidate window:
+    - If `startAt` is not after `now`, advance by 24h
+    - If the window has a weekday set and `weekdayFeature` is enabled, advance
+      `startAt` day-by-day until its weekday matches the set
+  - In the "active window → next window" branch, after computing `nextAt`:
+    - If the next window has a weekday set, advance day-by-day until match
+    - The max scan is 7 days per window
+  - A helper `nextMatchingWeekday(t time.Time, weekdays map[time.Weekday]bool) time.Time`
+    advances `t` by 24h increments until `t.Weekday()` is in the set
+  - Read `weekdayFeature` from `r.cfg.WeekdayFeature`
+- **Patterns to follow:** Existing `scheduleBoundaryTick` structure —
+  candidate loop, `startAt` computation, `newTimerFunc` delay scheduling.
+- **Test scenarios:**
+  - Active window `mon-fri`, today is Friday — boundary targets the next
+    window's start on Monday
+  - No active window, today is Saturday, only weekday windows exist —
+    boundary targets Monday's first window start
+  - No active window, today is Saturday, weekend windows exist — boundary
+    targets Saturday's first matching window
+  - Single window `wed`, today is Tuesday — boundary targets Wednesday
+  - Windows with empty weekdays — boundary tick works as before (no
+    day-advancement)
+  - All windows have non-matching weekdays for the next 7 days — should
+    still find a valid target (weekday set is non-empty by validation)
+
+### U5. Wire weekday_feature flag through config and runner
+
+- **Goal:** Add `weekday_feature` as a top-level config key available via
+  CLI flag, env var, and config.yaml, and pass it through to all gated
+  call sites.
+- **Requirements:** R10, R11
+- **Dependencies:** U2, U3, U4
+- **Files:**
+  - `pkg/cmd/schedule.go` — package-level var, constant, CLI flag
+    registration, Viper read, pass to `checkScheduleschedule` and
+    `RunnerConfig`
+  - `pkg/cmd/schedule_runner.go` — add `WeekdayFeature bool` to
+    `RunnerConfig`, pass to `ResolveActiveWindow` and `scheduleBoundaryTick`
+  - `pkg/cmd/schedule_validation_test.go` — test `weekday_feature` gating
+    in `checkScheduleschedule`
+  - `pkg/cmd/schedule_runner_test.go` — test runner with
+    `WeekdayFeature` enabled/disabled
+- **Approach:**
+  - Add `var weekday_feature bool` to the package-level var block
+  - Add `const const_weekday_feature = true` to the constants block
+  - Register `--weekday_feature` flag via
+    `scdCmd.Flags().BoolVar(&weekday_feature, "weekday_feature", const_weekday_feature, "Enable weekday filtering on charge windows")`
+  - Read via `weekday_feature = viper.GetBool("weekday_feature")` in the
+    `Run` handler
+  - Add `WeekdayFeature bool` to `RunnerConfig`
+  - Update `checkScheduleschedule` to accept and forward `weekdayFeature bool`
+    to `pw.ValidateWindows`
+  - Update `Runner.resolveActiveWindow` to pass
+    `r.cfg.WeekdayFeature` to `pw.ResolveActiveWindow`
+  - Auto-binds to `WEEKDAY_FEATURE` env var via Viper's `AutomaticEnv`
+- **Patterns to follow:** `mqtt_enabled` flag pattern (top-level bool, CLI +
+  env + config.yaml, passed to struct).
+- **Test scenarios:**
+  - `weekday_feature: true` — windows with invalid weekdays are rejected
+  - `weekday_feature: false` — windows with invalid weekdays are accepted
+    (validation skipped)
+  - Flag `--weekday_feature=false` overrides config `weekday_feature: true`
+  - Env `WEEKDAY_FEATURE=false` overrides config
+  - Default (no config, no flag) — `weekday_feature` is `true`
+
+### U6. Add HA add-on schema entries
+
+- **Goal:** Update the Home Assistant add-on `config.yaml` to include the
+  `weekday_feature` option and the per-window `weekdays` schema entry.
+- **Requirements:** R1, R10
+- **Dependencies:** U5
+- **Files:**
+  - `home-assistant/addons/sbam/config.yaml` — add `weekday_feature` to
+    options and schema, add `weekdays` to the windows schema list
+- **Approach:**
+  - Add `weekday_feature: true` to the `options:` section
+  - Add `weekday_feature: bool` to the `schema:` section
+  - Add `weekdays: str?` to the `windows:` schema list
+- **Patterns to follow:** Existing `mqtt_enabled: bool` and `scheduler_mode:`
+  schema entries.
+- **Test scenarios:**
+  - Test expectation: none — schema-only change; the existing
+    `config_schema_test.go` validates regex patterns but `weekdays` uses
+    `str?` (no regex)
+
+### U7. Add weekday documentation page
+
+- **Goal:** Create a dedicated documentation page explaining weekday
+  filtering with multiple worked examples.
+- **Requirements:** R1–R4
+- **Dependencies:** U1–U6
+- **Files:**
+  - `docs/site/weekdays.md` — new documentation page
+  - `mkdocs.yml` — add `weekdays.md` to the nav
+- **Approach:**
+  - Follow the structure of `docs/site/mqtt.md` as a template
+  - Cover: enabling the feature, weekday format reference, the start-day
+    model explanation with a diagram-like example, five worked config
+    examples
+  - Examples: beta tester weekday off-peak, weekend-only, same-time
+    different-days (no overlap), single-day special rate, mixed
+    weekday/weekend
+  - Include a note that `weekday_feature: false` disables all filtering
+  - Link from `mkdocs.yml` nav under a new "Weekday Filtering" entry
+- **Test scenarios:**
+  - Test expectation: none — documentation only; MkDocs build verified via
+    `make docs` or CI
+
+---
+
+## Scope Boundaries
+
+- Weekday filtering applies to window activation only. It does not affect
+  forecast horizon resolution, MQTT discovery payloads, or Modbus operations.
+- Crontab mode with legacy `start_hr`/`end_hr` is unaffected.
+- Holiday calendars, timezone-aware day-boundary logic, and UI-based
+  scheduling are out of scope.
+
+---
+
+## Sources / Research
+
+- Origin requirements:
+  `docs/brainstorms/2026-06-17-weekday-windows-requirements.md`
+- Beta tester feedback:
+  [discussion #164](https://github.com/atbore-phx/sbam/discussions/164)
+- Window struct and validation patterns: `pkg/power/window.go:46-275`
+- Schedule runner and boundary tick: `pkg/cmd/schedule_runner.go:255-345`
+- Config loading and flag registration: `pkg/cmd/schedule.go:124-333`
+- HA add-on schema: `home-assistant/addons/sbam/config.yaml:14-86`
+- Prior multi-window feature plan:
+  `docs/plans/2026-06-11-001-feat-scheduler-mode-selector-plan.md`

--- a/docs/site/cli.md
+++ b/docs/site/cli.md
@@ -41,6 +41,7 @@ sbam schedule [flags]
 | `-d, --defaults` | `DEFAULTS` | Reconfigure inverter to defaults at cycle end | `true` |
 | `--forecast_horizon` | `FORECAST_HORIZON` | Forecast window mode | `default` |
 | `--consumption_horizon` | `CONSUMPTION_HORIZON` | Consumption model | `full_day` |
+| `--weekday_feature` | `WEEKDAY_FEATURE` | Enable weekday filtering on charge windows | `true` |
 | `--windows` | `WINDOWS` | Charge windows in YAML format | — |
 | `--mqtt_enabled` | `MQTT_ENABLED` | Enable MQTT | `false` |
 | `--mqtt_broker` | `MQTT_BROKER` | MQTT broker URL | — |
@@ -134,3 +135,8 @@ With optional reserve window:
 ```
 
 Equal start/end values are invalid. Overlapping windows are rejected at startup.
+
+Each window can also include a `weekdays` field for day-of-week filtering and
+the `weekday_feature` flag controls the feature globally. See the
+[Weekday Filtering](weekdays.md) guide for the format, start-day model, and
+worked examples.

--- a/docs/site/cli.md
+++ b/docs/site/cli.md
@@ -41,7 +41,6 @@ sbam schedule [flags]
 | `-d, --defaults` | `DEFAULTS` | Reconfigure inverter to defaults at cycle end | `true` |
 | `--forecast_horizon` | `FORECAST_HORIZON` | Forecast window mode | `default` |
 | `--consumption_horizon` | `CONSUMPTION_HORIZON` | Consumption model | `full_day` |
-| `--weekday_feature` | `WEEKDAY_FEATURE` | Enable weekday filtering on charge windows | `true` |
 | `--windows` | `WINDOWS` | Charge windows in YAML format | — |
 | `--mqtt_enabled` | `MQTT_ENABLED` | Enable MQTT | `false` |
 | `--mqtt_broker` | `MQTT_BROKER` | MQTT broker URL | — |

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -80,7 +80,6 @@ The battery reserve defines a minimum charge level to maintain during the reserv
 |--------|-------------|----------|---------|---------------|---------|
 | `scheduler_mode` | Scheduling mode. `crontab` — the legacy cron engine. Uses the global `crontab` field and the top-level `start_hr`/`end_hr` single window. Fully backward-compatible with existing configs. `windows` — the new internal ticker. No cron needed. Ticks fire at per-window intervals (tick_minutes), window transitions are detected at exact boundary times, and a tick fires immediately on startup. This is the recommended mode.. | `--scheduler_mode` | `SCHEDULER_MODE` | `scheduler_mode` | `crontab` |
 | `crontab` | Cron expression for recurring execution. Deprecated use `scheduler_mode: windows` instead.| `--crontab` | `CRONTAB` | `crontab` | `0 0 0 0 0` (CLI) / `00 00-05 * * *` (HA) |
-| `weekday_feature` | Enable weekday filtering on charge windows. Set to `false` to disable all weekday logic. See [Weekday Filtering](weekdays.md). CLI/standalone only. | `--weekday_feature` | `WEEKDAY_FEATURE` | — | `true` |
 
 !!! warning "crontab deprecation"
     `crontab` is deprecated and will be removed in v3.0.0. Migrate to `scheduler_mode: windows` before then.

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -80,7 +80,7 @@ The battery reserve defines a minimum charge level to maintain during the reserv
 |--------|-------------|----------|---------|---------------|---------|
 | `scheduler_mode` | Scheduling mode. `crontab` — the legacy cron engine. Uses the global `crontab` field and the top-level `start_hr`/`end_hr` single window. Fully backward-compatible with existing configs. `windows` — the new internal ticker. No cron needed. Ticks fire at per-window intervals (tick_minutes), window transitions are detected at exact boundary times, and a tick fires immediately on startup. This is the recommended mode.. | `--scheduler_mode` | `SCHEDULER_MODE` | `scheduler_mode` | `crontab` |
 | `crontab` | Cron expression for recurring execution. Deprecated use `scheduler_mode: windows` instead.| `--crontab` | `CRONTAB` | `crontab` | `0 0 0 0 0` (CLI) / `00 00-05 * * *` (HA) |
-| `weekday_feature` | Enable weekday filtering on charge windows. Set to `false` to disable all weekday logic. See [Weekday Filtering](weekdays.md). | `--weekday_feature` | `WEEKDAY_FEATURE` | `weekday_feature` | `true` |
+| `weekday_feature` | Enable weekday filtering on charge windows. Set to `false` to disable all weekday logic. See [Weekday Filtering](weekdays.md). CLI/standalone only. | `--weekday_feature` | `WEEKDAY_FEATURE` | — | `true` |
 
 !!! warning "crontab deprecation"
     `crontab` is deprecated and will be removed in v3.0.0. Migrate to `scheduler_mode: windows` before then.

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -52,6 +52,7 @@ Each window accepts these fields:
 | `tick_minutes` | No | Evaluation interval in minutes within this window. |
 | `set_defaults` | No | Whether to reset inverter to defaults when this window ends. |
 | `before_end_defaults_minutes` | No | Minutes before window end to trigger defaults. |
+| `weekdays` | No | Day-of-week filter for the window. See [Weekday Filtering](weekdays.md). |
 
 ## Battery Reserve
 
@@ -79,6 +80,7 @@ The battery reserve defines a minimum charge level to maintain during the reserv
 |--------|-------------|----------|---------|---------------|---------|
 | `scheduler_mode` | Scheduling mode. `crontab` — the legacy cron engine. Uses the global `crontab` field and the top-level `start_hr`/`end_hr` single window. Fully backward-compatible with existing configs. `windows` — the new internal ticker. No cron needed. Ticks fire at per-window intervals (tick_minutes), window transitions are detected at exact boundary times, and a tick fires immediately on startup. This is the recommended mode.. | `--scheduler_mode` | `SCHEDULER_MODE` | `scheduler_mode` | `crontab` |
 | `crontab` | Cron expression for recurring execution. Deprecated use `scheduler_mode: windows` instead.| `--crontab` | `CRONTAB` | `crontab` | `0 0 0 0 0` (CLI) / `00 00-05 * * *` (HA) |
+| `weekday_feature` | Enable weekday filtering on charge windows. Set to `false` to disable all weekday logic. See [Weekday Filtering](weekdays.md). | `--weekday_feature` | `WEEKDAY_FEATURE` | `weekday_feature` | `true` |
 
 !!! warning "crontab deprecation"
     `crontab` is deprecated and will be removed in v3.0.0. Migrate to `scheduler_mode: windows` before then.

--- a/docs/site/weekdays.md
+++ b/docs/site/weekdays.md
@@ -1,0 +1,203 @@
+# Weekday Filtering
+
+Weekday filtering lets you assign each charge window to specific days of the
+week. This is useful when your electricity rates vary between weekdays and
+weekends, or when you have a special-rate day.
+
+The feature is enabled by default via the `weekday_feature` flag. Set it to
+`false` to disable all weekday logic without removing the `weekdays` fields
+from your config.
+
+## Quick Start
+
+Add `weekdays` to any window in your `windows:` list:
+
+```yaml
+scheduler_mode: windows
+weekday_feature: true
+windows:
+  - name: "weekday-offpeak"
+    start: "21:00"
+    end: "07:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+```
+
+With this config, the window is active Monday 21:00 through Tuesday 07:00,
+Tuesday 21:00 through Wednesday 07:00, …, Friday 21:00 through Saturday
+07:00. It is **not** active on Saturday or Sunday.
+
+## Weekday Format
+
+| Expression | Meaning |
+|---|---|
+| `mon` | Monday only |
+| `mon,fri` | Monday and Friday |
+| `mon-fri` | Monday through Friday (inclusive) |
+| `mon-fri,sun` | Monday through Friday, plus Sunday |
+| *(empty)* | Every day (backward compatible) |
+
+Day names use lowercase 3-letter English abbreviations: `mon`, `tue`, `wed`,
+`thu`, `fri`, `sat`, `sun`.
+
+Ranges expand inclusively. Overlapping ranges are flattened: `mon-wed,tue-thu`
+produces Monday, Tuesday, Wednesday, Thursday.
+
+## The Start-Day Model
+
+A window's weekday always refers to the **day the window starts**. This
+matters for windows that cross midnight.
+
+```
+window: start "22:00", end "04:00", weekdays "fri"
+
+Friday 22:00 ───┐
+                │  WINDOW ACTIVE (start day is Friday)
+Saturday 03:00 ─┘
+
+Saturday 22:00 ─── NOT ACTIVE (start day is Saturday, not in set)
+```
+
+A Monday 23:00–03:00 with `weekdays: "mon"` is active Monday night/Tuesday
+morning but **not** Tuesday night/Wednesday morning — because the Tuesday
+night occurrence would have a Tuesday start day.
+
+You never need to think about the "carry-over" day for the post-midnight
+portion. The rule is: **the day the window opens determines the weekday.**
+
+## Configuration Examples
+
+### Weekday off-peak + weekend all-day off-peak
+
+The beta tester's use case: cheaper off-peak rates Monday–Friday nights, and
+all-day off-peak on weekends.
+
+```yaml
+windows:
+  - name: "weekday-offpeak"
+    start: "21:00"
+    end: "07:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+  - name: "weekend-offpeak"
+    start: "00:00"
+    end: "23:59"
+    max_charge: 3500
+    weekdays: "sat,sun"
+```
+
+### Same clock range, different max_charge by day
+
+Charge at 3500 W on weekdays and 5000 W on weekends, using the same time
+slot. Because the weekday sets are disjoint, validation does not flag an
+overlap.
+
+```yaml
+windows:
+  - name: "weekday-morning"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 3500
+    weekdays: "mon-fri"
+  - name: "weekend-morning"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 5000
+    weekdays: "sat,sun"
+```
+
+### Single-day free-power window
+
+Your provider gives free power every Wednesday 12:00–15:00.
+
+```yaml
+windows:
+  - name: "free-power-wed"
+    start: "12:00"
+    end: "15:00"
+    max_charge: 5000
+    weekdays: "wed"
+  - name: "normal"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 3500
+```
+
+The `free-power-wed` window is invisible on every day except Wednesday.
+On Wednesday it takes priority because windows are evaluated in list order
+and it comes first.
+
+### Mixed weekday/weekend with different horizon strategies
+
+Forecast horizon `off` on weekends (no solar forecast) and `next_solar_day`
+on weekdays.
+
+```yaml
+windows:
+  - name: "weekday"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 3500
+    forecast_horizon: "next_solar_day"
+    weekdays: "mon-fri"
+  - name: "weekend"
+    start: "02:00"
+    end: "05:00"
+    max_charge: 5000
+    forecast_horizon: "off"
+    weekdays: "sat,sun"
+```
+
+### All windows share the same day filter
+
+When every window in your list uses the same weekday pattern, the scheduler
+only ticks on those days. Be aware that on excluded days no window is
+active — the battery will not charge from the grid.
+
+```yaml
+windows:
+  - name: "morning"
+    start: "06:00"
+    end: "12:00"
+    max_charge: 2000
+    weekdays: "mon-fri"
+  - name: "afternoon"
+    start: "12:01"
+    end: "18:00"
+    max_charge: 0
+    weekdays: "mon-fri"
+```
+
+On Saturday and Sunday neither window activates. The scheduler runs but
+reports "outside all configured charge windows."
+
+## Feature Flag
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `weekday_feature` | bool | `true` | Enable weekday filtering |
+
+When `weekday_feature` is `false`:
+- All windows are active every day, regardless of their `weekdays` field
+- Weekday token validation is skipped at startup
+- Overlap detection ignores weekday sets
+
+This is a maintainer kill switch. If you encounter a bug, set it to `false`
+to disable weekday logic without editing your window definitions.
+
+The flag is available as:
+- Config key: `weekday_feature: false`
+- CLI flag: `--weekday_feature=false`
+- Env var: `WEEKDAY_FEATURE=false`
+
+## Validation Rules
+
+- Unknown weekday tokens (`mon,xyz`) are rejected at startup
+- Empty elements (`mon,,fri`) are rejected
+- Day names are case-sensitive — `MON` and `Mon` are rejected; use `mon`
+- Two windows with the same clock range but disjoint weekday sets (e.g.,
+  `mon-fri` and `sat,sun`) are **not** flagged as overlapping
+- Two windows with overlapping weekday sets AND overlapping clock ranges
+  are rejected as normal
+- A window with no `weekdays` (or an empty value) is treated as "all days"
+  and always overlaps with other windows at the same clock range

--- a/docs/site/weekdays.md
+++ b/docs/site/weekdays.md
@@ -4,17 +4,12 @@ Weekday filtering lets you assign each charge window to specific days of the
 week. This is useful when your electricity rates vary between weekdays and
 weekends, or when you have a special-rate day.
 
-The feature is enabled by default via the `weekday_feature` flag. Set it to
-`false` to disable all weekday logic without removing the `weekdays` fields
-from your config.
-
 ## Quick Start
 
 Add `weekdays` to any window in your `windows:` list:
 
 ```yaml
 scheduler_mode: windows
-weekday_feature: true
 windows:
   - name: "weekday-offpeak"
     start: "21:00"
@@ -170,24 +165,6 @@ windows:
 
 On Saturday and Sunday neither window activates. The scheduler runs but
 reports "outside all configured charge windows."
-
-## Feature Flag
-
-| Key | Type | Default | Description |
-|---|---|---|---|
-| `weekday_feature` | bool | `true` | Enable weekday filtering |
-
-When `weekday_feature` is `false`:
-- All windows are active every day, regardless of their `weekdays` field
-- Weekday token validation is skipped at startup
-- Overlap detection ignores weekday sets
-
-This is a maintainer kill switch. If you encounter a bug, set it to `false`
-to disable weekday logic without editing your window definitions.
-
-The flag is internal (hidden from help output) and enabled by default.
-Advanced users can set `WEEKDAY_FEATURE=false` as an environment variable
-or pass `--weekday_feature=false` on the CLI to disable it.
 
 ## Validation Rules
 

--- a/docs/site/weekdays.md
+++ b/docs/site/weekdays.md
@@ -185,8 +185,9 @@ When `weekday_feature` is `false`:
 This is a maintainer kill switch. If you encounter a bug, set it to `false`
 to disable weekday logic without editing your window definitions.
 
-The flag is available as a CLI flag (`--weekday_feature=false`) and env var
-(`WEEKDAY_FEATURE=false`). See the [CLI Reference](cli.md) for details.
+The flag is internal (hidden from help output) and enabled by default.
+Advanced users can set `WEEKDAY_FEATURE=false` as an environment variable
+or pass `--weekday_feature=false` on the CLI to disable it.
 
 ## Validation Rules
 

--- a/docs/site/weekdays.md
+++ b/docs/site/weekdays.md
@@ -185,10 +185,8 @@ When `weekday_feature` is `false`:
 This is a maintainer kill switch. If you encounter a bug, set it to `false`
 to disable weekday logic without editing your window definitions.
 
-The flag is available as:
-- Config key: `weekday_feature: false`
-- CLI flag: `--weekday_feature=false`
-- Env var: `WEEKDAY_FEATURE=false`
+The flag is available as a CLI flag (`--weekday_feature=false`) and env var
+(`WEEKDAY_FEATURE=false`). See the [CLI Reference](cli.md) for details.
 
 ## Validation Rules
 

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -16,9 +16,6 @@ A cross-midnight window uses the start-day model: `start: "22:00", end:
 Saturday night. Two windows with the same clock range but different weekday
 sets (e.g., `mon-fri` vs `sat,sun`) validate without overlap errors.
 
-The `weekday_feature` global option (default `true`) gates all weekday logic.
-Set it to `false` to disable filtering without editing window definitions.
-
 See the [Weekday Filtering guide](https://atbore-phx.github.io/sbam/weekdays/)
 for the full format reference, start-day model explanation, and worked
 configuration examples.

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## What's New in v2.1.0
 
+### Multi-window charging schedule
+
+New `windows` configuration option replaces the single `start_hr`/`end_hr`/`max_charge` triple with an ordered list of charge windows, each with its own `max_charge` and optional `forecast_horizon`/`consumption_horizon` overrides. Key highlights:
+
+- Define multiple charge windows per day (e.g. night 02:00–06:00 and midday 12:00–15:00) with independent power limits and horizons.
+- Cross-midnight windows supported (e.g. 22:00–04:00).
+- Overlap detection rejects misconfigured windows at startup.
+- Legacy `start_hr`/`end_hr`/`max_charge` keys remain fully supported — they are synthesized into a single window when `windows` is absent.
+- MQTT state payload and Home Assistant discovery now expose the active window name, max charge, and forecast horizon as diagnostic sensors.
+- New `forecast_horizon` and `consumption_horizon` options replace the hardcoded noon-threshold forecast selection with explicit, named modes:
+    - `forecast_horizon`: `default` (current behavior), `next_solar_day`, `remaining_today`, `today`, `tomorrow`, `off`
+    - `consumption_horizon`: `full_day` (current behavior), `remaining_today`
+
+Existing installations keep current behavior under `forecast_horizon=default` and `consumption_horizon=full_day`.
+
 ### Weekday filtering on charge windows
 
 Each window in the `windows:` list now accepts an optional `weekdays` field
@@ -19,21 +34,6 @@ sets (e.g., `mon-fri` vs `sat,sun`) validate without overlap errors.
 See the [Weekday Filtering guide](https://atbore-phx.github.io/sbam/weekdays/)
 for the full format reference, start-day model explanation, and worked
 configuration examples.
-
-### Multi-window charging schedule
-
-New `windows` configuration option replaces the single `start_hr`/`end_hr`/`max_charge` triple with an ordered list of charge windows, each with its own `max_charge` and optional `forecast_horizon`/`consumption_horizon` overrides. Key highlights:
-
-- Define multiple charge windows per day (e.g. night 02:00–06:00 and midday 12:00–15:00) with independent power limits and horizons.
-- Cross-midnight windows supported (e.g. 22:00–04:00).
-- Overlap detection rejects misconfigured windows at startup.
-- Legacy `start_hr`/`end_hr`/`max_charge` keys remain fully supported — they are synthesized into a single window when `windows` is absent.
-- MQTT state payload and Home Assistant discovery now expose the active window name, max charge, and forecast horizon as diagnostic sensors.
-- New `forecast_horizon` and `consumption_horizon` options replace the hardcoded noon-threshold forecast selection with explicit, named modes:
-    - `forecast_horizon`: `default` (current behavior), `next_solar_day`, `remaining_today`, `today`, `tomorrow`, `off`
-    - `consumption_horizon`: `full_day` (current behavior), `remaining_today`
-
-Existing installations keep current behavior under `forecast_horizon=default` and `consumption_horizon=full_day`.
 
 ### Scheduler mode selector
 

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,3 +1,28 @@
+## What's New in v2.2.0
+
+### Weekday filtering on charge windows
+
+Each window in the `windows:` list now accepts an optional `weekdays` field
+for day-of-week filtering:
+
+```yaml
+weekdays: "mon-fri"        # Monday through Friday
+weekdays: "mon,fri"        # Monday and Friday only
+weekdays: "mon-fri,sun"    # weekdays plus Sunday
+```
+
+A cross-midnight window uses the start-day model: `start: "22:00", end:
+"04:00", weekdays: "fri"` is active Friday night/Saturday morning but not
+Saturday night. Two windows with the same clock range but different weekday
+sets (e.g., `mon-fri` vs `sat,sun`) validate without overlap errors.
+
+The `weekday_feature` global option (default `true`) gates all weekday logic.
+Set it to `false` to disable filtering without editing window definitions.
+
+See the [Weekday Filtering guide](https://atbore-phx.github.io/sbam/weekdays/)
+for the full format reference, start-day model explanation, and worked
+configuration examples.
+
 ## What's New in v2.1.0
 
 ### Multi-window charging schedule

--- a/home-assistant/addons/sbam/CHANGELOG.md
+++ b/home-assistant/addons/sbam/CHANGELOG.md
@@ -1,4 +1,4 @@
-## What's New in v2.2.0
+## What's New in v2.1.0
 
 ### Weekday filtering on charge windows
 
@@ -19,8 +19,6 @@ sets (e.g., `mon-fri` vs `sat,sun`) validate without overlap errors.
 See the [Weekday Filtering guide](https://atbore-phx.github.io/sbam/weekdays/)
 for the full format reference, start-day model explanation, and worked
 configuration examples.
-
-## What's New in v2.1.0
 
 ### Multi-window charging schedule
 

--- a/home-assistant/addons/sbam/config.yaml
+++ b/home-assistant/addons/sbam/config.yaml
@@ -83,4 +83,4 @@ schema:
       tick_minutes: int?
       set_defaults: bool?
       before_end_defaults_minutes: int?
-      weekdays: match(^$|^(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?(,(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?)*$)?
+      weekdays: match(^$|^(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?(,(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?)*$)

--- a/home-assistant/addons/sbam/config.yaml
+++ b/home-assistant/addons/sbam/config.yaml
@@ -41,6 +41,7 @@ options:
   mqtt_ha_discovery: true
   mqtt_ha_discovery_prefix: homeassistant
   scheduler_mode: crontab
+  weekday_feature: true
   windows: []
 
 schema:
@@ -73,6 +74,7 @@ schema:
   mqtt_ha_discovery: bool
   mqtt_ha_discovery_prefix: str
   scheduler_mode: list(crontab|windows)
+  weekday_feature: bool
   windows:
     - name: str
       start: match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)
@@ -83,3 +85,4 @@ schema:
       tick_minutes: int?
       set_defaults: bool?
       before_end_defaults_minutes: int?
+      weekdays: str?

--- a/home-assistant/addons/sbam/config.yaml
+++ b/home-assistant/addons/sbam/config.yaml
@@ -41,7 +41,6 @@ options:
   mqtt_ha_discovery: true
   mqtt_ha_discovery_prefix: homeassistant
   scheduler_mode: crontab
-  weekday_feature: true
   windows: []
 
 schema:
@@ -74,7 +73,6 @@ schema:
   mqtt_ha_discovery: bool
   mqtt_ha_discovery_prefix: str
   scheduler_mode: list(crontab|windows)
-  weekday_feature: bool
   windows:
     - name: str
       start: match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)

--- a/home-assistant/addons/sbam/config.yaml
+++ b/home-assistant/addons/sbam/config.yaml
@@ -83,4 +83,4 @@ schema:
       tick_minutes: int?
       set_defaults: bool?
       before_end_defaults_minutes: int?
-      weekdays: str?
+      weekdays: match(^$|^(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?(,(mon|tue|wed|thu|fri|sat|sun)(-(mon|tue|wed|thu|fri|sat|sun))?)*$)?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Installation: installation.md
     - Configuration: configuration.md
     - MQTT Guide: mqtt.md
+    - Weekday Filtering: weekdays.md
     - CLI Reference: cli.md
     - Changelog: changelog.md
   - Help: help.md

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -28,7 +28,7 @@ var s_apiKey, s_url, start_hr, end_hr, batt_reserve_start_hr, batt_reserve_end_h
 	scheduler_mode string
 var pw_consumption, max_charge, pw_lwt, pw_upt, pw_batt_reserve float64
 var s_cache_time int32
-var s_defaults, s_cache_forecast, mqtt_enabled, mqtt_ha_discovery, mqtt_tls_insecure_skip bool
+var s_defaults, s_cache_forecast, mqtt_enabled, mqtt_ha_discovery, mqtt_tls_insecure_skip, weekday_feature bool
 
 const (
 	const_pc                  = 0.0
@@ -47,6 +47,7 @@ const (
 	const_forecast_horizon    = "default"
 	const_consumption_horizon = "full_day"
 	const_scheduler_mode      = "crontab"
+	const_weekday_feature     = true
 	scheduleClockLayout       = "15:04"
 )
 
@@ -120,6 +121,7 @@ var scdCmd = &cobra.Command{
 		forecast_horizon = viper.GetString("forecast_horizon")
 		consumption_horizon = viper.GetString("consumption_horizon")
 		scheduler_mode = viper.GetString("scheduler_mode")
+		weekday_feature = viper.GetBool("weekday_feature")
 
 		// Resolve windows with flag > env > config.yaml precedence.
 		var windows []pw.Window
@@ -196,7 +198,7 @@ var scdCmd = &cobra.Command{
 		}
 		u.LogStartupParams(cmd, extras)
 
-		err = checkScheduleschedule(crontab, s_apiKey, s_url, fronius_ip, pw_consumption, max_charge, pw_batt_reserve, w_start_hr, w_end_hr, windows, scheduler_mode)
+		err = checkScheduleschedule(crontab, s_apiKey, s_url, fronius_ip, pw_consumption, max_charge, pw_batt_reserve, w_start_hr, w_end_hr, windows, scheduler_mode, weekday_feature)
 		if err != nil {
 			u.Log.Error(err)
 			return
@@ -223,6 +225,7 @@ var scdCmd = &cobra.Command{
 			ForecastHorizon:    forecast_horizon,
 			ConsumptionHorizon: consumption_horizon,
 			SchedulerMode:      scheduler_mode,
+			WeekdayFeature:     weekday_feature,
 			MQTT:               mqttCfg,
 			Now:                time.Now,
 		}
@@ -327,6 +330,7 @@ func registerScdCmd() {
 	scdCmd.Flags().StringVar(&forecast_horizon, "forecast_horizon", const_forecast_horizon, "Forecast horizon mode (default, next_solar_day, remaining_today, today, tomorrow, off)")
 	scdCmd.Flags().StringVar(&consumption_horizon, "consumption_horizon", const_consumption_horizon, "Consumption horizon mode (full_day, remaining_today)")
 	scdCmd.Flags().StringVar(&scheduler_mode, "scheduler_mode", const_scheduler_mode, "Scheduler mode (crontab, windows)")
+	scdCmd.Flags().BoolVar(&weekday_feature, "weekday_feature", const_weekday_feature, "Enable weekday filtering on charge windows")
 	scdCmd.Flags().String("windows", "", "Charge windows in YAML format (same as config.yaml windows: key)")
 
 	rootCmd.AddCommand(scdCmd)
@@ -441,11 +445,11 @@ func isWindowContainedIn(innerStart, innerEnd, outerStart, outerEnd string) (boo
 // The function intentionally keeps validation local to the command so the
 // runtime can exit early with user-friendly messages when flags are invalid.
 func checkScheduleschedule(crontab, apiKey, url, fronius_ip string, pw_consumption, max_charge,
-	pw_batt_reserve float64, start_hr, end_hr string, windows []pw.Window, scheduler_mode string) error {
+	pw_batt_reserve float64, start_hr, end_hr string, windows []pw.Window, scheduler_mode string, weekdayFeature bool) error {
 
 	if len(windows) > 0 {
 		u.Log.Info("windows configuration is provided; start_hr/end_hr will be ignored")
-		if err := pw.ValidateWindows(windows); err != nil {
+		if err := pw.ValidateWindows(windows, weekdayFeature); err != nil {
 			return fmt.Errorf("invalid windows configuration: %w", err)
 		}
 	}

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -48,6 +48,7 @@ type RunnerConfig struct {
 	ConsumptionHorizon string
 	SchedulerMode      string
 	Windows            []pw.Window
+	WeekdayFeature     bool
 	MQTT               mqtt.Config
 	Now                func() time.Time
 }
@@ -163,7 +164,7 @@ func (r *Runner) StartWindowsTicker(now time.Time) {
 func (r *Runner) startWindowsTicker(now time.Time) {
 	r.stopWindowsTicker()
 
-	active := pw.ResolveActiveWindow(r.cfg.Windows, now)
+	active := pw.ResolveActiveWindow(r.cfg.Windows, now, r.cfg.WeekdayFeature)
 	if active != nil {
 		r.activeWindow = active.Name
 	} else {
@@ -258,7 +259,7 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 		return
 	}
 
-	active := pw.ResolveActiveWindow(windows, now)
+	active := pw.ResolveActiveWindow(windows, now, r.cfg.WeekdayFeature)
 
 	var next pw.Window
 
@@ -275,6 +276,11 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 				startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
 			if !startAt.After(now) {
 				startAt = startAt.Add(24 * time.Hour)
+			}
+			if r.cfg.WeekdayFeature && windows[i].Weekdays != "" {
+				if wdSet, err := pw.ParseWeekdays(windows[i].Weekdays); err == nil && len(wdSet) > 0 {
+					startAt = nextMatchingWeekday(startAt, wdSet)
+				}
 			}
 			if best == nil || startAt.Before(bestStart) {
 				best = &windows[i]
@@ -327,6 +333,12 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 	// If nextAt is before or equal to now, advance by 24h.
 	if !nextAt.After(now) {
 		nextAt = nextAt.Add(24 * time.Hour)
+	}
+
+	if r.cfg.WeekdayFeature && next.Weekdays != "" {
+		if wdSet, err := pw.ParseWeekdays(next.Weekdays); err == nil && len(wdSet) > 0 {
+			nextAt = nextMatchingWeekday(nextAt, wdSet)
+		}
 	}
 
 	delay := nextAt.Sub(now)
@@ -435,7 +447,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 	var inCooldown bool
 	var cooldownErr error
 	if r.cfg.SchedulerMode == "windows" && len(r.cfg.Windows) > 0 {
-		active := pw.ResolveActiveWindow(r.cfg.Windows, now)
+		active := pw.ResolveActiveWindow(r.cfg.Windows, now, r.cfg.WeekdayFeature)
 		if active != nil {
 			cooldownDuration := chargeCooldownMinutes
 			if active.Defaults != nil && *active.Defaults && active.BeforeEndDefaults != nil {
@@ -782,7 +794,7 @@ func (r *Runner) resolveActiveWindow(now time.Time) (inWindow bool, maxCharge fl
 	consumptionHorizon = r.cfg.ConsumptionHorizon
 
 	if len(r.cfg.Windows) > 0 {
-		active := pw.ResolveActiveWindow(r.cfg.Windows, now)
+		active := pw.ResolveActiveWindow(r.cfg.Windows, now, r.cfg.WeekdayFeature)
 		if active == nil {
 			return false, maxCharge, forecastHorizon, consumptionHorizon, ""
 		}
@@ -883,4 +895,18 @@ func checkTimeRangeAt(now time.Time, startHR, endHR string) (bool, error) {
 
 	inRange := (now.After(startAt) || now.Equal(startAt)) && (now.Before(endAt) || now.Equal(endAt))
 	return inRange, nil
+}
+
+// nextMatchingWeekday advances t by 24h increments until its weekday is in
+// the provided set. The set must be non-empty; the function loops at most 7
+// times before returning (since a non-empty set guarantees a match within 7
+// days).
+func nextMatchingWeekday(t time.Time, weekdays map[time.Weekday]bool) time.Time {
+	for i := 0; i < 7; i++ {
+		if weekdays[t.Weekday()] {
+			return t
+		}
+		t = t.Add(24 * time.Hour)
+	}
+	return t
 }

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -65,6 +65,7 @@ func newRunnerForTests(client mqtt.Client) *Runner {
 		CacheForecast:      false,
 		CacheFilePrefix:    "cached_forecast",
 		CacheTime:          7200,
+		WeekdayFeature:     true,
 		MQTT: mqtt.Config{
 			Enabled:     true,
 			TopicPrefix: "sbam",

--- a/pkg/cmd/schedule_test.go
+++ b/pkg/cmd/schedule_test.go
@@ -468,49 +468,49 @@ func TestMakeBasePayloadSetsCommonFields(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCheckScheduleschedule_EmptyFroniusIP(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fronius_ip")
 }
 
 func TestCheckScheduleschedule_EmptyApiKey(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "apikey")
 }
 
 func TestCheckScheduleschedule_EmptyURL(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "url")
 }
 
 func TestCheckScheduleschedule_EmptyCrontab(t *testing.T) {
-	err := checkScheduleschedule("", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "crontab")
 }
 
 func TestCheckScheduleschedule_NegativePWConsumption(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", -1, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", -1, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_consumption")
 }
 
 func TestCheckScheduleschedule_NegativeMaxCharge(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, -1, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, -1, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_charge")
 }
 
 func TestCheckScheduleschedule_InvalidWindow(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "bad", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "bad", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid start_hr")
 }
 
 func TestCheckScheduleschedule_BattReserveNotContained(t *testing.T) {
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "06:00", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "06:00", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "batt_reserve_start_hr")
 }
@@ -525,7 +525,7 @@ func TestCheckScheduleschedule_InvalidCacheTime(t *testing.T) {
 	s_cache_time = -1
 	defer func() { s_cache_time = oldCacheTime }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cache_time")
 }
@@ -540,7 +540,7 @@ func TestCheckScheduleschedule_CacheTimeTooLarge(t *testing.T) {
 	s_cache_time = 90000
 	defer func() { s_cache_time = oldCacheTime }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cache_time")
 }
@@ -561,7 +561,7 @@ func TestCheckScheduleschedule_InvalidForecastHorizon(t *testing.T) {
 	forecast_horizon = "invalid_horizon"
 	defer func() { forecast_horizon = oldForecastHorizon }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forecast_horizon")
 }
@@ -582,7 +582,7 @@ func TestCheckScheduleschedule_InvalidConsumptionHorizon(t *testing.T) {
 	consumption_horizon = "invalid_horizon"
 	defer func() { consumption_horizon = oldConsumptionHorizon }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "consumption_horizon")
 }
@@ -758,7 +758,7 @@ func TestCheckScheduleschedule_NegativePWLWT(t *testing.T) {
 	pw_lwt = -1
 	defer func() { pw_lwt = oldPwLwt }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_lwt")
 }
@@ -779,7 +779,7 @@ func TestCheckScheduleschedule_NegativePWUPT(t *testing.T) {
 	pw_upt = -1
 	defer func() { pw_upt = oldPwUpt }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_upt")
 }
@@ -800,7 +800,7 @@ func TestCheckScheduleschedule_NegativePWBattReserve(t *testing.T) {
 	pw_batt_reserve = -1
 	defer func() { pw_batt_reserve = oldPwBR }()
 
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, -1, "00:00", "23:59", nil, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, -1, "00:00", "23:59", nil, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pw_batt_reserve")
 }
@@ -822,7 +822,7 @@ func TestCheckScheduleschedule_WithWindowsValidates(t *testing.T) {
 	windows := []pw.Window{
 		{Name: "morning", Start: "06:00", End: "08:00", MaxCharge: 3500},
 	}
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", windows, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "00:00", "23:59", windows, "crontab", true)
 	require.NoError(t, err)
 }
 
@@ -842,7 +842,7 @@ func TestCheckScheduleschedule_InvalidWindows(t *testing.T) {
 	windows := []pw.Window{
 		{Start: "bad", End: "also_bad", MaxCharge: -1},
 	}
-	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "", "", windows, "crontab")
+	err := checkScheduleschedule("0 0 * * *", "key", "http://url", "127.0.0.1", 1000, 3500, 100, "", "", windows, "crontab", true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "windows")
 }

--- a/pkg/cmd/schedule_validation_test.go
+++ b/pkg/cmd/schedule_validation_test.go
@@ -73,7 +73,7 @@ func TestCheckScheduleScheduleValid(t *testing.T) {
 		args.startHr,
 		args.endHr,
 		nil,
-		args.schedulerMode)
+		args.schedulerMode, true)
 
 	require.NoError(t, err)
 }
@@ -218,7 +218,7 @@ func TestCheckScheduleScheduleValidationErrors(t *testing.T) {
 				args.startHr,
 				args.endHr,
 				nil,
-				args.schedulerMode)
+				args.schedulerMode, true)
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errSubstr)
@@ -243,7 +243,7 @@ func TestCheckScheduleScheduleCrossMidnightChargeWindowValid(t *testing.T) {
 		args.startHr,
 		args.endHr,
 		nil,
-		args.schedulerMode)
+		args.schedulerMode, true)
 
 	require.NoError(t, err)
 }
@@ -310,7 +310,7 @@ func TestCheckScheduleScheduleReserveWindowContainment(t *testing.T) {
 				args.startHr,
 				args.endHr,
 				nil,
-				args.schedulerMode)
+				args.schedulerMode, true)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/power/window.go
+++ b/pkg/power/window.go
@@ -3,11 +3,24 @@ package power
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
 // scheduleClockLayout is the expected wall-clock format ("HH:MM").
 const scheduleClockLayout = "15:04"
+
+// weekdayNames maps lowercase 3-letter English weekday abbreviations to
+// time.Weekday values. Used by parseWeekdays for validation and resolution.
+var weekdayNames = map[string]time.Weekday{
+	"mon": time.Monday,
+	"tue": time.Tuesday,
+	"wed": time.Wednesday,
+	"thu": time.Thursday,
+	"fri": time.Friday,
+	"sat": time.Saturday,
+	"sun": time.Sunday,
+}
 
 // clockSegment represents a half-open minute-of-day interval [startMinute, endMinute).
 // endMinute is exclusive; a segment with startMinute == endMinute is zero-width.
@@ -53,12 +66,13 @@ type Window struct {
 	TickMinutes        *int    `json:"tick_minutes,omitempty" yaml:"tick_minutes,omitempty" mapstructure:"tick_minutes,omitempty"`
 	Defaults           *bool   `json:"set_defaults,omitempty" yaml:"set_defaults,omitempty" mapstructure:"set_defaults,omitempty"`
 	BeforeEndDefaults  *int    `json:"before_end_defaults_minutes,omitempty" yaml:"before_end_defaults_minutes,omitempty" mapstructure:"before_end_defaults_minutes,omitempty"`
+	Weekdays           string  `json:"weekdays,omitempty" yaml:"weekdays,omitempty" mapstructure:"weekdays,omitempty"`
 }
 
 // ValidateWindows checks a non-empty ordered list of charge windows and
 // returns nil when every window passes individual field validation and no
 // two windows overlap. Overlap detection supports cross-midnight windows.
-func ValidateWindows(windows []Window) error {
+func ValidateWindows(windows []Window, weekdayFeature bool) error {
 	if len(windows) == 0 {
 		return fmt.Errorf("windows must contain at least one entry")
 	}
@@ -71,7 +85,7 @@ func ValidateWindows(windows []Window) error {
 	var allSegments []namedSegment
 
 	for i, w := range windows {
-		if err := validateWindowFields(w); err != nil {
+		if err := validateWindowFields(w, weekdayFeature); err != nil {
 			return fmt.Errorf("window %q (#%d): %w", WindowNameOrDefault(w, i), i+1, err)
 		}
 
@@ -111,6 +125,14 @@ func ValidateWindows(windows []Window) error {
 			if a.startMinute < b.endMinute && b.startMinute < a.endMinute {
 				wa := windows[allSegments[i].windowN]
 				wb := windows[allSegments[j].windowN]
+
+				// When weekdayFeature is enabled and both windows have
+				// non-empty weekday sets, skip the overlap check if the
+				// sets are disjoint — they never activate on the same day.
+				if weekdayFeature && !weekdaySetsIntersect(wa.Weekdays, wb.Weekdays) {
+					continue
+				}
+
 				na := WindowNameOrDefault(wa, allSegments[i].windowN)
 				nb := WindowNameOrDefault(wb, allSegments[j].windowN)
 				return fmt.Errorf("window %q overlaps with window %q", na, nb)
@@ -118,7 +140,8 @@ func ValidateWindows(windows []Window) error {
 		}
 	}
 
-	// Reject configurations where one window's end equals another window's start.
+	// Reject configurations where one window's end equals another window's start,
+	// unless their weekday sets are disjoint (when weekdayFeature is enabled).
 	for i := range windows {
 		endTime, _ := parseClock(windows[i].End)
 		endMin := clockMinute(endTime)
@@ -126,6 +149,13 @@ func ValidateWindows(windows []Window) error {
 			if i == j {
 				continue
 			}
+
+			// Skip when weekday sets are disjoint — the windows never
+			// activate on the same day, so an equal boundary is safe.
+			if weekdayFeature && !weekdaySetsIntersect(windows[i].Weekdays, windows[j].Weekdays) {
+				continue
+			}
+
 			startTime, _ := parseClock(windows[j].Start)
 			if clockMinute(startTime) == endMin {
 				ni := WindowNameOrDefault(windows[i], i)
@@ -141,7 +171,7 @@ func ValidateWindows(windows []Window) error {
 
 // validateWindowFields checks individual fields of a single Window and
 // returns an error describing the first validation failure.
-func validateWindowFields(w Window) error {
+func validateWindowFields(w Window, weekdayFeature bool) error {
 	if _, err := parseClock(w.Start); err != nil {
 		return fmt.Errorf("invalid start time %q: %w", w.Start, err)
 	}
@@ -167,6 +197,11 @@ func validateWindowFields(w Window) error {
 	if w.BeforeEndDefaults != nil && *w.BeforeEndDefaults < 0 {
 		return fmt.Errorf("before_end_defaults must be >= 0, got %d", *w.BeforeEndDefaults)
 	}
+	if weekdayFeature && w.Weekdays != "" {
+		if err := validateWeekdays(w.Weekdays); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -175,7 +210,7 @@ func validateWindowFields(w Window) error {
 // the existing checkTimeRangeAt semantics).
 //
 // Returns nil when no window contains now.
-func ResolveActiveWindow(windows []Window, now time.Time) *Window {
+func ResolveActiveWindow(windows []Window, now time.Time, weekdayFeature bool) *Window {
 	for i := range windows {
 		startTime, err := parseClock(windows[i].Start)
 		if err != nil {
@@ -195,12 +230,26 @@ func ResolveActiveWindow(windows []Window, now time.Time) *Window {
 			inRange := (now.After(startAt) || now.Equal(startAt)) ||
 				(now.Before(endAt) || now.Equal(endAt))
 			if inRange {
+				if weekdayFeature && windows[i].Weekdays != "" {
+					effectiveDay := now.Weekday()
+					if now.Before(startAt) {
+						effectiveDay = now.Add(-24 * time.Hour).Weekday()
+					}
+					if wdSet, err := parseWeekdays(windows[i].Weekdays); err == nil && !wdSet[effectiveDay] {
+						continue
+					}
+				}
 				return &windows[i]
 			}
 		} else {
 			inRange := (now.After(startAt) || now.Equal(startAt)) &&
 				(now.Before(endAt) || now.Equal(endAt))
 			if inRange {
+				if weekdayFeature && windows[i].Weekdays != "" {
+					if wdSet, err := parseWeekdays(windows[i].Weekdays); err == nil && !wdSet[now.Weekday()] {
+						continue
+					}
+				}
 				return &windows[i]
 			}
 		}
@@ -271,4 +320,92 @@ func expandClockMinutes(startMinute, endMinute int) []clockSegment {
 // after the end clock time, indicating a window that spans midnight.
 func isCrossMidnightWindow(startTime, endTime time.Time) bool {
 	return startTime.After(endTime)
+}
+
+// parseWeekdays parses a weekday expression string into a set of
+// time.Weekday values. It accepts single days ("mon"), comma-separated
+// lists ("mon,fri"), inclusive ranges ("mon-fri"), and combinations
+// ("mon-fri,sun"). Returns an error on unknown tokens or empty elements.
+//
+// An empty string returns (nil, nil) — caller should treat this as "all days".
+// ParseWeekdays is the exported entry point for parsing weekday
+// expressions. See parseWeekdays for the full contract.
+func ParseWeekdays(s string) (map[time.Weekday]bool, error) {
+	return parseWeekdays(s)
+}
+
+func parseWeekdays(s string) (map[time.Weekday]bool, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	result := make(map[time.Weekday]bool)
+	parts := strings.Split(s, ",")
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("invalid weekdays %q: empty element", s)
+		}
+
+		if strings.Contains(part, "-") {
+			rangeParts := strings.SplitN(part, "-", 2)
+			if len(rangeParts) != 2 || rangeParts[0] == "" || rangeParts[1] == "" {
+				return nil, fmt.Errorf("invalid weekdays %q: malformed range %q", s, part)
+			}
+			startWd, startOk := weekdayNames[rangeParts[0]]
+			endWd, endOk := weekdayNames[rangeParts[1]]
+			if !startOk || !endOk {
+				return nil, fmt.Errorf("invalid weekdays %q: unknown token in range %q", s, part)
+			}
+			for wd := startWd; ; wd = (wd + 1) % 7 {
+				result[wd] = true
+				if wd == endWd {
+					break
+				}
+			}
+		} else {
+			wd, ok := weekdayNames[part]
+			if !ok {
+				return nil, fmt.Errorf("invalid weekdays %q: unknown token %q", s, part)
+			}
+			result[wd] = true
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
+// validateWeekdays validates a weekday expression string by parsing it and
+// returning any parse error. An empty string (all days) is valid.
+func validateWeekdays(s string) error {
+	_, err := parseWeekdays(s)
+	return err
+}
+
+// weekdaySetsIntersect returns true when the two weekday expressions could
+// activate on the same calendar day. An empty string for either set means
+// "all days" and always intersects.
+func weekdaySetsIntersect(a, b string) bool {
+	if a == "" || b == "" {
+		return true
+	}
+
+	setA, errA := parseWeekdays(a)
+	setB, errB := parseWeekdays(b)
+	if errA != nil || errB != nil {
+		// Parse errors mean the sets can't be meaningfully compared;
+		// default to intersecting so validation still catches real issues.
+		return true
+	}
+
+	for wd := range setA {
+		if setB[wd] {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/power/window_test.go
+++ b/pkg/power/window_test.go
@@ -15,12 +15,12 @@ func TestValidateWindows_TwoNonOverlapping(t *testing.T) {
 		{Name: "night", Start: "02:00", End: "06:00", MaxCharge: 3500},
 		{Name: "midday", Start: "12:00", End: "15:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
 func TestValidateWindows_EmptyList(t *testing.T) {
-	err := ValidateWindows([]Window{})
+	err := ValidateWindows([]Window{}, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one entry")
 }
@@ -37,18 +37,18 @@ func TestResolveActiveWindow_TwoWindows(t *testing.T) {
 	base := time.Date(2026, 6, 3, 0, 0, 0, 0, time.Local)
 
 	// 04:00 → night window.
-	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 4, 0, 0, 0, time.Local))
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 4, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "night", active.Name)
 	_ = base
 
 	// 13:00 → midday window.
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 13, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 13, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "midday", active.Name)
 
 	// 09:00 → no window active.
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 9, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 9, 0, 0, 0, time.Local), true)
 	assert.Nil(t, active)
 }
 
@@ -59,22 +59,22 @@ func TestResolveActiveWindow_CrossMidnightPlusDaytime(t *testing.T) {
 	}
 
 	// 23:00 → night window.
-	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 23, 0, 0, 0, time.Local))
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 23, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "night", active.Name)
 
 	// 03:00 (next day still night, cross-midnight).
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 4, 3, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 4, 3, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "night", active.Name)
 
 	// 12:00 → day window.
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 12, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 12, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "day", active.Name)
 
 	// 08:00 → no window.
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 8, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 8, 0, 0, 0, time.Local), true)
 	assert.Nil(t, active)
 }
 
@@ -84,17 +84,17 @@ func TestResolveActiveWindow_BoundaryTickInclusive(t *testing.T) {
 	}
 
 	// Exactly at start → active.
-	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 2, 0, 0, 0, time.Local))
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 2, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "morning", active.Name)
 
 	// Exactly at end → active (inclusive end).
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 0, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "morning", active.Name)
 
 	// One minute after end → not active.
-	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 1, 0, 0, time.Local))
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 1, 0, 0, time.Local), true)
 	assert.Nil(t, active)
 }
 
@@ -107,7 +107,7 @@ func TestResolveActiveWindow_FirstWindowWinsAtSharedBoundary(t *testing.T) {
 		{Name: "B", Start: "06:00", End: "10:00", MaxCharge: 2000},
 	}
 
-	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 0, 0, 0, time.Local))
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 3, 6, 0, 0, 0, time.Local), true)
 	require.NotNil(t, active)
 	assert.Equal(t, "A", active.Name)
 }
@@ -119,7 +119,7 @@ func TestValidateWindows_OverlappingRejected(t *testing.T) {
 		{Name: "A", Start: "02:00", End: "06:00", MaxCharge: 3500},
 		{Name: "B", Start: "04:00", End: "08:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overlaps")
 }
@@ -129,7 +129,7 @@ func TestValidateWindows_CrossMidnightOverlapRejected(t *testing.T) {
 		{Name: "night", Start: "22:00", End: "04:00", MaxCharge: 3000},
 		{Name: "early", Start: "03:00", End: "08:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overlaps")
 }
@@ -140,7 +140,7 @@ func TestValidateWindows_AdjacentNonOverlapping(t *testing.T) {
 		{Name: "A", Start: "02:00", End: "06:00", MaxCharge: 1000},
 		{Name: "B", Start: "06:00", End: "10:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "end 06:00 equals window \"B\" start 06:00")
 }
@@ -151,7 +151,7 @@ func TestValidateWindows_CrossMidnightAdjacentNonOverlapping(t *testing.T) {
 		{Name: "night", Start: "22:00", End: "04:00", MaxCharge: 3000},
 		{Name: "early", Start: "04:00", End: "08:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "end 04:00 equals window \"early\" start 04:00")
 }
@@ -162,7 +162,7 @@ func TestValidateWindows_EqualBoundaryBetweenFirstAndSecond(t *testing.T) {
 		{Name: "B", Start: "12:00", End: "18:00", MaxCharge: 2000},
 		{Name: "C", Start: "18:01", End: "22:00", MaxCharge: 1500},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "equals")
 }
@@ -172,7 +172,7 @@ func TestValidateWindows_AdjacentNonEqualBoundariesPasses(t *testing.T) {
 		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
 		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -180,7 +180,7 @@ func TestValidateWindows_SingleWindowPasses(t *testing.T) {
 	windows := []Window{
 		{Name: "only", Start: "06:00", End: "22:00", MaxCharge: 3000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -192,7 +192,7 @@ func TestValidateWindows_EqualBoundaryNonAdjacentRejected(t *testing.T) {
 		{Name: "B", Start: "14:00", End: "18:00", MaxCharge: 2000},
 		{Name: "C", Start: "10:00", End: "12:00", MaxCharge: 1500},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "equals")
 }
@@ -203,7 +203,7 @@ func TestValidateWindows_ZeroWidthRejected(t *testing.T) {
 	windows := []Window{
 		{Name: "zero", Start: "02:00", End: "02:00", MaxCharge: 3500},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "zero-width")
 }
@@ -212,7 +212,7 @@ func TestValidateWindows_InvalidTimeFormat(t *testing.T) {
 	windows := []Window{
 		{Name: "bad", Start: "25:00", End: "26:00", MaxCharge: 3500},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid start time")
 }
@@ -221,7 +221,7 @@ func TestValidateWindows_InvalidForecastHorizon(t *testing.T) {
 	windows := []Window{
 		{Name: "bad-fh", Start: "02:00", End: "06:00", MaxCharge: 3500, ForecastHorizon: "bogus"},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forecast_horizon")
 }
@@ -230,7 +230,7 @@ func TestValidateWindows_InvalidConsumptionHorizon(t *testing.T) {
 	windows := []Window{
 		{Name: "bad-ch", Start: "02:00", End: "06:00", MaxCharge: 3500, ConsumptionHorizon: "bogus"},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "consumption_horizon")
 }
@@ -239,7 +239,7 @@ func TestValidateWindows_NegativeMaxCharge(t *testing.T) {
 	windows := []Window{
 		{Name: "neg", Start: "02:00", End: "06:00", MaxCharge: -100},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_charge")
 }
@@ -254,7 +254,7 @@ func TestValidateWindows_AutoNameForErrorMessages(t *testing.T) {
 		{Start: "02:00", End: "06:00", MaxCharge: 3500},
 		{Start: "04:00", End: "08:00", MaxCharge: 2000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "window-1")
 	assert.Contains(t, err.Error(), "window-2")
@@ -287,7 +287,7 @@ func TestValidateWindows_CrossMidnightValid(t *testing.T) {
 	windows := []Window{
 		{Name: "night", Start: "22:00", End: "04:00", MaxCharge: 3000},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -300,7 +300,7 @@ func TestValidateWindows_TickMinutesValid(t *testing.T) {
 	windows := []Window{
 		{Name: "fast", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(30)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -308,7 +308,7 @@ func TestValidateWindows_TickMinutesZeroRejected(t *testing.T) {
 	windows := []Window{
 		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(0)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tick_minutes")
 }
@@ -317,7 +317,7 @@ func TestValidateWindows_TickMinutesNegativeRejected(t *testing.T) {
 	windows := []Window{
 		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500, TickMinutes: intPtr(-1)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tick_minutes")
 }
@@ -327,7 +327,7 @@ func TestValidateWindows_DefaultsAndBeforeEndValid(t *testing.T) {
 		{Name: "with-defaults", Start: "06:00", End: "07:00", MaxCharge: 3500,
 			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(10)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -336,7 +336,7 @@ func TestValidateWindows_BeforeEndDefaultsZeroValid(t *testing.T) {
 		{Name: "at-end", Start: "06:00", End: "07:00", MaxCharge: 3500,
 			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(0)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
 }
 
@@ -345,7 +345,7 @@ func TestValidateWindows_BeforeEndDefaultsNegativeRejected(t *testing.T) {
 		{Name: "bad", Start: "06:00", End: "07:00", MaxCharge: 3500,
 			Defaults: boolPtr(true), BeforeEndDefaults: intPtr(-1)},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "before_end_defaults")
 }
@@ -355,6 +355,216 @@ func TestValidateWindows_NewFieldsOptional(t *testing.T) {
 	windows := []Window{
 		{Name: "plain", Start: "06:00", End: "07:00", MaxCharge: 3500},
 	}
-	err := ValidateWindows(windows)
+	err := ValidateWindows(windows, true)
 	assert.NoError(t, err)
+}
+
+// --- Weekday parsing tests ---
+
+func TestParseWeekdays_SingleDay(t *testing.T) {
+	set, err := parseWeekdays("mon")
+	assert.NoError(t, err)
+	assert.True(t, set[time.Monday])
+	assert.Len(t, set, 1)
+}
+
+func TestParseWeekdays_CommaList(t *testing.T) {
+	set, err := parseWeekdays("mon,fri")
+	assert.NoError(t, err)
+	assert.True(t, set[time.Monday])
+	assert.True(t, set[time.Friday])
+	assert.Len(t, set, 2)
+}
+
+func TestParseWeekdays_Range(t *testing.T) {
+	set, err := parseWeekdays("mon-fri")
+	assert.NoError(t, err)
+	for wd := time.Monday; wd <= time.Friday; wd++ {
+		assert.True(t, set[wd], "expected %s to be in set", wd.String())
+	}
+	assert.Len(t, set, 5)
+}
+
+func TestParseWeekdays_RangeAndSingle(t *testing.T) {
+	set, err := parseWeekdays("mon-fri,sun")
+	assert.NoError(t, err)
+	assert.Len(t, set, 6)
+	assert.True(t, set[time.Sunday])
+}
+
+func TestParseWeekdays_OverlappingRangesFlattened(t *testing.T) {
+	set, err := parseWeekdays("mon-wed,tue-thu")
+	assert.NoError(t, err)
+	assert.Len(t, set, 4)
+}
+
+func TestParseWeekdays_SingleDayRange(t *testing.T) {
+	set, err := parseWeekdays("mon-mon")
+	assert.NoError(t, err)
+	assert.Len(t, set, 1)
+	assert.True(t, set[time.Monday])
+}
+
+func TestParseWeekdays_EmptyString(t *testing.T) {
+	set, err := parseWeekdays("")
+	assert.NoError(t, err)
+	assert.Nil(t, set)
+}
+
+func TestParseWeekdays_UnknownToken(t *testing.T) {
+	_, err := parseWeekdays("mon,xyz")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown token")
+}
+
+func TestParseWeekdays_UnknownTokenInRange(t *testing.T) {
+	_, err := parseWeekdays("mon-xyz")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown token")
+}
+
+func TestParseWeekdays_EmptyElement(t *testing.T) {
+	_, err := parseWeekdays("mon,,fri")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty element")
+}
+
+func TestParseWeekdays_CaseSensitiveRejected(t *testing.T) {
+	_, err := parseWeekdays("MON")
+	assert.Error(t, err)
+}
+
+func TestParseWeekdays_MixedCaseRangeRejected(t *testing.T) {
+	_, err := parseWeekdays("mon-FRI")
+	assert.Error(t, err)
+}
+
+// --- Weekday-aware ValidateWindows tests ---
+
+func TestValidateWindows_DisjointWeekdaysNoOverlap(t *testing.T) {
+	windows := []Window{
+		{Name: "weekday", Start: "22:00", End: "04:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+		{Name: "weekend", Start: "22:00", End: "04:00", MaxCharge: 5000, Weekdays: "sat,sun"},
+	}
+	err := ValidateWindows(windows, true)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_OverlappingWeekdaysStillRejected(t *testing.T) {
+	windows := []Window{
+		{Name: "A", Start: "22:00", End: "04:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+		{Name: "B", Start: "22:00", End: "04:00", MaxCharge: 5000, Weekdays: "fri,sat"},
+	}
+	err := ValidateWindows(windows, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "overlaps")
+}
+
+func TestValidateWindows_DisjointWeekdaysAdjacentBoundaryPasses(t *testing.T) {
+	windows := []Window{
+		{Name: "weekday", Start: "22:00", End: "06:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+		{Name: "weekend", Start: "06:00", End: "22:00", MaxCharge: 5000, Weekdays: "sat,sun"},
+	}
+	err := ValidateWindows(windows, true)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_InvalidWeekdaysRejectedWithFlag(t *testing.T) {
+	windows := []Window{
+		{Name: "bad", Start: "02:00", End: "06:00", MaxCharge: 3500, Weekdays: "xyz"},
+	}
+	err := ValidateWindows(windows, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "weekdays")
+}
+
+func TestValidateWindows_InvalidWeekdaysAcceptedWhenFlagDisabled(t *testing.T) {
+	windows := []Window{
+		{Name: "bad", Start: "02:00", End: "06:00", MaxCharge: 3500, Weekdays: "xyz"},
+	}
+	err := ValidateWindows(windows, false)
+	assert.NoError(t, err)
+}
+
+func TestValidateWindows_OneEmptyWeekdaysAlwaysOverlaps(t *testing.T) {
+	windows := []Window{
+		{Name: "A", Start: "22:00", End: "04:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+		{Name: "B", Start: "22:00", End: "04:00", MaxCharge: 5000},
+	}
+	err := ValidateWindows(windows, true)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "overlaps")
+}
+
+// --- Weekday-aware ResolveActiveWindow tests ---
+
+func TestResolveActiveWindow_WeekdayMatch(t *testing.T) {
+	windows := []Window{
+		{Name: "weekday", Start: "10:00", End: "14:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+	}
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 1, 12, 0, 0, 0, time.Local), true)
+	require.NotNil(t, active)
+	assert.Equal(t, "weekday", active.Name)
+}
+
+func TestResolveActiveWindow_WeekdayNoMatch(t *testing.T) {
+	windows := []Window{
+		{Name: "weekday", Start: "10:00", End: "14:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+	}
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 6, 12, 0, 0, 0, time.Local), true)
+	assert.Nil(t, active)
+}
+
+func TestResolveActiveWindow_CrossMidnightStartDayModel(t *testing.T) {
+	windows := []Window{
+		{Name: "fri-night", Start: "22:00", End: "04:00", MaxCharge: 3500, Weekdays: "fri"},
+	}
+	// Friday 23:00 — start day is Friday
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 5, 23, 0, 0, 0, time.Local), true)
+	require.NotNil(t, active)
+	assert.Equal(t, "fri-night", active.Name)
+
+	// Saturday 03:00 — post-midnight, start day is still Friday
+	active = ResolveActiveWindow(windows, time.Date(2026, 6, 6, 3, 0, 0, 0, time.Local), true)
+	require.NotNil(t, active)
+	assert.Equal(t, "fri-night", active.Name)
+}
+
+func TestResolveActiveWindow_CrossMidnightNotActiveNextDayStart(t *testing.T) {
+	windows := []Window{
+		{Name: "fri-night", Start: "22:00", End: "04:00", MaxCharge: 3500, Weekdays: "fri"},
+	}
+	// Saturday 23:00 — start day is Saturday, not Friday, should NOT be active
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 6, 23, 0, 0, 0, time.Local), true)
+	assert.Nil(t, active)
+}
+
+func TestResolveActiveWindow_EmptyWeekdaysAlwaysActive(t *testing.T) {
+	windows := []Window{
+		{Name: "always", Start: "10:00", End: "14:00", MaxCharge: 3500},
+	}
+	// Saturday with no weekday filter
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 6, 12, 0, 0, 0, time.Local), true)
+	require.NotNil(t, active)
+	assert.Equal(t, "always", active.Name)
+}
+
+func TestResolveActiveWindow_FeatureDisabledIgnoresWeekdays(t *testing.T) {
+	windows := []Window{
+		{Name: "weekday", Start: "10:00", End: "14:00", MaxCharge: 3500, Weekdays: "mon-fri"},
+	}
+	// Saturday with feature disabled — should still be active
+	active := ResolveActiveWindow(windows, time.Date(2026, 6, 6, 12, 0, 0, 0, time.Local), false)
+	require.NotNil(t, active)
+	assert.Equal(t, "weekday", active.Name)
+}
+
+func TestValidateWindows_FeatureDisabledOverlapPasses(t *testing.T) {
+	windows := []Window{
+		{Name: "A", Start: "02:00", End: "06:00", MaxCharge: 3500},
+		{Name: "B", Start: "04:00", End: "08:00", MaxCharge: 2000},
+	}
+	err := ValidateWindows(windows, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "overlaps")
 }


### PR DESCRIPTION
## Summary

Users can now assign charge windows to specific days of the week. This is the missing piece for households with different electricity rates on weekdays vs. weekends — a single sbam instance can now handle both with one config, instead of running separate instances.

From beta tester feedback in [discussion #164](https://github.com/atbore-phx/sbam/discussions/164): *"My off peak is from 21:00 till 07:00 Monday to Friday. Weekends are all off peak. The window function doesn't have a day selection."*

## What changed

Each window accepts an optional `weekdays` field using a compact expression format:

```yaml
weekdays: "mon-fri"        # Monday through Friday
weekdays: "mon,fri"        # Monday and Friday only
weekdays: "mon-fri,sun"    # weekdays plus Sunday
```

A cross-midnight window uses the **start-day model**: `start: "22:00", end: "04:00", weekdays: "fri"` is active Friday 22:00 through Saturday 04:00, but not Saturday 22:00. You never need to think about the carry-over day — the day the window opens determines the weekday.

Two windows with the same clock range but different weekday sets (e.g., `mon-fri` and `sat,sun`) validate without overlap errors — they never activate on the same calendar day.

A `weekday_feature` kill switch (default `true`) gates all weekday logic. Set it to `false` to disable filtering without editing window definitions.

## Design decisions

- **String format over array.** `"mon-fri,sun"` is more compact in YAML than `["mon","tue","wed","thu","fri","sun"]`, and follows the existing `ForecastHorizon`/`ConsumptionHorizon` pattern of storing a validated string.
- **Start-day model over "no cross-midnight with weekdays."** The alternative (rejecting cross-midnight when weekdays are set) would force users to split a natural "Monday night" window into two unintuitive entries with confusing day labels. The start-day model is one rule: the day the window opens.
- **Feature flag as kill switch, not phased rollout.** `weekday_feature` defaults to `true` so the feature ships enabled. It exists so a maintainer can disable it with one config change if a bug surfaces.

## Configuration surface

| Surface | Key |
|---|---|
| config.yaml | `weekday_feature: true` |
| config.yaml | `windows[].weekdays: "mon-fri"` |
| CLI | `--weekday_feature` |
| Env | `WEEKDAY_FEATURE` |
| HA add-on | `weekday_feature: bool`, `weekdays: str?` |

## Test plan

- 12 parsing tests covering single days, comma lists, ranges, combinations, empty strings, unknown tokens, empty elements, and case sensitivity
- 6 validation tests for overlap detection with disjoint/overlapping weekday sets, adjacent-boundary gating, and feature-flag gating
- 6 resolution tests for weekday matching, cross-midnight start-day model, empty weekdays backward compatibility, and feature-flag bypass
- All existing tests updated for the new function signatures
- `make all` (fmt, tidy, vet, test -race, build) passes

Closes #177.
Ref #151.
Ref #164.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
