### PR TITLE
fix(cmd): keep runner alive in windows mode without MQTT

### DIFF
--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -284,7 +284,7 @@ var scdCmd = &cobra.Command{
 			return
 		}
 
-		if err := finalizeRunnerMode(mqtt_enabled, runner, runDone, stop); err != nil {
+		if err := finalizeRunnerMode(mqtt_enabled, scheduler_mode, runner, runDone, stop); err != nil {
 			u.Log.Error(err)
 		}
 	},
@@ -583,13 +583,16 @@ func makeBasePayload(lastDecision, lastReason string, inChargeWindow, reserveWin
 	}
 }
 
-// finalizeRunnerMode stops the runner immediately when MQTT is disabled
-// (non-interactive mode) or blocks until the runner completes when MQTT
-// is enabled (interactive mode). When stopping the runner it submits a
-// shutdown intent and waits for the runner goroutine to finish.
-func finalizeRunnerMode(mqttEnabled bool, runner *Runner, runDone <-chan error, stop context.CancelFunc) error {
-	if !mqttEnabled {
-		u.Log.Info("MQTT integration disabled, stopping runner")
+// finalizeRunnerMode either blocks until the runner completes (interactive
+// mode) or stops the runner immediately (non-interactive mode). The runner
+// is kept alive when MQTT is enabled or when the scheduler mode has its own
+// internal driver (e.g. windows, auto). Only crontab mode reaches this
+// function without an internal driver — when crontab is configured,
+// crontabSchedule blocks and finalizeRunnerMode is never reached. When
+// stopping, it submits a shutdown intent and waits for the runner to finish.
+func finalizeRunnerMode(mqttEnabled bool, schedulerMode string, runner *Runner, runDone <-chan error, stop context.CancelFunc) error {
+	if !mqttEnabled && schedulerMode == "crontab" {
+		u.Log.Info("MQTT integration disabled and no internal driver active, stopping runner")
 		_ = runner.Submit(mqtt.Intent{Kind: mqtt.IntentShutdown})
 		if stop != nil {
 			stop()
@@ -597,7 +600,7 @@ func finalizeRunnerMode(mqttEnabled bool, runner *Runner, runDone <-chan error, 
 		return waitForRunnerDone(runDone)
 	}
 
-	u.Log.Info("MQTT integration enabled, waiting for commands... press ctrl+c to exit...")
+	u.Log.Info("MQTT integration enabled or internal scheduler active, waiting for commands... press ctrl+c to exit...")
 	return waitForRunnerDone(runDone)
 }
 

--- a/pkg/cmd/schedule_lifecycle_test.go
+++ b/pkg/cmd/schedule_lifecycle_test.go
@@ -21,7 +21,7 @@ func TestFinalizeRunnerModeMQTTEnabledWaitsForSignal(t *testing.T) {
 
 	finalized := make(chan error, 1)
 	go func() {
-		finalized <- finalizeRunnerMode(true, runner, runDone, stop)
+		finalized <- finalizeRunnerMode(true, "crontab", runner, runDone, stop)
 	}()
 
 	select {
@@ -50,8 +50,41 @@ func TestFinalizeRunnerModeMQTTDisabledStopsRunner(t *testing.T) {
 		runDone <- runner.Run(ctx)
 	}()
 
-	err := finalizeRunnerMode(false, runner, runDone, nil)
+	err := finalizeRunnerMode(false, "crontab", runner, runDone, nil)
 	require.NoError(t, err)
+}
+
+func TestFinalizeRunnerModeWindowsMQTTDisabledKeepsRunning(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+
+	runner := NewRunner(RunnerConfig{Now: time.Now}, nil)
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- runner.Run(ctx)
+	}()
+
+	finalized := make(chan error, 1)
+	go func() {
+		finalized <- finalizeRunnerMode(false, "windows", runner, runDone, stop)
+	}()
+
+	// Windows mode with MQTT disabled should NOT return immediately —
+	// the runner should stay alive, driven by its internal ticker.
+	select {
+	case err := <-finalized:
+		t.Fatalf("finalizeRunnerMode returned before signal in windows mode: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	stop()
+
+	select {
+	case err := <-finalized:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("finalizeRunnerMode did not return after stop in windows mode")
+	}
 }
 
 func TestWaitForRunnerDoneRejectsNilChannel(t *testing.T) {

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -1636,7 +1636,7 @@ func TestFinalizeRunnerMode_MQTTEnabled(t *testing.T) {
 	// Submit shutdown so Run exits cleanly.
 	runner.Submit(mqtt.Intent{Kind: mqtt.IntentShutdown})
 
-	err := finalizeRunnerMode(true, runner, runDone, cancel)
+	err := finalizeRunnerMode(true, "crontab", runner, runDone, cancel)
 	require.NoError(t, err)
 }
 

--- a/pkg/cmd/schedule_test.go
+++ b/pkg/cmd/schedule_test.go
@@ -707,7 +707,7 @@ func TestFinalizeRunnerMode_NilStop(t *testing.T) {
 		runDone <- runner.Run(ctx)
 	}()
 
-	err := finalizeRunnerMode(false, runner, runDone, nil)
+	err := finalizeRunnerMode(false, "crontab", runner, runDone, nil)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
When `scheduler_mode` is `windows` and `mqtt_enabled` is `false`, the runner process would exit immediately after starting the windows ticker — no charge windows were ever executed.

The root cause: `finalizeRunnerMode` only checked `mqtt_enabled` to decide whether to keep the runner alive, ignoring that windows mode has its own internal ticker. When MQTT was disabled, it unconditionally shut down.

The fix: `finalizeRunnerMode` now checks `!mqttEnabled && schedulerMode == "crontab"` — it only shuts down for crontab mode, which has no internal driver when no crontab expression is configured. Windows mode (and future modes like `auto`) stay alive regardless of MQTT state.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
