### PR TITLE
feat(power,cmd): add to_next_window consumption horizon

### DIFF
--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -111,6 +111,29 @@ The battery reserve defines a minimum charge level to maintain during the reserv
 | `remaining_today` | Scale `pw_consumption` proportionally to the fraction of the local day remaining. |
 | `to_next_window` | Scale `pw_consumption` by the time from now until the next charge window starts (`pw_consumption × hours / 24`). The span may cross midnight, and may exceed 24 h for weekday-gapped windows — the result is the expected consumption until the next charge opportunity. Falls back to `remaining_today` when no next window can be resolved. |
 
+!!! info "How `to_next_window` picks the next window"
+    The "next window" is resolved as the window whose **start is soonest
+    after now**, scanned across *all* configured windows and honouring each
+    window's [weekday filter](weekdays.md). It is **not** the next entry in
+    the `windows:` list, so:
+
+    - **Config order does not matter.** Windows may be listed in any order;
+      the nearest upcoming start always wins.
+    - **A later-same-day window is preferred over tomorrow.** With, say, a
+      morning and an afternoon window, sitting inside the morning window
+      sizes consumption only to the afternoon start — not to tomorrow.
+    - **Weekday-gapped coverage lengthens the span.** After a window whose
+      next occurrence is days away (e.g. a `sat`-only or `wed`-only free-power
+      window), the span — and therefore the sized consumption — can be
+      several times `pw_consumption`. This is intended: the battery must
+      carry the load until the next chance to charge. It is bounded in
+      practice by battery capacity, so the effect is simply "charge toward
+      full."
+    - **DST:** day advancement uses fixed 24 h steps. In timezones that
+      observe daylight-saving, a span that crosses a DST boundary can be off
+      by an hour. Timezones without DST (e.g. `Australia/Perth`) are
+      unaffected.
+
 ## Forecast Caching
 
 | Option | Description | CLI flag | Env var | HA add-on key | Default |

--- a/docs/site/configuration.md
+++ b/docs/site/configuration.md
@@ -109,6 +109,7 @@ The battery reserve defines a minimum charge level to maintain during the reserv
 |------|----------|
 | `full_day` | Use `pw_consumption` as-is. |
 | `remaining_today` | Scale `pw_consumption` proportionally to the fraction of the local day remaining. |
+| `to_next_window` | Scale `pw_consumption` by the time from now until the next charge window starts (`pw_consumption × hours / 24`). The span may cross midnight, and may exceed 24 h for weekday-gapped windows — the result is the expected consumption until the next charge opportunity. Falls back to `remaining_today` when no next window can be resolved. |
 
 ## Forecast Caching
 

--- a/docs/site/weekdays.md
+++ b/docs/site/weekdays.md
@@ -166,6 +166,28 @@ windows:
 On Saturday and Sunday neither window activates. The scheduler runs but
 reports "outside all configured charge windows."
 
+## Interaction with the `to_next_window` consumption horizon
+
+When any window uses the [`to_next_window` consumption horizon](configuration.md#consumption-horizon-modes),
+sbam sizes consumption to the gap until the **next window that actually
+runs**, weekday filters included. The next window is chosen by nearest
+upcoming start across all windows — never by list position — so weekday and
+weekend windows interleave correctly no matter how they are ordered.
+
+Two consequences worth planning for:
+
+- **Weekend/weekday interleaving works automatically.** Inside a Friday
+  weekday window, the next window is Saturday's weekend window (if one
+  exists); inside a Sunday weekend window, it is Monday's weekday window.
+  You do not need to order the list a particular way.
+- **A sparse day filter widens the span.** After a window that only runs on
+  one weekday (e.g. `weekdays: "wed"` free-power), the next occurrence may be
+  up to a week away. Under `to_next_window` that produces a large sized
+  consumption (up to ~7× `pw_consumption`) — by design, since the battery
+  must last until that next window. If you do **not** want the battery
+  charging toward full to cover a whole week, pair sparse-day windows with a
+  `full_day` or `remaining_today` consumption horizon instead.
+
 ## Validation Rules
 
 - Unknown weekday tokens (`mon,xyz`) are rejected at startup

--- a/home-assistant/addons/sbam/config.yaml
+++ b/home-assistant/addons/sbam/config.yaml
@@ -79,7 +79,7 @@ schema:
       end: match(^([01]?[0-9]|2[0-3]):[0-5][0-9]$)
       max_charge: float
       forecast_horizon: list(default|next_solar_day|remaining_today|today|tomorrow|off)?
-      consumption_horizon: list(full_day|remaining_today)?
+      consumption_horizon: list(full_day|remaining_today|to_next_window)?
       tick_minutes: int?
       set_defaults: bool?
       before_end_defaults_minutes: int?

--- a/pkg/cmd/schedule.go
+++ b/pkg/cmd/schedule.go
@@ -328,7 +328,7 @@ func registerScdCmd() {
 	scdCmd.Flags().BoolVar(&mqtt_ha_discovery, "mqtt_ha_discovery", true, "Enable Home Assistant MQTT discovery")
 	scdCmd.Flags().StringVar(&mqtt_ha_discovery_prefix, "mqtt_ha_discovery_prefix", const_ha_discovery_prefix, "Home Assistant MQTT discovery prefix")
 	scdCmd.Flags().StringVar(&forecast_horizon, "forecast_horizon", const_forecast_horizon, "Forecast horizon mode (default, next_solar_day, remaining_today, today, tomorrow, off)")
-	scdCmd.Flags().StringVar(&consumption_horizon, "consumption_horizon", const_consumption_horizon, "Consumption horizon mode (full_day, remaining_today)")
+	scdCmd.Flags().StringVar(&consumption_horizon, "consumption_horizon", const_consumption_horizon, "Consumption horizon mode (full_day, remaining_today, to_next_window)")
 	scdCmd.Flags().StringVar(&scheduler_mode, "scheduler_mode", const_scheduler_mode, "Scheduler mode (crontab, windows)")
 	scdCmd.Flags().BoolVar(&weekday_feature, "weekday_feature", const_weekday_feature, "Enable weekday filtering on charge windows")
 	scdCmd.Flags().String("windows", "", "Charge windows in YAML format (same as config.yaml windows: key)")

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -453,6 +453,7 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 			nextWindowStartAt = nextAt
 		} else {
 			u.Log.Warn("consumption_horizon to_next_window needs a resolvable next window; falling back to remaining_today")
+			effectiveConsumptionHorizon = pw.ConsumptionHorizonRemainingToday
 		}
 	}
 

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -248,106 +248,66 @@ func (r *Runner) scheduleDefaults(active *pw.Window, now time.Time) {
 	})
 }
 
-// nextWindowStart resolves the next upcoming window and the instant it
-// starts. When a window is active it selects the following window in the
-// ordered list (wrapping past midnight for the last one); when no window
-// is active (gapped coverage), it finds the next upcoming window start
-// from all windows. ok is false when no windows are configured or the
-// selected window's start cannot be parsed.
+// nextWindowStart resolves the next upcoming charge window and the instant
+// it starts. It scans every configured window for its next start strictly
+// after now — advancing a day at a time to honour per-window weekday
+// filters — and returns the one whose start is earliest.
+//
+// Selecting by nearest instant, rather than by position in the ordered
+// list, makes the result correct regardless of how the windows are ordered
+// in the config, how many there are, or how their weekday sets differ. The
+// currently-active window's own next start naturally falls after any window
+// that recurs sooner, so it is only chosen when it genuinely is the next
+// one (e.g. a single configured window, which wraps to its own next start).
+//
+// ok is false only when no window is configured or none has a parseable
+// start; a single malformed window is skipped rather than abandoning the
+// whole resolution.
 func (r *Runner) nextWindowStart(now time.Time) (next pw.Window, nextAt time.Time, ok bool) {
 	windows := r.cfg.Windows
 	if len(windows) == 0 {
 		return pw.Window{}, time.Time{}, false
 	}
 
-	active := pw.ResolveActiveWindow(windows, now, r.cfg.WeekdayFeature)
-
-	if active == nil {
-		// No window active — find the next window whose start is after now.
-		var best *pw.Window
-		var bestStart time.Time
-		for i := range windows {
-			startTime, err := parseScheduleClock(windows[i].Start, "start")
-			if err != nil {
-				continue
-			}
-			startAt := time.Date(now.Year(), now.Month(), now.Day(),
-				startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
-			if !startAt.After(now) {
-				startAt = startAt.Add(24 * time.Hour)
-			}
-			if r.cfg.WeekdayFeature && windows[i].Weekdays != "" {
-				if wdSet, err := pw.ParseWeekdays(windows[i].Weekdays); err == nil && len(wdSet) > 0 {
-					startAt = nextMatchingWeekday(startAt, wdSet)
-				}
-			}
-			if best == nil || startAt.Before(bestStart) {
-				best = &windows[i]
-				bestStart = startAt
+	var best *pw.Window
+	var bestStart time.Time
+	for i := range windows {
+		startTime, err := parseScheduleClock(windows[i].Start, "start")
+		if err != nil {
+			u.Log.Warnw("cannot parse window start",
+				"window", windows[i].Name, "start", windows[i].Start, "error", err)
+			continue
+		}
+		startAt := time.Date(now.Year(), now.Month(), now.Day(),
+			startTime.Hour(), startTime.Minute(), 0, 0, now.Location())
+		// Only future starts count; a start at or before now is that
+		// window's next occurrence tomorrow.
+		if !startAt.After(now) {
+			startAt = startAt.Add(24 * time.Hour)
+		}
+		if r.cfg.WeekdayFeature && windows[i].Weekdays != "" {
+			if wdSet, err := pw.ParseWeekdays(windows[i].Weekdays); err == nil && len(wdSet) > 0 {
+				startAt = nextMatchingWeekday(startAt, wdSet)
 			}
 		}
-		if best != nil {
-			next = *best
-		} else {
-			return pw.Window{}, time.Time{}, false
+		if best == nil || startAt.Before(bestStart) {
+			best = &windows[i]
+			bestStart = startAt
 		}
-	} else {
-		// Find the active window's index in the ordered list.
-		activeIdx := -1
-		for i := range windows {
-			name := pw.WindowNameOrDefault(windows[i], i)
-			if name == active.Name || (active.Name == "" && name == pw.WindowNameOrDefault(windows[i], i)) {
-				activeIdx = i
-				break
-			}
-		}
-		// Fall back to name comparison if the active window was resolved.
-		if activeIdx < 0 {
-			for i := range windows {
-				if windows[i].Name == active.Name || windows[i].Start == active.Start {
-					activeIdx = i
-					break
-				}
-			}
-		}
-		if activeIdx < 0 {
-			return pw.Window{}, time.Time{}, false
-		}
-
-		// Select the next window (wrap for last).
-		nextIdx := (activeIdx + 1) % len(windows)
-		next = windows[nextIdx]
 	}
 
-	nextStart, err := parseScheduleClock(next.Start, "start")
-	if err != nil {
-		u.Log.Warnw("cannot parse next window start",
-			"window", next.Name, "start", next.Start, "error", err)
+	if best == nil {
 		return pw.Window{}, time.Time{}, false
 	}
 
-	nextAt = time.Date(now.Year(), now.Month(), now.Day(),
-		nextStart.Hour(), nextStart.Minute(), 0, 0, now.Location())
-
-	// If nextAt is before or equal to now, advance by 24h.
-	if !nextAt.After(now) {
-		nextAt = nextAt.Add(24 * time.Hour)
-	}
-
-	if r.cfg.WeekdayFeature && next.Weekdays != "" {
-		if wdSet, err := pw.ParseWeekdays(next.Weekdays); err == nil && len(wdSet) > 0 {
-			nextAt = nextMatchingWeekday(nextAt, wdSet)
-		}
-	}
-
-	return next, nextAt, true
+	return *best, bestStart, true
 }
 
 // scheduleBoundaryTick schedules a one-shot timer that fires an IntentTick
-// at the start of the next window in the ordered list. For the last window,
-// the boundary wraps to the first window's next start + 24h. When no window
-// is active (gapped coverage), it finds the next upcoming window start
-// from all windows.
+// at the start of the next upcoming window, as resolved by nextWindowStart
+// (the nearest window start after now across all configured windows,
+// honouring weekday filters). This is what makes a later-same-day window
+// activate on time even while an earlier window is still running.
 func (r *Runner) scheduleBoundaryTick(now time.Time) {
 	next, nextAt, ok := r.nextWindowStart(now)
 	if !ok {

--- a/pkg/cmd/schedule_runner.go
+++ b/pkg/cmd/schedule_runner.go
@@ -248,20 +248,19 @@ func (r *Runner) scheduleDefaults(active *pw.Window, now time.Time) {
 	})
 }
 
-// scheduleBoundaryTick schedules a one-shot timer that fires an IntentTick
-// at the start of the next window in the ordered list. For the last window,
-// the boundary wraps to the first window's next start + 24h. When no window
+// nextWindowStart resolves the next upcoming window and the instant it
+// starts. When a window is active it selects the following window in the
+// ordered list (wrapping past midnight for the last one); when no window
 // is active (gapped coverage), it finds the next upcoming window start
-// from all windows.
-func (r *Runner) scheduleBoundaryTick(now time.Time) {
+// from all windows. ok is false when no windows are configured or the
+// selected window's start cannot be parsed.
+func (r *Runner) nextWindowStart(now time.Time) (next pw.Window, nextAt time.Time, ok bool) {
 	windows := r.cfg.Windows
 	if len(windows) == 0 {
-		return
+		return pw.Window{}, time.Time{}, false
 	}
 
 	active := pw.ResolveActiveWindow(windows, now, r.cfg.WeekdayFeature)
-
-	var next pw.Window
 
 	if active == nil {
 		// No window active — find the next window whose start is after now.
@@ -290,7 +289,7 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 		if best != nil {
 			next = *best
 		} else {
-			return
+			return pw.Window{}, time.Time{}, false
 		}
 	} else {
 		// Find the active window's index in the ordered list.
@@ -312,7 +311,7 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 			}
 		}
 		if activeIdx < 0 {
-			return
+			return pw.Window{}, time.Time{}, false
 		}
 
 		// Select the next window (wrap for last).
@@ -322,12 +321,12 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 
 	nextStart, err := parseScheduleClock(next.Start, "start")
 	if err != nil {
-		u.Log.Warnw("cannot parse next window start for boundary timer",
+		u.Log.Warnw("cannot parse next window start",
 			"window", next.Name, "start", next.Start, "error", err)
-		return
+		return pw.Window{}, time.Time{}, false
 	}
 
-	nextAt := time.Date(now.Year(), now.Month(), now.Day(),
+	nextAt = time.Date(now.Year(), now.Month(), now.Day(),
 		nextStart.Hour(), nextStart.Minute(), 0, 0, now.Location())
 
 	// If nextAt is before or equal to now, advance by 24h.
@@ -339,6 +338,20 @@ func (r *Runner) scheduleBoundaryTick(now time.Time) {
 		if wdSet, err := pw.ParseWeekdays(next.Weekdays); err == nil && len(wdSet) > 0 {
 			nextAt = nextMatchingWeekday(nextAt, wdSet)
 		}
+	}
+
+	return next, nextAt, true
+}
+
+// scheduleBoundaryTick schedules a one-shot timer that fires an IntentTick
+// at the start of the next window in the ordered list. For the last window,
+// the boundary wraps to the first window's next start + 24h. When no window
+// is active (gapped coverage), it finds the next upcoming window start
+// from all windows.
+func (r *Runner) scheduleBoundaryTick(now time.Time) {
+	next, nextAt, ok := r.nextWindowStart(now)
+	if !ok {
+		return
 	}
 
 	delay := nextAt.Sub(now)
@@ -472,8 +485,19 @@ func (r *Runner) Tick(ctx context.Context, now time.Time) error {
 		return nil
 	}
 
+	// to_next_window scales consumption to the span until the next window
+	// start; resolve that instant only when the mode needs it.
+	var nextWindowStartAt time.Time
+	if effectiveConsumptionHorizon == pw.ConsumptionHorizonToNextWindow {
+		if _, nextAt, ok := r.nextWindowStart(now); ok {
+			nextWindowStartAt = nextAt
+		} else {
+			u.Log.Warn("consumption_horizon to_next_window needs a resolvable next window; falling back to remaining_today")
+		}
+	}
+
 	effectiveConsumption := pw.ResolveConsumption(
-		effectiveConsumptionHorizon, r.cfg.PWConsumption, now)
+		effectiveConsumptionHorizon, r.cfg.PWConsumption, now, nextWindowStartAt)
 
 	var solarPowerProduction float64
 	var forecastRetrieved bool

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -2009,6 +2009,63 @@ func TestRunner_NextWindowStart_NoWindows(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// 2026-07-10 is a Friday; 07-11 Saturday, 07-13 Monday, 07-17 Friday.
+
+func TestRunner_NextWindowStart_WeekdayGapSpansWeekend(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.WeekdayFeature = true
+	runner.cfg.Windows = []pw.Window{
+		{Name: "wd-night", Start: "01:00", End: "05:00", MaxCharge: 2000, Weekdays: "mon-fri"},
+	}
+
+	// Friday 06:00, after today's run -- next occurrence is Monday 01:00,
+	// skipping the weekend. Under to_next_window this is the >24h span.
+	now := time.Date(2026, time.July, 10, 6, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "wd-night", next.Name)
+	assert.Equal(t, time.Date(2026, time.July, 13, 1, 0, 0, 0, time.UTC), nextAt)
+}
+
+func TestRunner_NextWindowStart_WeekendWeekdayInterleave(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.WeekdayFeature = true
+	runner.cfg.Windows = []pw.Window{
+		{Name: "wd", Start: "06:00", End: "08:00", MaxCharge: 2000, Weekdays: "mon-fri"},
+		{Name: "we", Start: "01:00", End: "03:00", MaxCharge: 2000, Weekdays: "sat-sun"},
+	}
+
+	// Friday 07:00 inside wd -- next is Saturday's we window at 01:00,
+	// not wd's own Monday recurrence, regardless of list order.
+	now := time.Date(2026, time.July, 10, 7, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "we", next.Name)
+	assert.Equal(t, time.Date(2026, time.July, 11, 1, 0, 0, 0, time.UTC), nextAt)
+}
+
+func TestRunner_NextWindowStart_CrossMidnightWeekdayFilter(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.WeekdayFeature = true
+	runner.cfg.Windows = []pw.Window{
+		{Name: "fri-night", Start: "23:00", End: "06:00", MaxCharge: 2000, Weekdays: "fri"},
+	}
+
+	// Saturday 01:00, inside Friday's cross-midnight run -- the weekday
+	// filter applies to the start day, so the next start is NEXT Friday.
+	now := time.Date(2026, time.July, 11, 1, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "fri-night", next.Name)
+	assert.Equal(t, time.Date(2026, time.July, 17, 23, 0, 0, 0, time.UTC), nextAt)
+}
+
 // --- to_next_window consumption horizon wiring in Tick ---
 
 func TestRunner_Tick_ToNextWindowConsumption(t *testing.T) {

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -26,11 +26,16 @@ type fakeBatteryWriter struct {
 }
 
 // stubFroniusClient is a test helper that implements the froniusClient
-// interface and records the number of Handler calls.
-type stubFroniusClient struct{ calls int }
+// interface and records the number of Handler calls and the consumption
+// value it was last invoked with.
+type stubFroniusClient struct {
+	calls           int
+	lastConsumption float64
+}
 
 func (s *stubFroniusClient) Handler(pw_forecast float64, pw_batt2charge float64, pw_batt_max float64, pw_consumption float64, max_charge float64, pw_batt_reserve float64, start_hr string, end_hr string, fronius_ip string, batt_reserve_charge_enabled bool, pw_lwt float64, pw_upt float64, forecast_charge_enabled bool, fronius_port ...string) (int16, fronius.Decision, fronius.Reason, fronius.PowerState, error) {
 	s.calls++
+	s.lastConsumption = pw_consumption
 	return 0, fronius.DecisionIdle, "stub", fronius.PowerState{}, nil
 }
 
@@ -1938,4 +1943,137 @@ func TestRunner_ScheduleBoundaryTick_NoWindows(t *testing.T) {
 	runner.scheduleBoundaryTick(now)
 
 	assert.False(t, called, "timer should not be created when no windows configured")
+}
+
+// --- next window start resolution (shared by boundary timer and
+// to_next_window consumption horizon) ---
+
+func TestRunner_NextWindowStart_InsideWindow(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	// 12:00 in day window -- next start is night at 22:00 today.
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "night", next.Name)
+	assert.Equal(t, time.Date(2026, time.May, 10, 22, 0, 0, 0, time.UTC), nextAt)
+}
+
+func TestRunner_NextWindowStart_CrossesMidnight(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	// 23:00 in night window -- next start wraps to day at 06:00 tomorrow.
+	now := time.Date(2026, time.May, 10, 23, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "day", next.Name)
+	assert.Equal(t, time.Date(2026, time.May, 11, 6, 0, 0, 0, time.UTC), nextAt)
+}
+
+func TestRunner_NextWindowStart_GappedCoverage(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "morning", Start: "09:00", End: "11:00", MaxCharge: 2000},
+		{Name: "evening", Start: "18:00", End: "20:00", MaxCharge: 2000},
+	}
+
+	// 14:00 is in a gap -- soonest upcoming start is evening at 18:00.
+	now := time.Date(2026, time.May, 10, 14, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "evening", next.Name)
+	assert.Equal(t, time.Date(2026, time.May, 10, 18, 0, 0, 0, time.UTC), nextAt)
+}
+
+func TestRunner_NextWindowStart_NoWindows(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	_, _, ok := runner.nextWindowStart(now)
+
+	assert.False(t, ok)
+}
+
+// --- to_next_window consumption horizon wiring in Tick ---
+
+func TestRunner_Tick_ToNextWindowConsumption(t *testing.T) {
+	client := newFakeClient()
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	oldPowerFactory := newPower
+	newPower = func() powerClient { return &fakePowerClient{forecastWh: 0, retrieved: false} }
+	defer func() { newPower = oldPowerFactory }()
+
+	stub := &stubFroniusClient{}
+	oldFroniusFactory := newFronius
+	newFronius = func() froniusClient { return stub }
+	defer func() { newFronius = oldFroniusFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "day", Start: "06:00", End: "21:59", MaxCharge: 0,
+			ConsumptionHorizon: pw.ConsumptionHorizonToNextWindow},
+		{Name: "night", Start: "22:00", End: "05:59", MaxCharge: 2000},
+	}
+
+	// 12:00 in day window, next window starts at 22:00 -- 10h span, so
+	// consumption is PWConsumption (1000) * 10/24.
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, runner.Tick(context.Background(), now))
+
+	require.Equal(t, 1, stub.calls)
+	assert.InDelta(t, 1000.0*10.0/24.0, stub.lastConsumption, 0.01)
+
+	// The published state reports the effective horizon.
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	assert.Equal(t, pw.ConsumptionHorizonToNextWindow, state.ConsumptionHorizon)
+}
+
+func TestRunner_Tick_ToNextWindowFallsBackWithoutWindows(t *testing.T) {
+	client := newFakeClient()
+	fakeStorage := &fakeStorageClient{capacityToCharge: 500, capacityMax: 10000, socPct: 40}
+	oldStorageFactory := newStorage
+	newStorage = func() storageClient { return fakeStorage }
+	defer func() { newStorage = oldStorageFactory }()
+
+	oldPowerFactory := newPower
+	newPower = func() powerClient { return &fakePowerClient{forecastWh: 0, retrieved: false} }
+	defer func() { newPower = oldPowerFactory }()
+
+	stub := &stubFroniusClient{}
+	oldFroniusFactory := newFronius
+	newFronius = func() froniusClient { return stub }
+	defer func() { newFronius = oldFroniusFactory }()
+
+	runner := newRunnerForTests(client)
+	runner.cfg.ConsumptionHorizon = pw.ConsumptionHorizonToNextWindow
+
+	// No windows configured -- to_next_window cannot resolve a start and
+	// falls back to remaining_today: at 12:00 that is half of 1000.
+	now := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, runner.Tick(context.Background(), now))
+
+	require.Equal(t, 1, stub.calls)
+	assert.InDelta(t, 500.0, stub.lastConsumption, 0.01)
 }

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -2133,4 +2133,12 @@ func TestRunner_Tick_ToNextWindowFallsBackWithoutWindows(t *testing.T) {
 
 	require.Equal(t, 1, stub.calls)
 	assert.InDelta(t, 500.0, stub.lastConsumption, 0.01)
+
+	// The published state reports the actually-applied horizon, not the
+	// configured one.
+	msgs := drainPublishes(client)
+	stateMsg, ok := findPublishedBySuffix(msgs, "/state")
+	require.True(t, ok, "expected state publish")
+	state := decodeStatePayload(t, stateMsg.payload)
+	assert.Equal(t, pw.ConsumptionHorizonRemainingToday, state.ConsumptionHorizon)
 }

--- a/pkg/cmd/schedule_runner_test.go
+++ b/pkg/cmd/schedule_runner_test.go
@@ -2009,6 +2009,27 @@ func TestRunner_NextWindowStart_NoWindows(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRunner_NextWindowStart_OutOfOrderList(t *testing.T) {
+	client := newFakeClient()
+	runner := newRunnerForTests(client)
+	runner.cfg.Windows = []pw.Window{
+		{Name: "morning", Start: "06:00", End: "08:00", MaxCharge: 2000},
+		{Name: "night", Start: "22:00", End: "23:59", MaxCharge: 2000},
+		{Name: "midday", Start: "12:00", End: "14:00", MaxCharge: 2000},
+	}
+
+	// 07:00 inside morning -- the nearest upcoming start is midday at
+	// 12:00, not night at 22:00, which follows morning in list order.
+	// Guards the scan-by-nearest-instant behaviour against a regression
+	// to list-position advancement.
+	now := time.Date(2026, time.May, 10, 7, 0, 0, 0, time.UTC)
+	next, nextAt, ok := runner.nextWindowStart(now)
+
+	require.True(t, ok)
+	assert.Equal(t, "midday", next.Name)
+	assert.Equal(t, time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC), nextAt)
+}
+
 // 2026-07-10 is a Friday; 07-11 Saturday, 07-13 Monday, 07-17 Friday.
 
 func TestRunner_NextWindowStart_WeekdayGapSpansWeekend(t *testing.T) {

--- a/pkg/power/horizon.go
+++ b/pkg/power/horizon.go
@@ -35,6 +35,7 @@ func ValidateForecastHorizon(s string) (string, error) {
 const (
 	ConsumptionHorizonFullDay        = "full_day"
 	ConsumptionHorizonRemainingToday = "remaining_today"
+	ConsumptionHorizonToNextWindow   = "to_next_window"
 )
 
 // ValidateConsumptionHorizon returns s if it names a known consumption
@@ -42,10 +43,11 @@ const (
 func ValidateConsumptionHorizon(s string) (string, error) {
 	switch s {
 	case ConsumptionHorizonFullDay,
-		ConsumptionHorizonRemainingToday:
+		ConsumptionHorizonRemainingToday,
+		ConsumptionHorizonToNextWindow:
 		return s, nil
 	default:
-		return "", fmt.Errorf("unknown consumption_horizon %q: must be one of full_day, remaining_today", s)
+		return "", fmt.Errorf("unknown consumption_horizon %q: must be one of full_day, remaining_today, to_next_window", s)
 	}
 }
 
@@ -101,7 +103,17 @@ func checkSun(now time.Time) time.Time {
 //   - full_day returns pwConsumption unchanged.
 //   - remaining_today returns pwConsumption scaled by the fraction of the
 //     local day that remains (seconds remaining / 86400).
-func ResolveConsumption(h string, pwConsumption float64, now time.Time) float64 {
+//   - to_next_window returns pwConsumption scaled by the duration from now
+//     until nextWindowStart (hours / 24). The span may cross midnight and
+//     may exceed 24h for weekday-gapped windows, in which case the result
+//     exceeds pwConsumption: it is the expected consumption until the next
+//     charge opportunity. When nextWindowStart is the zero value or not
+//     after now (no windows configured, or the start could not be
+//     resolved), it falls back to remaining_today behaviour.
+//
+// nextWindowStart is only consulted by to_next_window; callers using the
+// other modes may pass the zero time.
+func ResolveConsumption(h string, pwConsumption float64, now time.Time, nextWindowStart time.Time) float64 {
 	switch h {
 	case ConsumptionHorizonFullDay:
 		return pwConsumption
@@ -112,6 +124,12 @@ func ResolveConsumption(h string, pwConsumption float64, now time.Time) float64 
 			remaining = 0
 		}
 		return pwConsumption * float64(remaining) / 86400.0
+	case ConsumptionHorizonToNextWindow:
+		if nextWindowStart.After(now) {
+			hours := nextWindowStart.Sub(now).Hours()
+			return pwConsumption * hours / 24.0
+		}
+		return ResolveConsumption(ConsumptionHorizonRemainingToday, pwConsumption, now, time.Time{})
 	default:
 		return pwConsumption
 	}

--- a/pkg/power/horizon_test.go
+++ b/pkg/power/horizon_test.go
@@ -25,7 +25,7 @@ func TestValidateForecastHorizon_Invalid(t *testing.T) {
 }
 
 func TestValidateConsumptionHorizon_Valid(t *testing.T) {
-	valid := []string{"full_day", "remaining_today"}
+	valid := []string{"full_day", "remaining_today", "to_next_window"}
 	for _, s := range valid {
 		t.Run(s, func(t *testing.T) {
 			h, err := ValidateConsumptionHorizon(s)
@@ -146,24 +146,24 @@ func TestResolveForecastDay_NearMidnight(t *testing.T) {
 
 func TestResolveConsumption_FullDay(t *testing.T) {
 	now := time.Date(2026, 6, 1, 14, 0, 0, 0, time.UTC)
-	got := ResolveConsumption(ConsumptionHorizonFullDay, 10000, now)
+	got := ResolveConsumption(ConsumptionHorizonFullDay, 10000, now, time.Time{})
 	assert.Equal(t, 10000.0, got)
 }
 
 func TestResolveConsumption_RemainingToday(t *testing.T) {
 	// Exactly noon → 12h remaining → 50%.
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-	got := ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now)
+	got := ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now, time.Time{})
 	assert.InDelta(t, 6000.0, got, 1.0)
 
 	// Start of day → full value.
 	now = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	got = ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now)
+	got = ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now, time.Time{})
 	assert.InDelta(t, 12000.0, got, 1.0)
 
 	// End of day → near zero.
 	now = time.Date(2026, 6, 1, 23, 59, 59, 0, time.UTC)
-	got = ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now)
+	got = ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now, time.Time{})
 	assert.InDelta(t, 0.0, got, 1.0)
 }
 
@@ -171,10 +171,51 @@ func TestResolveConsumption_RemainingToday_ClampZero(t *testing.T) {
 	// If seconds_remaining would be negative it clamps to 0.
 	// This can't happen with a real clock, but test the safety clamp.
 	now := time.Date(2026, 6, 2, 0, 0, 1, 0, time.UTC)
-	got := ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now)
+	got := ResolveConsumption(ConsumptionHorizonRemainingToday, 12000, now, time.Time{})
 	// At 00:00:01 remaining = 86399, so this is not negative.
 	// The clamp is a safety net, truly negative can't happen with valid inputs.
 	assert.GreaterOrEqual(t, got, 0.0)
+}
+
+func TestResolveConsumption_ToNextWindow_SameDay(t *testing.T) {
+	// 12:00 → next window 18:00 same day = 6h → 25% of daily consumption.
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	next := time.Date(2026, 6, 1, 18, 0, 0, 0, time.UTC)
+	got := ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, next)
+	assert.InDelta(t, 3000.0, got, 1.0)
+}
+
+func TestResolveConsumption_ToNextWindow_CrossesMidnight(t *testing.T) {
+	// 21:00 → next window 09:00 tomorrow = 12h → 50%. This is the case
+	// remaining_today undersizes (it would only cover 3h to midnight).
+	now := time.Date(2026, 6, 1, 21, 0, 0, 0, time.UTC)
+	next := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC)
+	got := ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, next)
+	assert.InDelta(t, 6000.0, got, 1.0)
+}
+
+func TestResolveConsumption_ToNextWindow_GapBeyond24h(t *testing.T) {
+	// Weekday-gapped windows: Mon 10:00 → next window Wed 09:00 = 47h.
+	// The result intentionally exceeds pwConsumption: it is the expected
+	// consumption until the next charge opportunity.
+	now := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	next := time.Date(2026, 6, 3, 9, 0, 0, 0, time.UTC)
+	got := ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, next)
+	assert.InDelta(t, 12000.0*47.0/24.0, got, 1.0)
+}
+
+func TestResolveConsumption_ToNextWindow_FallbackWhenUnresolved(t *testing.T) {
+	// Zero next-window start (no windows configured / unresolvable) falls
+	// back to remaining_today behaviour.
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	got := ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, time.Time{})
+	assert.InDelta(t, 6000.0, got, 1.0)
+
+	// A next-window start at or before now also falls back.
+	got = ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, now)
+	assert.InDelta(t, 6000.0, got, 1.0)
+	got = ResolveConsumption(ConsumptionHorizonToNextWindow, 12000, now, now.Add(-time.Hour))
+	assert.InDelta(t, 6000.0, got, 1.0)
 }
 
 func TestCheckSun_BackwardCompatibility(t *testing.T) {


### PR DESCRIPTION
## What

Adds a third consumption horizon mode, `to_next_window`: expected consumption is sized to the span from now until the **next charge window start** — `pw_consumption × hours / 24` — instead of stopping at midnight (`remaining_today`) or ignoring elapsed time (`full_day`).

Closes #187 (part of the v2.2.0 epic #151).

## Why

With a single daytime window (e.g. 09:00–15:00), `remaining_today` undersizes progressively through the day because it resets at local midnight, and `full_day` never shrinks at all. Sizing to the next charge opportunity matches what the battery actually has to bridge.

## How

- `pkg/power/horizon.go`: new mode constant; `ResolveConsumption` now takes the next window start. Spans may cross midnight and may exceed 24 h for weekday-gapped windows — intended, since the battery must carry the load until the next chance to charge. Falls back to `remaining_today` when no next window can be resolved.
- `pkg/cmd/schedule_runner.go`: extracted `nextWindowStart()`, which resolves the next window by **nearest upcoming start across all configured windows** (honouring weekday filters), shared by the boundary-tick timer and the new horizon. This also fixes boundary scheduling for 3+ out-of-order windows, where the previous list-position selection could aim past a nearer window and miss its activation.
- Add-on schema, CLI help, and docs (`configuration.md`, `weekdays.md`) updated, including how the next window is picked, the weekday interaction, and a DST note.

## Testing

- Unit: new coverage for same-day / cross-midnight / >24 h spans, the unresolvable-window fallback, gapped coverage, unsorted window lists, and weekday filters (weekday-gapped window spanning a weekend, weekend↔weekday interleaving, cross-midnight start-day semantics). `make test` and `make vet` green.
- Live soak: ran as a dev HA add-on (amd64, GEN24 + BYD) through a full 09:00–15:00 window with `tick_minutes: 15` and `pw_consumption: 30000`. All 25 ticks matched the formula exactly (09:00 → 29999 Wh, 12:00 → 26249 Wh, 14:50 → 22689 Wh); the boundary timer fired at 09:00:00 and re-armed for the next day; per-window `set_defaults` fired 5 min before close; decisions ran `forecast_charge` → `battery_full` → `set_defaults` → `idle` with no errors and no fallback warnings.

## Notes for review

- In legacy/crontab mode (no `windows:` list) the mode is accepted but always falls back to `remaining_today` with a per-tick warning — happy to make that a startup validation error instead if you'd prefer.
- Day stepping uses fixed 24 h increments (consistent with the existing window logic), so a span crossing a DST shift can be off by an hour; documented in `configuration.md`.
